### PR TITLE
Refactor types

### DIFF
--- a/src_rebuild/EMULATOR/LIBPAD.H
+++ b/src_rebuild/EMULATOR/LIBPAD.H
@@ -35,13 +35,13 @@
 
 #define MAX_CONTROLLERS 2
 
-struct PADRAW
+typedef struct PADRAW
 {
 	unsigned char status; // size=0, offset=0
 	unsigned char id; // size=0, offset=1
 	unsigned char buttons[2]; // size=2, offset=2
 	unsigned char analog[4]; // size=4, offset=4
-};
+} *LPPADRAW;
 
 extern void PadInitDirect(unsigned char* pad1, unsigned char* pad2);
 extern void PadInitMtap(unsigned char* unk00, unsigned char* unk01);

--- a/src_rebuild/GAME/C/AI.C
+++ b/src_rebuild/GAME/C/AI.C
@@ -40,7 +40,7 @@ void StoreGameFlags(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ TannerCanEnterCar(struct _CAR_DATA *cp /*$a0*/, int distToCarSq /*$a1*/)
+// int /*$ra*/ TannerCanEnterCar(CAR_DATA *cp /*$a0*/, int distToCarSq /*$a1*/)
  // line 297, offset 0x0001bbe8
 	/* begin block 1 */
 		// Start line: 298
@@ -50,7 +50,7 @@ void StoreGameFlags(void)
 			// Start line: 310
 			// Start offset: 0x0001BC7C
 			// Variables:
-		// 		struct SVECTOR *carCollBox; // $v0
+		// 		SVECTOR *carCollBox; // $v0
 		// 		int carRange; // $a0
 		/* end block 1.1 */
 		// End offset: 0x0001BCCC
@@ -70,7 +70,7 @@ void StoreGameFlags(void)
 	// End Line: 661
 
 // [D] [T]
-int TannerCanEnterCar(_CAR_DATA *cp, int distToCarSq)
+int TannerCanEnterCar(CAR_DATA *cp, int distToCarSq)
 {
 	int carRange;
 
@@ -106,7 +106,7 @@ int TannerCanEnterCar(_CAR_DATA *cp, int distToCarSq)
 		// Start line: 325
 		// Start offset: 0x0001BA90
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $a2
+	// 		CAR_DATA *cp; // $a2
 	/* end block 1 */
 	// End offset: 0x0001BBB8
 	// End Line: 341
@@ -127,8 +127,8 @@ int TannerStuckInCar(int doSpeedCheck, int player_id)
 	short *playerFelony;
 	int speed;
 
-	_CAR_DATA *cp;
-	_PLAYER* lp;
+	CAR_DATA *cp;
+	PLAYER* lp;
 	
 	cp = NULL;
 	lp = &player[player_id];

--- a/src_rebuild/GAME/C/AI.H
+++ b/src_rebuild/GAME/C/AI.H
@@ -4,7 +4,7 @@
 
 extern void StoreGameFlags(); // 0x0001BBB8
 
-extern int TannerCanEnterCar(_CAR_DATA *cp, int distToCarSq); // 0x0001BBE8
+extern int TannerCanEnterCar(CAR_DATA *cp, int distToCarSq); // 0x0001BBE8
 
 extern int TannerStuckInCar(int doSpeedCheck, int player_id); // 0x0001BA90
 

--- a/src_rebuild/GAME/C/BCOLL3D.C
+++ b/src_rebuild/GAME/C/BCOLL3D.C
@@ -4,16 +4,16 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PointFaceCheck(struct _CAR_DATA *cp0 /*$t7*/, struct _CAR_DATA *cp1 /*$t8*/, int i /*$t9*/, struct TestResult *least /*$a3*/, int nSign /*stack 16*/)
+// void /*$ra*/ PointFaceCheck(CAR_DATA *cp0 /*$t7*/, CAR_DATA *cp1 /*$t8*/, int i /*$t9*/, TestResult *least /*$a3*/, int nSign /*stack 16*/)
  // line 83, offset 0x0001c160
 	/* begin block 1 */
 		// Start line: 84
 		// Start offset: 0x0001C160
 		// Variables:
 	// 		int k; // $t5
-	// 		struct VECTOR normal; // stack offset -56
-	// 		struct VECTOR diff; // stack offset -40
-	// 		struct VECTOR point; // stack offset -24
+	// 		VECTOR normal; // stack offset -56
+	// 		VECTOR diff; // stack offset -40
+	// 		VECTOR point; // stack offset -24
 	// 		int depth; // $t0
 
 		/* begin block 1.1 */
@@ -34,7 +34,7 @@
 	// End Line: 167
 
 // [D] [T]
-void PointFaceCheck(_CAR_DATA *cp0, _CAR_DATA *cp1, int i, TestResult *least, int nSign)
+void PointFaceCheck(CAR_DATA *cp0, CAR_DATA *cp1, int i, TestResult *least, int nSign)
 {
 	int partialDepth;
 	int depth;
@@ -126,7 +126,7 @@ void PointFaceCheck(_CAR_DATA *cp0, _CAR_DATA *cp1, int i, TestResult *least, in
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ collided3d(struct _CAR_DATA *cp0 /*$s3*/, struct _CAR_DATA *cp1 /*$s2*/, struct TestResult *least /*$s1*/)
+// int /*$ra*/ collided3d(CAR_DATA *cp0 /*$s3*/, CAR_DATA *cp1 /*$s2*/, TestResult *least /*$s1*/)
  // line 133, offset 0x0001c408
 	/* begin block 1 */
 		// Start line: 134
@@ -148,7 +148,7 @@ void PointFaceCheck(_CAR_DATA *cp0, _CAR_DATA *cp1, int i, TestResult *least, in
 	// End Line: 267
 
 // [D] [T]
-int collided3d(_CAR_DATA *cp0, _CAR_DATA *cp1, TestResult *least)
+int collided3d(CAR_DATA *cp0, CAR_DATA *cp1, TestResult *least)
 {
 	int i;
 
@@ -182,13 +182,13 @@ int collided3d(_CAR_DATA *cp0, _CAR_DATA *cp1, TestResult *least)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CarCarCollision3(struct _CAR_DATA *c0 /*$a0*/, struct _CAR_DATA *c1 /*$a1*/, int *depth /*$s2*/, struct VECTOR *where /*$s0*/, struct VECTOR *normal /*stack 16*/)
+// int /*$ra*/ CarCarCollision3(CAR_DATA *c0 /*$a0*/, CAR_DATA *c1 /*$a1*/, int *depth /*$s2*/, VECTOR *where /*$s0*/, VECTOR *normal /*stack 16*/)
  // line 153, offset 0x0001c380
 	/* begin block 1 */
 		// Start line: 154
 		// Start offset: 0x0001C380
 		// Variables:
-	// 		struct TestResult tr; // stack offset -56
+	// 		TestResult tr; // stack offset -56
 	// 		int res; // $t1
 	/* end block 1 */
 	// End offset: 0x0001C408
@@ -205,7 +205,7 @@ int collided3d(_CAR_DATA *cp0, _CAR_DATA *cp1, TestResult *least)
 	// End Line: 361
 
 // [D] [T]
-int CarCarCollision3(_CAR_DATA *c0, _CAR_DATA *c1, int *depth, VECTOR *where, VECTOR *normal)
+int CarCarCollision3(CAR_DATA *c0, CAR_DATA *c1, int *depth, VECTOR *where, VECTOR *normal)
 {
 	int res;
 	TestResult tr;

--- a/src_rebuild/GAME/C/BCOLL3D.H
+++ b/src_rebuild/GAME/C/BCOLL3D.H
@@ -2,11 +2,11 @@
 #define BCOLL3D_H
 
 
-extern void PointFaceCheck(_CAR_DATA *cp0, _CAR_DATA *cp1, int i, TestResult *least, int nSign); // 0x0001C160
+extern void PointFaceCheck(CAR_DATA *cp0, CAR_DATA *cp1, int i, TestResult *least, int nSign); // 0x0001C160
 
-extern int collided3d(_CAR_DATA *cp0, _CAR_DATA *cp1, TestResult *least); // 0x0001C408
+extern int collided3d(CAR_DATA *cp0, CAR_DATA *cp1, TestResult *least); // 0x0001C408
 
-extern int CarCarCollision3(_CAR_DATA *c0, _CAR_DATA *c1, int *depth, VECTOR *where, VECTOR *normal); // 0x0001C380
+extern int CarCarCollision3(CAR_DATA *c0, CAR_DATA *c1, int *depth, VECTOR *where, VECTOR *normal); // 0x0001C380
 
 
 #endif

--- a/src_rebuild/GAME/C/BCOLLIDE.C
+++ b/src_rebuild/GAME/C/BCOLLIDE.C
@@ -23,13 +23,13 @@
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ bcollided2d(struct CDATA2D *body /*$t4*/, int needOverlap /*$fp*/)
+// int /*$ra*/ bcollided2d(CDATA2D *body /*$t4*/, int needOverlap /*$fp*/)
  // line 120, offset 0x0001c51c
 	/* begin block 1 */
 		// Start line: 121
 		// Start offset: 0x0001C51C
 		// Variables:
-	// 		struct VECTOR delta; // stack offset -56
+	// 		VECTOR delta; // stack offset -56
 	// 		int dtheta; // $v1
 	// 		int ac; // $s6
 	// 		int as; // $s5
@@ -160,7 +160,7 @@ int bcollided2d(CDATA2D *body, int needOverlap)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ bFindCollisionPoint(struct CDATA2D *body /*$t6*/, struct CRET2D *collisionResult /*$s0*/)
+// void /*$ra*/ bFindCollisionPoint(CDATA2D *body /*$t6*/, CRET2D *collisionResult /*$s0*/)
  // line 195, offset 0x0001c8c0
 	/* begin block 1 */
 		// Start line: 196
@@ -330,7 +330,7 @@ void bFindCollisionPoint(CDATA2D *body, CRET2D *collisionResult)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ bFindCollisionTime(struct CDATA2D *cd /*$s5*/, struct CRET2D *collisionResult /*stack 4*/)
+// int /*$ra*/ bFindCollisionTime(CDATA2D *cd /*$s5*/, CRET2D *collisionResult /*stack 4*/)
  // line 275, offset 0x0001cc30
 	/* begin block 1 */
 		// Start line: 276
@@ -342,7 +342,7 @@ void bFindCollisionPoint(CDATA2D *body, CRET2D *collisionResult)
 	// 		int neverfree; // $fp
 	// 		int time; // $s1
 	// 		int step; // $s3
-	// 		struct CDATA2D original[2]; // stack offset -248
+	// 		CDATA2D original[2]; // stack offset -248
 	/* end block 1 */
 	// End offset: 0x0001CEEC
 	// End Line: 357
@@ -459,7 +459,7 @@ int bFindCollisionTime(CDATA2D *cd, CRET2D *collisionResult)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ApplyDamage(struct _CAR_DATA *cp /*$a0*/, char region /*$a1*/, int value /*$a2*/, char fakeDamage /*$a3*/)
+// void /*$ra*/ ApplyDamage(CAR_DATA *cp /*$a0*/, char region /*$a1*/, int value /*$a2*/, char fakeDamage /*$a3*/)
  // line 384, offset 0x0001ceec
 	/* begin block 1 */
 		// Start line: 385
@@ -481,7 +481,7 @@ int bFindCollisionTime(CDATA2D *cd, CRET2D *collisionResult)
 	// End Line: 994
 
 // [D] [T]
-void ApplyDamage(_CAR_DATA *cp, char region, int value, char fakeDamage)
+void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage)
 {
 	short *pRegion;
 
@@ -553,7 +553,7 @@ void ApplyDamage(_CAR_DATA *cp, char region, int value, char fakeDamage)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ DamageCar3D(struct _CAR_DATA *cp /*$s1*/, long (*delta)[4] /*$t4*/, int strikeVel /*$t6*/, struct _CAR_DATA *pOtherCar /*$s2*/)
+// int /*$ra*/ DamageCar3D(CAR_DATA *cp /*$s1*/, long (*delta)[4] /*$t4*/, int strikeVel /*$t6*/, CAR_DATA *pOtherCar /*$s2*/)
  // line 470, offset 0x0001d0b0
 	/* begin block 1 */
 		// Start line: 471
@@ -592,7 +592,7 @@ void ApplyDamage(_CAR_DATA *cp, char region, int value, char fakeDamage)
 	// End Line: 1169
 
 // [D] [T]
-int DamageCar3D(_CAR_DATA *cp, long(*delta)[4], int strikeVel, _CAR_DATA *pOtherCar)
+int DamageCar3D(CAR_DATA *cp, long(*delta)[4], int strikeVel, CAR_DATA *pOtherCar)
 {
 	char region;
 	int value;
@@ -706,13 +706,13 @@ int DamageCar3D(_CAR_DATA *cp, long(*delta)[4], int strikeVel, _CAR_DATA *pOther
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DamageCar(struct _CAR_DATA *cp /*$s2*/, struct CDATA2D *cd /*$s1*/, struct CRET2D *collisionResult /*$s3*/, int strikeVel /*$s0*/)
+// void /*$ra*/ DamageCar(CAR_DATA *cp /*$s2*/, CDATA2D *cd /*$s1*/, CRET2D *collisionResult /*$s3*/, int strikeVel /*$s0*/)
  // line 587, offset 0x0001d454
 	/* begin block 1 */
 		// Start line: 588
 		// Start offset: 0x0001D454
 		// Variables:
-	// 		struct VECTOR delta; // stack offset -48
+	// 		VECTOR delta; // stack offset -48
 	// 		int l; // $v1
 	// 		int w; // $v0
 	// 		int region; // $a1
@@ -735,7 +735,7 @@ int DamageCar3D(_CAR_DATA *cp, long(*delta)[4], int strikeVel, _CAR_DATA *pOther
 	// End Line: 1442
 
 // [D] [T]
-void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVel)
+void DamageCar(CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVel)
 {
 	int impact;
 	int player_id;
@@ -805,24 +805,24 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CarBuildingCollision(struct _CAR_DATA *cp /*$s3*/, struct BUILDING_BOX *building /*$s2*/, struct CELL_OBJECT *cop /*$s6*/, int mightBeABarrier /*$s1*/)
+// int /*$ra*/ CarBuildingCollision(CAR_DATA *cp /*$s3*/, BUILDING_BOX *building /*$s2*/, CELL_OBJECT *cop /*$s6*/, int mightBeABarrier /*$s1*/)
  // line 839, offset 0x0001d68c
 	/* begin block 1 */
 		// Start line: 840
 		// Start offset: 0x0001D68C
 		// Variables:
-	// 		static struct CDATA2D cd[2]; // offset 0x0
-	// 		static struct CRET2D collisionResult; // offset 0xd0
+	// 		static CDATA2D cd[2]; // offset 0x0
+	// 		static CRET2D collisionResult; // offset 0xd0
 	// 		int debris_colour; // stack offset -48
-	// 		struct VECTOR tempwhere; // stack offset -168
-	// 		struct MODEL *pModel; // $s5
+	// 		VECTOR tempwhere; // stack offset -168
+	// 		MODEL *pModel; // $s5
 	// 		int player_id; // stack offset -44
 
 		/* begin block 1.1 */
 			// Start line: 866
 			// Start offset: 0x0001D794
 			// Variables:
-		// 		struct SVECTOR boxDisp; // stack offset -152
+		// 		SVECTOR boxDisp; // stack offset -152
 
 			/* begin block 1.1.1 */
 				// Start line: 908
@@ -844,7 +844,7 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 				// Start line: 977
 				// Start offset: 0x0001DA64
 				// Variables:
-			// 		struct VECTOR velocity; // stack offset -144
+			// 		VECTOR velocity; // stack offset -144
 			// 		long pointVel[4]; // stack offset -128
 			// 		long reaction[4]; // stack offset -112
 			// 		long lever[4]; // stack offset -96
@@ -867,8 +867,8 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 						// Start line: 1058
 						// Start offset: 0x0001DD28
 						// Variables:
-					// 		struct SMASHABLE_OBJECT *sip; // $a1
-					// 		struct SMASHABLE_OBJECT *match; // $s0
+					// 		SMASHABLE_OBJECT *sip; // $a1
+					// 		SMASHABLE_OBJECT *match; // $s0
 					// 		int chan; // $s1
 					// 		int adjust; // $s2
 					/* end block 1.2.1.2.1 */
@@ -882,7 +882,7 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 					// Start line: 1098
 					// Start offset: 0x0001DEF4
 					// Variables:
-				// 		struct VECTOR LeafPosition; // stack offset -80
+				// 		VECTOR LeafPosition; // stack offset -80
 				/* end block 1.2.1.3 */
 				// End offset: 0x0001DEF4
 				// End Line: 1098
@@ -895,7 +895,7 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 						// Start line: 1119
 						// Start offset: 0x0001DF90
 						// Variables:
-					// 		struct VECTOR lamp_velocity; // stack offset -64
+					// 		VECTOR lamp_velocity; // stack offset -64
 					/* end block 1.2.1.4.1 */
 					// End offset: 0x0001DFC4
 					// End Line: 1123
@@ -930,7 +930,7 @@ void DamageCar(_CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVe
 	// End Line: 1967
 
 // [D] [T]
-int CarBuildingCollision(_CAR_DATA *cp, BUILDING_BOX *building, CELL_OBJECT *cop, int flags)
+int CarBuildingCollision(CAR_DATA *cp, BUILDING_BOX *building, CELL_OBJECT *cop, int flags)
 {
 	static CDATA2D cd[2] = {0}; // offset 0x0
 	static CRET2D collisionResult = { 0 }; // offset 0xd0

--- a/src_rebuild/GAME/C/BCOLLIDE.C
+++ b/src_rebuild/GAME/C/BCOLLIDE.C
@@ -553,7 +553,7 @@ void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ DamageCar3D(CAR_DATA *cp /*$s1*/, long (*delta)[4] /*$t4*/, int strikeVel /*$t6*/, CAR_DATA *pOtherCar /*$s2*/)
+// int /*$ra*/ DamageCar3D(CAR_DATA *cp /*$s1*/, LONGVECTOR* delta /*$t4*/, int strikeVel /*$t6*/, CAR_DATA *pOtherCar /*$s2*/)
  // line 470, offset 0x0001d0b0
 	/* begin block 1 */
 		// Start line: 471
@@ -562,8 +562,8 @@ void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage)
 	// 		int l; // $v1
 	// 		int w; // $v0
 	// 		int region; // $a1
-	// 		long nose[4]; // stack offset -56
-	// 		long door[4]; // stack offset -40
+	// 		LONGVECTOR nose; // stack offset -56
+	// 		LONGVECTOR door; // stack offset -40
 	// 		int impact; // $s3
 	// 		int QQQ; // $t7
 
@@ -592,7 +592,7 @@ void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage)
 	// End Line: 1169
 
 // [D] [T]
-int DamageCar3D(CAR_DATA *cp, long(*delta)[4], int strikeVel, CAR_DATA *pOtherCar)
+int DamageCar3D(CAR_DATA *cp, LONGVECTOR* delta, int strikeVel, CAR_DATA *pOtherCar)
 {
 	char region;
 	int value;
@@ -845,9 +845,9 @@ void DamageCar(CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVel
 				// Start offset: 0x0001DA64
 				// Variables:
 			// 		VECTOR velocity; // stack offset -144
-			// 		long pointVel[4]; // stack offset -128
-			// 		long reaction[4]; // stack offset -112
-			// 		long lever[4]; // stack offset -96
+			// 		LONGVECTOR pointVel; // stack offset -128
+			// 		LONGVECTOR reaction; // stack offset -112
+			// 		LONGVECTOR lever; // stack offset -96
 			// 		int strikeVel; // $s1
 
 				/* begin block 1.2.1.1 */
@@ -949,9 +949,9 @@ int CarBuildingCollision(CAR_DATA *cp, BUILDING_BOX *building, CELL_OBJECT *cop,
 	VECTOR tempwhere;
 	SVECTOR boxDisp;
 	VECTOR velocity;
-	long pointVel[4];
-	long reaction[4];
-	long lever[4];
+	LONGVECTOR pointVel;
+	LONGVECTOR reaction;
+	LONGVECTOR lever;
 	VECTOR LeafPosition;
 	VECTOR lamp_velocity;
 	int debris_colour;

--- a/src_rebuild/GAME/C/BCOLLIDE.H
+++ b/src_rebuild/GAME/C/BCOLLIDE.H
@@ -11,7 +11,7 @@ extern int bFindCollisionTime(CDATA2D *cd, CRET2D *collisionResult); // 0x0001CC
 
 extern void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage); // 0x0001CEEC
 
-extern int DamageCar3D(CAR_DATA *cp, long (*delta)[4], int strikeVel, CAR_DATA *pOtherCar); // 0x0001D0B0
+extern int DamageCar3D(CAR_DATA *cp, LONGVECTOR* delta, int strikeVel, CAR_DATA *pOtherCar); // 0x0001D0B0
 
 extern void DamageCar(CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVel); // 0x0001D454
 

--- a/src_rebuild/GAME/C/BCOLLIDE.H
+++ b/src_rebuild/GAME/C/BCOLLIDE.H
@@ -3,19 +3,19 @@
 
 extern int boxOverlap;
 
-extern int bcollided2d(struct CDATA2D *body, int needOverlap); // 0x0001C51C
+extern int bcollided2d(CDATA2D *body, int needOverlap); // 0x0001C51C
 
-extern void bFindCollisionPoint(struct CDATA2D *body, struct CRET2D *collisionResult); // 0x0001C8C0
+extern void bFindCollisionPoint(CDATA2D *body, CRET2D *collisionResult); // 0x0001C8C0
 
-extern int bFindCollisionTime(struct CDATA2D *cd, struct CRET2D *collisionResult); // 0x0001CC30
+extern int bFindCollisionTime(CDATA2D *cd, CRET2D *collisionResult); // 0x0001CC30
 
-extern void ApplyDamage(struct _CAR_DATA *cp, char region, int value, char fakeDamage); // 0x0001CEEC
+extern void ApplyDamage(CAR_DATA *cp, char region, int value, char fakeDamage); // 0x0001CEEC
 
-extern int DamageCar3D(struct _CAR_DATA *cp, long (*delta)[4], int strikeVel, struct _CAR_DATA *pOtherCar); // 0x0001D0B0
+extern int DamageCar3D(CAR_DATA *cp, long (*delta)[4], int strikeVel, CAR_DATA *pOtherCar); // 0x0001D0B0
 
-extern void DamageCar(struct _CAR_DATA *cp, struct CDATA2D *cd, struct CRET2D *collisionResult, int strikeVel); // 0x0001D454
+extern void DamageCar(CAR_DATA *cp, CDATA2D *cd, CRET2D *collisionResult, int strikeVel); // 0x0001D454
 
-extern int CarBuildingCollision(struct _CAR_DATA *cp, struct BUILDING_BOX *building, struct CELL_OBJECT *cop, int flags); // 0x0001D68C
+extern int CarBuildingCollision(CAR_DATA *cp, BUILDING_BOX *building, CELL_OBJECT *cop, int flags); // 0x0001D68C
 
 
 #endif

--- a/src_rebuild/GAME/C/BOMBERMAN.C
+++ b/src_rebuild/GAME/C/BOMBERMAN.C
@@ -29,7 +29,7 @@ static BOMB ThrownBombs[MAX_THROWN_BOMBS];
 static int ThrownBombDelay = 0;
 static int CurrentBomb = 0;
 static int gWantFlash = 0;
-_CAR_DATA *gBombTargetVehicle = NULL;
+CAR_DATA *gBombTargetVehicle = NULL;
 static int flashval;
 
 // decompiled code
@@ -91,9 +91,9 @@ void InitThrownBombs(void)
 		// Start line: 247
 		// Start offset: 0x0001E3E8
 		// Variables:
-	// 		struct BOMB *bomb; // $s1
-	// 		struct VECTOR velocity; // stack offset -48
-	// 		struct _CAR_DATA *cp; // $s0
+	// 		BOMB *bomb; // $s1
+	// 		VECTOR velocity; // stack offset -48
+	// 		CAR_DATA *cp; // $s0
 	// 		int i; // $s5
 	// 		int y; // $a0
 
@@ -136,7 +136,7 @@ void InitThrownBombs(void)
 // [D] [T]
 void HandleThrownBombs(void)
 {
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 	BOMB *bomb;
 	int i;
 	int y;
@@ -250,10 +250,10 @@ void HandleThrownBombs(void)
 		// Start line: 383
 		// Start offset: 0x0001E810
 		// Variables:
-	// 		struct MATRIX object_matrix; // stack offset -80
-	// 		struct MATRIX *finalmatrix; // $s2
-	// 		struct BOMB *bomb; // $s0
-	// 		struct VECTOR pos; // stack offset -48
+	// 		MATRIX object_matrix; // stack offset -80
+	// 		MATRIX *finalmatrix; // $s2
+	// 		BOMB *bomb; // $s0
+	// 		VECTOR pos; // stack offset -48
 	// 		int i; // $s3
 
 		/* begin block 1.1 */
@@ -370,7 +370,7 @@ void DrawThrownBombs(void)
 		// Start line: 433
 		// Start offset: 0x0001EA00
 		// Variables:
-	// 		struct BOMB *bomb; // $t3
+	// 		BOMB *bomb; // $t3
 	/* end block 1 */
 	// End offset: 0x0001EC3C
 	// End Line: 486
@@ -453,13 +453,13 @@ void BombThePlayerToHellAndBack(int car)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ BombCollisionCheck(struct _CAR_DATA *cp /*$a0*/, struct VECTOR *pPos /*$a1*/)
+// int /*$ra*/ BombCollisionCheck(CAR_DATA *cp /*$a0*/, VECTOR *pPos /*$a1*/)
  // line 496, offset 0x0001ec58
 	/* begin block 1 */
 		// Start line: 497
 		// Start offset: 0x0001EC58
 		// Variables:
-	// 		struct CDATA2D cd[2]; // stack offset -216
+	// 		CDATA2D cd[2]; // stack offset -216
 	// 		int carLength[2]; // stack offset -16
 
 		/* begin block 1.1 */
@@ -483,7 +483,7 @@ void BombThePlayerToHellAndBack(int car)
 	// End Line: 1236
 
 // [D] [T]
-int BombCollisionCheck(_CAR_DATA *cp, VECTOR *pPos)
+int BombCollisionCheck(CAR_DATA *cp, VECTOR *pPos)
 {
 	CDATA2D cd[2] = {0};
 
@@ -510,13 +510,13 @@ int BombCollisionCheck(_CAR_DATA *cp, VECTOR *pPos)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ExplosionCollisionCheck(struct _CAR_DATA *cp /*$s1*/, struct _ExOBJECT *pE /*$s3*/)
+// void /*$ra*/ ExplosionCollisionCheck(CAR_DATA *cp /*$s1*/, _ExOBJECT *pE /*$s3*/)
  // line 534, offset 0x0001ed18
 	/* begin block 1 */
 		// Start line: 535
 		// Start offset: 0x0001ED18
 		// Variables:
-	// 		struct CDATA2D cd[2]; // stack offset -352
+	// 		CDATA2D cd[2]; // stack offset -352
 	// 		int carLength[2]; // stack offset -152
 	// 		static int setUsed; // offset 0x28
 	// 		int tanner; // $s6
@@ -545,7 +545,7 @@ int BombCollisionCheck(_CAR_DATA *cp, VECTOR *pPos)
 				// Variables:
 			// 		int x; // $a1
 			// 		int z; // $v1
-			// 		struct VECTOR *pos; // $v0
+			// 		VECTOR *pos; // $v0
 			/* end block 1.1.3 */
 			// End offset: 0x0001EF54
 			// End Line: 600
@@ -554,13 +554,13 @@ int BombCollisionCheck(_CAR_DATA *cp, VECTOR *pPos)
 				// Start line: 623
 				// Start offset: 0x0001EF94
 				// Variables:
-			// 		struct CRET2D collisionResult; // stack offset -144
+			// 		CRET2D collisionResult; // stack offset -144
 
 				/* begin block 1.1.4.1 */
 					// Start line: 626
 					// Start offset: 0x0001EF94
 					// Variables:
-				// 		struct VECTOR velocity; // stack offset -104
+				// 		VECTOR velocity; // stack offset -104
 				// 		long pointVel[4]; // stack offset -88
 				// 		long reaction[4]; // stack offset -72
 				// 		long lever[4]; // stack offset -56
@@ -615,7 +615,7 @@ const int halfStrike = 0x32000;
 const int fullStrike = 0x32000;
 
 // [D] [T]
-void ExplosionCollisionCheck(_CAR_DATA *cp, _ExOBJECT *pE)
+void ExplosionCollisionCheck(CAR_DATA *cp, EXOBJECT *pE)
 {
 	static int setUsed = 0;
 
@@ -795,7 +795,7 @@ void ExplosionCollisionCheck(_CAR_DATA *cp, _ExOBJECT *pE)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddFlash(struct VECTOR *pos /*$a0*/)
+// void /*$ra*/ AddFlash(VECTOR *pos /*$a0*/)
  // line 747, offset 0x0001f4f4
 	/* begin block 1 */
 		// Start line: 748

--- a/src_rebuild/GAME/C/BOMBERMAN.C
+++ b/src_rebuild/GAME/C/BOMBERMAN.C
@@ -561,9 +561,9 @@ int BombCollisionCheck(CAR_DATA *cp, VECTOR *pPos)
 					// Start offset: 0x0001EF94
 					// Variables:
 				// 		VECTOR velocity; // stack offset -104
-				// 		long pointVel[4]; // stack offset -88
-				// 		long reaction[4]; // stack offset -72
-				// 		long lever[4]; // stack offset -56
+				// 		LONGVECTOR pointVel; // stack offset -88
+				// 		LONGVECTOR reaction; // stack offset -72
+				// 		LONGVECTOR lever; // stack offset -56
 				// 		int strikeVel; // $s0
 
 					/* begin block 1.1.4.1.1 */
@@ -630,9 +630,9 @@ void ExplosionCollisionCheck(CAR_DATA *cp, EXOBJECT *pE)
 	int carLength[2];
 	CRET2D collisionResult;
 	VECTOR velocity;
-	long pointVel[4];
-	long reaction[4];
-	long lever[4];
+	LONGVECTOR pointVel;
+	LONGVECTOR reaction;
+	LONGVECTOR lever;
 
 	isCar = (cp != &car_data[CAMERA_COLLIDER_CARID]);
 

--- a/src_rebuild/GAME/C/BOMBERMAN.H
+++ b/src_rebuild/GAME/C/BOMBERMAN.H
@@ -2,7 +2,7 @@
 #define BOMBERMAN_H
 
 extern MODEL* gBombModel;
-extern _CAR_DATA *gBombTargetVehicle;
+extern CAR_DATA *gBombTargetVehicle;
 
 extern void InitThrownBombs(); // 0x0001F570
 
@@ -12,9 +12,9 @@ extern void DrawThrownBombs(); // 0x0001E810
 
 extern void BombThePlayerToHellAndBack(int car); // 0x0001EA00
 
-extern int BombCollisionCheck(_CAR_DATA *cp, VECTOR *pPos); // 0x0001EC58
+extern int BombCollisionCheck(CAR_DATA *cp, VECTOR *pPos); // 0x0001EC58
 
-extern void ExplosionCollisionCheck(_CAR_DATA *cp, _ExOBJECT *pE); // 0x0001ED18
+extern void ExplosionCollisionCheck(CAR_DATA *cp, EXOBJECT *pE); // 0x0001ED18
 
 extern void AddFlash(VECTOR *pos); // 0x0001F4F4
 

--- a/src_rebuild/GAME/C/CAMERA.C
+++ b/src_rebuild/GAME/C/CAMERA.C
@@ -46,7 +46,7 @@ unsigned short paddCamera;
 char cameraview = 0;
 int CameraCnt = 0;
 
-static long basePos[4]; // [A]
+static LONGVECTOR basePos; // [A]
 static long baseDir = 0;
 
 char tracking_car = 0;

--- a/src_rebuild/GAME/C/CAMERA.C
+++ b/src_rebuild/GAME/C/CAMERA.C
@@ -57,10 +57,10 @@ int TargetCar = 0;
 int CameraCar = 0;
 
 // [A] custom function - recalculates base camera position (separated from InitCamera)
-void CalcCameraBasePos(_PLAYER* lp)
+void CalcCameraBasePos(PLAYER* lp)
 {
 	CAR_COSMETICS* car_cos;
-	_EVENT* event;
+	EVENT* event;
 	SVECTOR boxDisp = { 0 };
 
 	if (lp->cameraCarId < 0)
@@ -110,13 +110,13 @@ void CalcCameraBasePos(_PLAYER* lp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitCamera(struct _PLAYER *lp /*$s0*/)
+// void /*$ra*/ InitCamera(PLAYER *lp /*$s0*/)
  // line 422, offset 0x0001f5f4
 	/* begin block 1 */
 		// Start line: 423
 		// Start offset: 0x0001F5F4
 		// Variables:
-	// 		struct SVECTOR boxDisp; // stack offset -16
+	// 		SVECTOR boxDisp; // stack offset -16
 
 		/* begin block 1.1 */
 			// Start line: 428
@@ -129,7 +129,7 @@ void CalcCameraBasePos(_PLAYER* lp)
 			// Start line: 441
 			// Start offset: 0x0001F6AC
 			// Variables:
-		// 		struct _CAR_DATA *lcp; // $a0
+		// 		CAR_DATA *lcp; // $a0
 		/* end block 1.2 */
 		// End offset: 0x0001F6AC
 		// End Line: 441
@@ -138,7 +138,7 @@ void CalcCameraBasePos(_PLAYER* lp)
 			// Start line: 454
 			// Start offset: 0x0001F794
 			// Variables:
-		// 		struct _EVENT *event; // $a1
+		// 		EVENT *event; // $a1
 		/* end block 1.3 */
 		// End offset: 0x0001F794
 		// End Line: 455
@@ -152,7 +152,7 @@ void CalcCameraBasePos(_PLAYER* lp)
 	// End Line: 845
 
 // [D] [T]
-void InitCamera(_PLAYER *lp)
+void InitCamera(PLAYER *lp)
 {
 	if (events.cameraEvent == NULL) 
 	{
@@ -240,8 +240,8 @@ void InitCamera(_PLAYER *lp)
 		// Start line: 555
 		// Start offset: 0x0001FA20
 		// Variables:
-	// 		struct PAD *locPad; // $a3
-	// 		struct _PLAYER *lp; // $a2
+	// 		PAD *locPad; // $a3
+	// 		PLAYER *lp; // $a2
 
 		/* begin block 1.1 */
 			// Start line: 568
@@ -295,7 +295,7 @@ void ModifyCamera(void)
 		1,0,2,1
 	};
 
-	_PLAYER *lp;
+	PLAYER *lp;
 	char *pNextCameraView;
 	int angle;
 	int length;
@@ -352,13 +352,13 @@ void ModifyCamera(void)
 		// Start line: 611
 		// Start offset: 0x0001FC18
 		// Variables:
-	// 		struct MODEL *model; // $v1
-	// 		struct COLLISION_PACKET *collide; // $t2
-	// 		struct CELL_OBJECT *cop; // $t3
-	// 		struct CELL_ITERATOR ci; // stack offset -168
-	// 		struct VECTOR nearpoint; // stack offset -144
-	// 		struct VECTOR surfacenormal; // stack offset -128
-	// 		struct VECTOR surfacepoint; // stack offset -112
+	// 		MODEL *model; // $v1
+	// 		COLLISION_PACKET *collide; // $t2
+	// 		CELL_OBJECT *cop; // $t3
+	// 		CELL_ITERATOR ci; // stack offset -168
+	// 		VECTOR nearpoint; // stack offset -144
+	// 		VECTOR surfacenormal; // stack offset -128
+	// 		VECTOR surfacepoint; // stack offset -112
 	// 		int cell_x; // $a0
 	// 		int cell_z; // $a1
 	// 		int xd; // $v1
@@ -368,16 +368,16 @@ void ModifyCamera(void)
 	// 		int sphere_sq; // $a2
 	// 		int camera_size; // $s0
 	// 		int count; // $s1
-	// 		struct VECTOR temp_cam; // stack offset -96
+	// 		VECTOR temp_cam; // stack offset -96
 
 		/* begin block 1.1 */
 			// Start line: 659
 			// Start offset: 0x0001FDF4
 			// Variables:
-		// 		struct MATRIX *mat; // $a2
-		// 		struct VECTOR offset; // stack offset -80
-		// 		struct VECTOR cam_vec; // stack offset -64
-		// 		struct VECTOR normal; // stack offset -48
+		// 		MATRIX *mat; // $a2
+		// 		VECTOR offset; // stack offset -80
+		// 		VECTOR cam_vec; // stack offset -64
+		// 		VECTOR normal; // stack offset -48
 		// 		int xmin; // $a0
 		// 		int xmax; // $a3
 		// 		int ymin; // $t0
@@ -519,7 +519,7 @@ int CameraCollisionCheck(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TurnHead(struct _PLAYER *lp /*$a0*/)
+// void /*$ra*/ TurnHead(PLAYER *lp /*$a0*/)
  // line 716, offset 0x00020a10
 	/* begin block 1 */
 		// Start line: 717
@@ -539,7 +539,7 @@ int CameraCollisionCheck(void)
 	// End Line: 2115
 
 // [D] [T]
-void TurnHead(_PLAYER *lp)
+void TurnHead(PLAYER *lp)
 {
 	if ((paddCamera & 3) == 3) 
 	{
@@ -585,7 +585,7 @@ void TurnHead(_PLAYER *lp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlaceCameraFollowCar(struct _PLAYER *lp /*$s2*/)
+// void /*$ra*/ PlaceCameraFollowCar(PLAYER *lp /*$s2*/)
  // line 777, offset 0x0002003c
 	/* begin block 1 */
 		// Start line: 778
@@ -596,7 +596,7 @@ void TurnHead(_PLAYER *lp)
 	// 		int cammapht; // $s0
 	// 		int new_angle; // $a0
 	// 		int camPosVy; // $s1
-	// 		struct VECTOR locCameraPos; // stack offset -48
+	// 		VECTOR locCameraPos; // stack offset -48
 	// 		int lbody; // $a0
 	// 		int hbody; // $a3
 	// 		int camExpandSpeed; // $s6
@@ -605,7 +605,7 @@ void TurnHead(_PLAYER *lp)
 			// Start line: 800
 			// Start offset: 0x00020088
 			// Variables:
-		// 		struct _CAR_DATA *camCar; // $v1
+		// 		CAR_DATA *camCar; // $v1
 		/* end block 1.1 */
 		// End offset: 0x0002011C
 		// End Line: 810
@@ -626,11 +626,11 @@ void TurnHead(_PLAYER *lp)
 short gCameraDistance = 1000;
 short gCameraMaxDistance = 0;
 
-_CAR_DATA *jcam = NULL;
+CAR_DATA *jcam = NULL;
 int switch_detail_distance = 10000;
 
 // [D] [T]
-void PlaceCameraFollowCar(_PLAYER *lp)
+void PlaceCameraFollowCar(PLAYER *lp)
 {
 	CAR_COSMETICS *car_cos;
 	int camAngle;
@@ -649,7 +649,7 @@ void PlaceCameraFollowCar(_PLAYER *lp)
 	
 	if (lp->cameraCarId >= 0)
 	{
-		_CAR_DATA* camCar;
+		CAR_DATA* camCar;
 		int carSpeed;
 		camCar = &car_data[lp->cameraCarId];
 
@@ -712,7 +712,7 @@ void PlaceCameraFollowCar(_PLAYER *lp)
 	}
 
 	jcam = &car_data[CAMERA_COLLIDER_CARID];
-	ClearMem((char *)jcam, sizeof(_CAR_DATA));
+	ClearMem((char *)jcam, sizeof(CAR_DATA));
 
 	jcam->controlType = CONTROL_TYPE_CAMERACOLLIDER;
 
@@ -759,7 +759,7 @@ void PlaceCameraFollowCar(_PLAYER *lp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlaceCameraAtLocation(struct _PLAYER *lp /*$s1*/, int zoom /*$s2*/)
+// void /*$ra*/ PlaceCameraAtLocation(PLAYER *lp /*$s1*/, int zoom /*$s2*/)
  // line 904, offset 0x00020904
 	/* begin block 1 */
 		// Start line: 905
@@ -771,7 +771,7 @@ void PlaceCameraFollowCar(_PLAYER *lp)
 			// Start line: 911
 			// Start offset: 0x00020930
 			// Variables:
-		// 		struct VECTOR temp; // stack offset -32
+		// 		VECTOR temp; // stack offset -32
 		/* end block 1.1 */
 		// End offset: 0x00020930
 		// End Line: 913
@@ -795,7 +795,7 @@ void PlaceCameraFollowCar(_PLAYER *lp)
 	// End Line: 2241
 
 // [D] [T]
-void PlaceCameraAtLocation(_PLAYER *lp, int zoom)
+void PlaceCameraAtLocation(PLAYER *lp, int zoom)
 {
 	int d;
 	VECTOR temp;
@@ -843,13 +843,13 @@ void PlaceCameraAtLocation(_PLAYER *lp, int zoom)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ PointAtTarget(struct VECTOR *pPosition /*$a0*/, struct VECTOR *pTarget /*$a1*/, struct SVECTOR *pAngleVec /*$s0*/)
+// int /*$ra*/ PointAtTarget(VECTOR *pPosition /*$a0*/, VECTOR *pTarget /*$a1*/, SVECTOR *pAngleVec /*$s0*/)
  // line 960, offset 0x00020b08
 	/* begin block 1 */
 		// Start line: 961
 		// Start offset: 0x00020B08
 		// Variables:
-	// 		struct VECTOR delta; // stack offset -32
+	// 		VECTOR delta; // stack offset -32
 	// 		int d; // $s1
 	/* end block 1 */
 	// End offset: 0x00020BC0
@@ -892,13 +892,13 @@ int PointAtTarget(VECTOR *pPosition, VECTOR *pTarget, SVECTOR *pAngleVec)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlaceCameraInCar(struct _PLAYER *lp /*$s3*/, int BumperCam /*$a1*/)
+// void /*$ra*/ PlaceCameraInCar(PLAYER *lp /*$s3*/, int BumperCam /*$a1*/)
  // line 987, offset 0x0002050c
 	/* begin block 1 */
 		// Start line: 988
 		// Start offset: 0x0002050C
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $s2
+	// 		CAR_DATA *cp; // $s2
 
 		/* begin block 1.1 */
 			// Start line: 1044
@@ -930,10 +930,10 @@ int PointAtTarget(VECTOR *pPosition, VECTOR *pTarget, SVECTOR *pAngleVec)
 VECTOR viewer_position;
 
 // [D] [T]
-void PlaceCameraInCar(_PLAYER *lp, int BumperCam)
+void PlaceCameraInCar(PLAYER *lp, int BumperCam)
 {
 	int angle;
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 
 	cp = NULL;
 
@@ -1037,7 +1037,7 @@ void PlaceCameraInCar(_PLAYER *lp, int BumperCam)
 		// Start offset: 0x00020BC0
 		// Variables:
 	// 		int old_z; // $s0
-	// 		struct VECTOR temp; // stack offset -24
+	// 		VECTOR temp; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00020C70
 	// End Line: 1114
@@ -1092,7 +1092,7 @@ int OK_To_Zoom(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetBasePos(struct VECTOR *pVec /*$a0*/)
+// void /*$ra*/ SetBasePos(VECTOR *pVec /*$a0*/)
  // line 1119, offset 0x00020c70
 	/* begin block 1 */
 		// Start line: 2945

--- a/src_rebuild/GAME/C/CAMERA.H
+++ b/src_rebuild/GAME/C/CAMERA.H
@@ -25,21 +25,21 @@ extern VECTOR gCameraOffset;
 
 extern int switch_detail_distance;
 
-extern void InitCamera(_PLAYER *lp); // 0x0001F5F4
+extern void InitCamera(PLAYER *lp); // 0x0001F5F4
 
 extern void ModifyCamera(); // 0x0001FA20
 
 extern int CameraCollisionCheck(); // 0x0001FC18
 
-extern void TurnHead(_PLAYER *lp); // 0x00020A10
+extern void TurnHead(PLAYER *lp); // 0x00020A10
 
-extern void PlaceCameraFollowCar(_PLAYER *lp); // 0x0002003C
+extern void PlaceCameraFollowCar(PLAYER *lp); // 0x0002003C
 
-extern void PlaceCameraAtLocation(_PLAYER *lp, int zoom); // 0x00020904
+extern void PlaceCameraAtLocation(PLAYER *lp, int zoom); // 0x00020904
 
 extern int PointAtTarget(VECTOR *pPosition, VECTOR *pTarget, SVECTOR *pAngleVec); // 0x00020B08
 
-extern void PlaceCameraInCar(_PLAYER *lp, int BumperCam); // 0x0002050C
+extern void PlaceCameraInCar(PLAYER *lp, int BumperCam); // 0x0002050C
 
 extern int OK_To_Zoom(); // 0x00020BC0
 

--- a/src_rebuild/GAME/C/CARS.C
+++ b/src_rebuild/GAME/C/CARS.C
@@ -36,25 +36,25 @@ MATRIX colour_matrix =
 { { { 4032, 0, 0 }, { 3936, 0, 0 }, { 3520, 0, 0 } }, { 0, 0, 0 } };
 
 // PHYSICS
-_CAR_DATA car_data[MAX_CARS + 2];	// all cars + Tanner cbox + Camera cbox
+CAR_DATA car_data[MAX_CARS + 2];	// all cars + Tanner cbox + Camera cbox
 
 HUBCAP gHubcap;
 
 // active cars
-_CAR_DATA* active_car_list[MAX_CARS];
+CAR_DATA* active_car_list[MAX_CARS];
 BOUND_BOX bbox[MAX_CARS];
 unsigned char lightsOnDelay[MAX_CARS];
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ plotNewCarModel(struct CAR_MODEL *car /*$s0*/, int palette /*$s2*/)
+// void /*$ra*/ plotNewCarModel(CAR_MODEL *car /*$s0*/, int palette /*$s2*/)
  // line 834, offset 0x00020c94
 	/* begin block 1 */
 		// Start line: 835
 		// Start offset: 0x00020C94
 		// Variables:
-	// 		struct plotCarGlobals _pg; // stack offset -72
-	// 		struct SVECTOR v0; // stack offset -32
+	// 		plotCarGlobals _pg; // stack offset -72
+	// 		SVECTOR v0; // stack offset -32
 	// 		unsigned long lightlevel; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00020E88
@@ -70,7 +70,7 @@ unsigned char lightsOnDelay[MAX_CARS];
 	/* end block 3 */
 	// End Line: 1671
 
-struct DENTUVS *gTempCarUVPtr;
+DENTUVS *gTempCarUVPtr;
 DENTUVS gTempHDCarUVDump[MAX_CARS][255];
 SVECTOR gTempCarVertDump[MAX_CARS][132];
 DENTUVS gTempLDCarUVDump[MAX_CARS][134];
@@ -153,13 +153,13 @@ void plotNewCarModel(CAR_MODEL *car, int palette)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ plotCarPolyB3(int numTris /*$a0*/, struct CAR_POLY *src /*$a1*/, struct SVECTOR *vlist /*$a2*/, struct plotCarGlobals *pg /*$a3*/)
+// void /*$ra*/ plotCarPolyB3(int numTris /*$a0*/, CAR_POLY *src /*$a1*/, SVECTOR *vlist /*$a2*/, plotCarGlobals *pg /*$a3*/)
  // line 917, offset 0x000237b8
 	/* begin block 1 */
 		// Start line: 918
 		// Start offset: 0x000237B8
 		// Variables:
-	// 		struct POLY_F3 *prim; // $t0
+	// 		POLY_F3 *prim; // $t0
 	// 		int i; // $t1
 	// 		long *ot; // $t3
 	// 		long F3rgb; // $t4
@@ -242,13 +242,13 @@ void plotCarPolyB3(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGlobals *p
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ plotCarPolyFT3(int numTris /*$a0*/, struct CAR_POLY *src /*$t1*/, struct SVECTOR *vlist /*$t4*/, struct plotCarGlobals *pg /*$t5*/)
+// void /*$ra*/ plotCarPolyFT3(int numTris /*$a0*/, CAR_POLY *src /*$t1*/, SVECTOR *vlist /*$t4*/, plotCarGlobals *pg /*$t5*/)
  // line 976, offset 0x000238c4
 	/* begin block 1 */
 		// Start line: 977
 		// Start offset: 0x000238C4
 		// Variables:
-	// 		struct POLY_FT3 *prim; // $t0
+	// 		POLY_FT3 *prim; // $t0
 	// 		long *ot; // $t6
 	// 		long FT3rgb; // stack offset -8
 	// 		int i; // $t2
@@ -350,13 +350,13 @@ void plotCarPolyFT3(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGlobals *
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ plotCarPolyGT3(int numTris /*$a0*/, struct CAR_POLY *src /*$t1*/, struct SVECTOR *vlist /*$s0*/, struct SVECTOR *nlist /*$a3*/, struct plotCarGlobals *pg /*stack 16*/, int palette /*stack 20*/)
+// void /*$ra*/ plotCarPolyGT3(int numTris /*$a0*/, CAR_POLY *src /*$t1*/, SVECTOR *vlist /*$s0*/, SVECTOR *nlist /*$a3*/, plotCarGlobals *pg /*stack 16*/, int palette /*stack 20*/)
  // line 1125, offset 0x00020ea0
 	/* begin block 1 */
 		// Start line: 1126
 		// Start offset: 0x00020EA0
 		// Variables:
-	// 		struct POLY_GT3 *prim; // $t0
+	// 		POLY_GT3 *prim; // $t0
 	// 		long *ot; // $s1
 	// 		long GT3rgb; // stack offset -24
 	// 		int i; // $t7
@@ -475,13 +475,13 @@ void plotCarPolyGT3(int numTris, CAR_POLY *src, SVECTOR *vlist, SVECTOR *nlist, 
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ plotCarPolyGT3nolight(int numTris /*$a0*/, struct CAR_POLY *src /*$t3*/, struct SVECTOR *vlist /*$t6*/, struct plotCarGlobals *pg /*$a3*/, int palette /*stack 16*/)
+// void /*$ra*/ plotCarPolyGT3nolight(int numTris /*$a0*/, CAR_POLY *src /*$t3*/, SVECTOR *vlist /*$t6*/, plotCarGlobals *pg /*$a3*/, int palette /*stack 16*/)
  // line 1349, offset 0x00023a20
 	/* begin block 1 */
 		// Start line: 1350
 		// Start offset: 0x00023A20
 		// Variables:
-	// 		struct POLY_FT3 *prim; // $t0
+	// 		POLY_FT3 *prim; // $t0
 	// 		long *ot; // $t7
 	// 		long GT3rgb; // stack offset -8
 	// 		int i; // $t4
@@ -588,7 +588,7 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawCar(struct _CAR_DATA *cp /*$s3*/, int view /*$a1*/)
+// void /*$ra*/ DrawCar(CAR_DATA *cp /*$s3*/, int view /*$a1*/)
  // line 1442, offset 0x000210b8
 	/* begin block 1 */
 		// Start line: 1443
@@ -596,13 +596,13 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 		// Variables:
 	// 		int WheelSpeed; // $s0
 	// 		int model; // $fp
-	// 		struct _PLAYER *lp; // $a2
+	// 		PLAYER *lp; // $a2
 
 		/* begin block 1.1 */
 			// Start line: 1454
 			// Start offset: 0x00021174
 			// Variables:
-		// 		struct CVECTOR col; // stack offset -312
+		// 		CVECTOR col; // stack offset -312
 		/* end block 1.1 */
 		// End offset: 0x00021244
 		// End Line: 1492
@@ -611,19 +611,19 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 			// Start line: 1496
 			// Start offset: 0x00021244
 			// Variables:
-		// 		struct MATRIX temp_mat1; // stack offset -304
-		// 		struct MATRIX temp_mat2; // stack offset -272
-		// 		struct MATRIX final_mat; // stack offset -240
-		// 		struct VECTOR pos; // stack offset -208
-		// 		struct VECTOR pos1; // stack offset -192
-		// 		struct SVECTOR temp_vec; // stack offset -176
+		// 		MATRIX temp_mat1; // stack offset -304
+		// 		MATRIX temp_mat2; // stack offset -272
+		// 		MATRIX final_mat; // stack offset -240
+		// 		VECTOR pos; // stack offset -208
+		// 		VECTOR pos1; // stack offset -192
+		// 		SVECTOR temp_vec; // stack offset -176
 		// 		int result; // $s4
 
 			/* begin block 1.2.1 */
 				// Start line: 1519
 				// Start offset: 0x00021290
 				// Variables:
-			// 		struct VECTOR corners[4]; // stack offset -168
+			// 		VECTOR corners[4]; // stack offset -168
 			/* end block 1.2.1 */
 			// End offset: 0x00021384
 			// End Line: 1538
@@ -632,8 +632,8 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 				// Start line: 1542
 				// Start offset: 0x00021384
 				// Variables:
-			// 		struct VECTOR d; // stack offset -104
-			// 		struct VECTOR dist; // stack offset -88
+			// 		VECTOR d; // stack offset -104
+			// 		VECTOR dist; // stack offset -88
 			/* end block 1.2.2 */
 			// End offset: 0x000214D8
 			// End Line: 1559
@@ -651,8 +651,8 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 				// Start line: 1627
 				// Start offset: 0x000215A4
 				// Variables:
-			// 		struct MATRIX workmatrix; // stack offset -104
-			// 		struct CAR_MODEL *CarModelPtr; // $s1
+			// 		MATRIX workmatrix; // stack offset -104
+			// 		CAR_MODEL *CarModelPtr; // $s1
 
 				/* begin block 1.2.4.1 */
 					// Start line: 1635
@@ -674,13 +674,13 @@ void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGl
 					// Start line: 1706
 					// Start offset: 0x000217BC
 					// Variables:
-				// 		struct CAR_MODEL *CarModelPtr; // $s0
+				// 		CAR_MODEL *CarModelPtr; // $s0
 
 					/* begin block 1.2.5.1.1 */
 						// Start line: 1706
 						// Start offset: 0x000217BC
 						// Variables:
-					// 		struct MATRIX workmatrix; // stack offset -72
+					// 		MATRIX workmatrix; // stack offset -72
 					/* end block 1.2.5.1.1 */
 					// End offset: 0x000218BC
 					// End Line: 1735
@@ -719,7 +719,7 @@ char RightLight = 0;
 char TransparentObject = 0;
 
 // [D] [T] [A]
-void DrawCar(_CAR_DATA *cp, int view)
+void DrawCar(CAR_DATA *cp, int view)
 {
 	int yVal;
 	int maxDamage;
@@ -990,7 +990,7 @@ void DrawCar(_CAR_DATA *cp, int view)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawCarObject(struct CAR_MODEL *car /*$s0*/, struct MATRIX *matrix /*$a1*/, struct VECTOR *pos /*$a2*/, struct VECTOR *pos1 /*$a3*/, int palette /*stack 16*/, struct _CAR_DATA *cp /*stack 20*/, int detail /*stack 24*/)
+// void /*$ra*/ DrawCarObject(CAR_MODEL *car /*$s0*/, MATRIX *matrix /*$a1*/, VECTOR *pos /*$a2*/, VECTOR *pos1 /*$a3*/, int palette /*stack 16*/, CAR_DATA *cp /*stack 20*/, int detail /*stack 24*/)
  // line 1793, offset 0x000233dc
 	/* begin block 1 */
 		// Start line: 1794
@@ -1000,8 +1000,8 @@ void DrawCar(_CAR_DATA *cp, int view)
 			// Start line: 1794
 			// Start offset: 0x000233DC
 			// Variables:
-		// 		struct SVECTOR cog; // stack offset -40
-		// 		struct VECTOR modelLocation; // stack offset -32
+		// 		SVECTOR cog; // stack offset -40
+		// 		VECTOR modelLocation; // stack offset -32
 		/* end block 1.1 */
 		// End offset: 0x000233DC
 		// End Line: 1794
@@ -1024,7 +1024,7 @@ void DrawCar(_CAR_DATA *cp, int view)
 	// End Line: 3587
 
 // [D] [T]
-void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CAR_DATA *cp, int detail)
+void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, CAR_DATA *cp, int detail)
 {
 	static unsigned long savedSP;
 	VECTOR modelLocation;
@@ -1054,17 +1054,17 @@ void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CA
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawCarWheels(struct _CAR_DATA *cp /*$fp*/, struct MATRIX *RearMatrix /*stack 4*/, struct VECTOR *pos /*stack 8*/, int zclip /*$a3*/)
+// void /*$ra*/ DrawCarWheels(CAR_DATA *cp /*$fp*/, MATRIX *RearMatrix /*stack 4*/, VECTOR *pos /*stack 8*/, int zclip /*$a3*/)
  // line 1850, offset 0x00021af8
 	/* begin block 1 */
 		// Start line: 1851
 		// Start offset: 0x00021AF8
 		// Variables:
-	// 		struct CAR_COSMETICS *car_cos; // $s0
-	// 		struct MATRIX FrontMatrix; // stack offset -144
-	// 		struct MODEL *WheelModel; // $s0
-	// 		struct MODEL *WheelModelBack; // stack offset -56
-	// 		struct MODEL *WheelModelFront; // stack offset -52
+	// 		CAR_COSMETICS *car_cos; // $s0
+	// 		MATRIX FrontMatrix; // stack offset -144
+	// 		MODEL *WheelModel; // $s0
+	// 		MODEL *WheelModelBack; // stack offset -56
+	// 		MODEL *WheelModelFront; // stack offset -52
 	// 		int i; // $s4
 	// 		static short FrontWheelRotation[20]; // offset 0x0
 	// 		static short BackWheelRotation[20]; // offset 0x30
@@ -1091,7 +1091,7 @@ void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CA
 		// 		int FW2z; // $a0
 		// 		int BW1z; // $v0
 		// 		int BW2z; // $a3
-		// 		struct SVECTOR *VertPtr; // $t6
+		// 		SVECTOR *VertPtr; // $t6
 		/* end block 1.2 */
 		// End offset: 0x00021CD0
 		// End Line: 1926
@@ -1100,7 +1100,7 @@ void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CA
 			// Start line: 1926
 			// Start offset: 0x00021CD0
 			// Variables:
-		// 		struct MATRIX SteerMatrix; // stack offset -112
+		// 		MATRIX SteerMatrix; // stack offset -112
 		/* end block 1.3 */
 		// End offset: 0x00021CD0
 		// End Line: 1926
@@ -1109,14 +1109,14 @@ void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CA
 			// Start line: 1988
 			// Start offset: 0x00021FA4
 			// Variables:
-		// 		struct SVECTOR *verts; // $s5
+		// 		SVECTOR *verts; // $s5
 
 			/* begin block 1.4.1 */
 				// Start line: 2007
 				// Start offset: 0x00021FF8
 				// Variables:
-			// 		struct VECTOR WheelPos; // stack offset -80
-			// 		struct SVECTOR sWheelPos; // stack offset -64
+			// 		VECTOR WheelPos; // stack offset -80
+			// 		SVECTOR sWheelPos; // stack offset -64
 			/* end block 1.4.1 */
 			// End offset: 0x00022028
 			// End Line: 2012
@@ -1146,7 +1146,7 @@ short FrontWheelRotation[MAX_CARS]; // offset 0x0
 short BackWheelRotation[MAX_CARS]; // offset 0x30
 
 // [D] [T]
-void DrawCarWheels(_CAR_DATA *cp, MATRIX *RearMatrix, VECTOR *pos, int zclip)
+void DrawCarWheels(CAR_DATA *cp, MATRIX *RearMatrix, VECTOR *pos, int zclip)
 {
 	short wheelSize;
 	int FW1z;
@@ -1361,14 +1361,14 @@ void DrawCarWheels(_CAR_DATA *cp, MATRIX *RearMatrix, VECTOR *pos, int zclip)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawWheelObject(struct MODEL *model /*$t2*/, struct SVECTOR *verts /*$t4*/, int transparent /*$a2*/, int wheelnum /*$a3*/)
+// void /*$ra*/ DrawWheelObject(MODEL *model /*$t2*/, SVECTOR *verts /*$t4*/, int transparent /*$a2*/, int wheelnum /*$a3*/)
  // line 2058, offset 0x00022180
 	/* begin block 1 */
 		// Start line: 2059
 		// Start offset: 0x00022180
 		// Variables:
-	// 		struct POLY_FT4 *prims; // $t0
-	// 		struct POLYFT4LIT *src; // $t1
+	// 		POLY_FT4 *prims; // $t0
+	// 		POLYFT4LIT *src; // $t1
 	// 		int i; // $t2
 	// 		int Z; // stack offset -4
 	// 		int clut; // $t8
@@ -1505,7 +1505,7 @@ void DrawWheelObject(MODEL *model, SVECTOR *verts, int transparent, int wheelnum
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlayerCarFX(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ PlayerCarFX(CAR_DATA *cp /*$s0*/)
  // line 2152, offset 0x000234dc
 	/* begin block 1 */
 		// Start line: 2153
@@ -1532,7 +1532,7 @@ void DrawWheelObject(MODEL *model, SVECTOR *verts, int transparent, int wheelnum
 	// End Line: 6921
 
 // [D] [T]
-void PlayerCarFX(_CAR_DATA *cp)
+void PlayerCarFX(CAR_DATA *cp)
 {
 	int WheelSpeed;
 	WheelSpeed = cp->hd.wheel_speed;
@@ -1559,30 +1559,30 @@ void PlayerCarFX(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ComputeCarLightingLevels(struct _CAR_DATA *cp /*$s1*/, char detail /*$s3*/)
+// void /*$ra*/ ComputeCarLightingLevels(CAR_DATA *cp /*$s1*/, char detail /*$s3*/)
  // line 2198, offset 0x00022458
 	/* begin block 1 */
 		// Start line: 2199
 		// Start offset: 0x00022458
 		// Variables:
 	// 		int light; // $s2
-	// 		struct SVECTOR lightsourcevector; // stack offset -96
-	// 		struct SVECTOR colour; // stack offset -88
-	// 		struct VECTOR lightValues; // stack offset -80
-	// 		struct VECTOR *orient; // $s0
+	// 		SVECTOR lightsourcevector; // stack offset -96
+	// 		SVECTOR colour; // stack offset -88
+	// 		VECTOR lightValues; // stack offset -80
+	// 		VECTOR *orient; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 2270
 			// Start offset: 0x0002270C
 			// Variables:
-		// 		struct MODEL *model; // $v1
-		// 		struct SVECTOR *norms; // $a3
-		// 		struct SVECTOR *ppads; // $a2
+		// 		MODEL *model; // $v1
+		// 		SVECTOR *norms; // $a3
+		// 		SVECTOR *ppads; // $a2
 		// 		int num_norms; // $a1
 		// 		int count; // $a1
-		// 		struct CVECTOR c0; // stack offset -64
-		// 		struct CVECTOR c1; // stack offset -56
-		// 		struct CVECTOR c2; // stack offset -48
+		// 		CVECTOR c0; // stack offset -64
+		// 		CVECTOR c1; // stack offset -56
+		// 		CVECTOR c2; // stack offset -48
 
 			/* begin block 1.1.1 */
 				// Start line: 2276
@@ -1618,7 +1618,7 @@ void PlayerCarFX(_CAR_DATA *cp)
 
 
 // [D] [T]
-void ComputeCarLightingLevels(_CAR_DATA *cp, char detail)
+void ComputeCarLightingLevels(CAR_DATA *cp, char detail)
 {
 	MATRIX scratchPadMat; // 0x1f800344
 
@@ -1777,7 +1777,7 @@ void buildNewCars(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ buildNewCarFromModel(struct CAR_MODEL *car /*$s5*/, struct MODEL *model /*$s7*/, int first /*$a2*/)
+// void /*$ra*/ buildNewCarFromModel(CAR_MODEL *car /*$s5*/, MODEL *model /*$s7*/, int first /*$a2*/)
  // line 2357, offset 0x00022960
 	/* begin block 1 */
 		// Start line: 2358
@@ -1792,7 +1792,7 @@ void buildNewCars(void)
 			// Start line: 2394
 			// Start offset: 0x00022A9C
 			// Variables:
-		// 		struct CAR_POLY *p; // $s1
+		// 		CAR_POLY *p; // $s1
 		// 		char ptype; // $s6
 
 			/* begin block 1.1.1 */
@@ -2091,8 +2091,8 @@ void buildNewCarFromModel(CAR_MODEL *car, MODEL *model, int first)
 		// Start offset: 0x000230C8
 		// Variables:
 	// 		int i; // $v1
-	// 		struct MODEL *m; // $t0
-	// 		struct POLYFT4LIT *src; // $a0
+	// 		MODEL *m; // $t0
+	// 		POLYFT4LIT *src; // $a0
 
 		/* begin block 1.1 */
 			// Start line: 2610

--- a/src_rebuild/GAME/C/CARS.H
+++ b/src_rebuild/GAME/C/CARS.H
@@ -6,10 +6,10 @@
 #define IS_ROADBLOCK_CAR(cp) (cp->controlType == CONTROL_TYPE_CIV_AI && (cp->controlFlags & CONTROL_FLAG_COP_SLEEPING))
 
 // PHYSICS
-extern _CAR_DATA car_data[MAX_CARS + 2];	// all cars + Tanner cbox + Camera cbox
+extern CAR_DATA car_data[MAX_CARS + 2];	// all cars + Tanner cbox + Camera cbox
 
 // active cars
-extern _CAR_DATA* active_car_list[MAX_CARS];
+extern CAR_DATA* active_car_list[MAX_CARS];
 extern BOUND_BOX bbox[MAX_CARS];
 extern unsigned char lightsOnDelay[MAX_CARS];
 
@@ -44,17 +44,17 @@ extern void plotCarPolyGT3(int numTris, CAR_POLY *src, SVECTOR *vlist, SVECTOR *
 
 extern void plotCarPolyGT3nolight(int numTris, CAR_POLY *src, SVECTOR *vlist, plotCarGlobals *pg, int palette); // 0x00023A20
 
-extern void DrawCar(_CAR_DATA *cp, int view); // 0x000210B8
+extern void DrawCar(CAR_DATA *cp, int view); // 0x000210B8
 
-extern void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, _CAR_DATA *cp, int detail); // 0x000233DC
+extern void DrawCarObject(CAR_MODEL *car, MATRIX *matrix, VECTOR *pos, int palette, CAR_DATA *cp, int detail); // 0x000233DC
 
-extern void DrawCarWheels(_CAR_DATA *cp, MATRIX *RearMatrix, VECTOR *pos, int zclip); // 0x00021AF8
+extern void DrawCarWheels(CAR_DATA *cp, MATRIX *RearMatrix, VECTOR *pos, int zclip); // 0x00021AF8
 
 extern void DrawWheelObject(MODEL *model, SVECTOR *verts, int transparent, int wheelnum); // 0x00022180
 
-extern void PlayerCarFX(_CAR_DATA *cp); // 0x000234DC
+extern void PlayerCarFX(CAR_DATA *cp); // 0x000234DC
 
-extern void ComputeCarLightingLevels(_CAR_DATA *cp, char detail); // 0x00022458
+extern void ComputeCarLightingLevels(CAR_DATA *cp, char detail); // 0x00022458
 
 extern void buildNewCars(); // 0x00022860
 

--- a/src_rebuild/GAME/C/CELL.C
+++ b/src_rebuild/GAME/C/CELL.C
@@ -41,13 +41,13 @@ void ClearCopUsage(void)
 
 // decompiled code
 // original method signature: 
-// struct PACKED_CELL_OBJECT * /*$ra*/ GetFirstPackedCop(int cellx /*$t3*/, int cellz /*$a1*/, struct CELL_ITERATOR *pci /*$a2*/, int use_computed /*$a3*/)
+// PACKED_CELL_OBJECT * /*$ra*/ GetFirstPackedCop(int cellx /*$t3*/, int cellz /*$a1*/, CELL_ITERATOR *pci /*$a2*/, int use_computed /*$a3*/)
  // line 67, offset 0x00023bac
 	/* begin block 1 */
 		// Start line: 68
 		// Start offset: 0x00023BAC
 		// Variables:
-	// 		struct PACKED_CELL_OBJECT *ppco; // $a1
+	// 		PACKED_CELL_OBJECT *ppco; // $a1
 	// 		unsigned short index; // $a0
 	// 		unsigned short num; // $t0
 	// 		int cbrx; // $t0
@@ -159,13 +159,13 @@ PACKED_CELL_OBJECT * GetFirstPackedCop(int cellx, int cellz, CELL_ITERATOR *pci,
 
 // decompiled code
 // original method signature: 
-// struct PACKED_CELL_OBJECT * /*$ra*/ GetNextPackedCop(struct CELL_ITERATOR *pci /*$a0*/)
+// PACKED_CELL_OBJECT * /*$ra*/ GetNextPackedCop(CELL_ITERATOR *pci /*$a0*/)
  // line 813, offset 0x0003f5f0
 	/* begin block 1 */
 		// Start line: 814
 		// Start offset: 0x0003F5F0
 		// Variables:
-	// 		struct PACKED_CELL_OBJECT *ppco; // $a3
+	// 		PACKED_CELL_OBJECT *ppco; // $a3
 	// 		unsigned short num; // $a1
 	/* end block 1 */
 	// End offset: 0x0003F6B0
@@ -229,13 +229,13 @@ PACKED_CELL_OBJECT* GetNextPackedCop(CELL_ITERATOR* pci)
 
 // decompiled code
 // original method signature: 
-// struct CELL_OBJECT * /*$ra*/ UnpackCellObject(struct PACKED_CELL_OBJECT *ppco /*$a3*/, struct XZPAIR *near /*$t0*/)
+// CELL_OBJECT * /*$ra*/ UnpackCellObject(PACKED_CELL_OBJECT *ppco /*$a3*/, XZPAIR *near /*$t0*/)
  // line 854, offset 0x000418e8
 	/* begin block 1 */
 		// Start line: 855
 		// Start offset: 0x000418E8
 		// Variables:
-	// 		struct CELL_OBJECT *pco; // $a2
+	// 		CELL_OBJECT *pco; // $a2
 	/* end block 1 */
 	// End offset: 0x000419A8
 	// End Line: 870

--- a/src_rebuild/GAME/C/CELL.H
+++ b/src_rebuild/GAME/C/CELL.H
@@ -5,10 +5,10 @@ extern unsigned char cell_object_computed_values[2048];
 
 extern void ClearCopUsage(); // 0x00023DC0
 
-extern struct PACKED_CELL_OBJECT * GetFirstPackedCop(int cellx, int cellz, struct CELL_ITERATOR *pci, int use_computed); // 0x00023BAC
+extern PACKED_CELL_OBJECT * GetFirstPackedCop(int cellx, int cellz, CELL_ITERATOR *pci, int use_computed); // 0x00023BAC
 
-extern struct PACKED_CELL_OBJECT* GetNextPackedCop(struct CELL_ITERATOR* pci); // 0x0003F5F0
+extern PACKED_CELL_OBJECT* GetNextPackedCop(CELL_ITERATOR* pci); // 0x0003F5F0
 
-extern struct CELL_OBJECT* UnpackCellObject(struct PACKED_CELL_OBJECT* ppco, struct XZPAIR* near); // 0x000418E8
+extern CELL_OBJECT* UnpackCellObject(PACKED_CELL_OBJECT* ppco, XZPAIR* near); // 0x000418E8
 
 #endif

--- a/src_rebuild/GAME/C/CIV_AI.C
+++ b/src_rebuild/GAME/C/CIV_AI.C
@@ -29,7 +29,20 @@
 
 unsigned char speedLimits[3] = { 56, 97, 138 };
 
-CIV_AI_234fake civPingTest = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+struct
+{
+	int NumPingedIn;
+	int OffRoad;
+	int NotDrivable;
+	int TooShortStr;
+	int NearEndStr;
+	int TooShortCrv;
+	int NearEndCrv;
+	int TooCloseNuddaCar;
+	int TooClosePlayer;
+	int InvalidRegion;
+} civPingTest = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
 char modelRandomList[] = { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 0, 1, 0, 4 };
 unsigned char reservedSlots[MAX_CARS] = { 0 };
 
@@ -74,13 +87,13 @@ int test555 = 0;
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ InitCar(struct _CAR_DATA *cp /*$s0*/, int direction /*$s6*/, long (*startPos)[4] /*$s2*/, unsigned char control /*$s4*/, int model /*stack 16*/, int palette /*stack 20*/, char *extraData /*stack 24*/)
+// int /*$ra*/ InitCar(CAR_DATA *cp /*$s0*/, int direction /*$s6*/, long (*startPos)[4] /*$s2*/, unsigned char control /*$s4*/, int model /*stack 16*/, int palette /*stack 20*/, char *extraData /*stack 24*/)
  // line 717, offset 0x00023de8
 	/* begin block 1 */
 		// Start line: 718
 		// Start offset: 0x00023DE8
 		// Variables:
-	// 		struct VECTOR tmpStart; // stack offset -48
+	// 		VECTOR tmpStart; // stack offset -48
 	/* end block 1 */
 	// End offset: 0x00024028
 	// End Line: 786
@@ -91,11 +104,11 @@ int test555 = 0;
 	// End Line: 1435
 
 // [D] [T]
-int InitCar(_CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char control, int model, int palette, char* extraData)
+int InitCar(CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char control, int model, int palette, char* extraData)
 {
 	VECTOR tmpStart;
 
-	ClearMem((char*)cp, sizeof(_CAR_DATA));
+	ClearMem((char*)cp, sizeof(CAR_DATA));
 
 	cp->wasOnGround = 1;
 
@@ -174,14 +187,14 @@ int InitCar(_CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char cont
 
 // decompiled code
 // original method signature: 
-// struct _CAR_DATA * /*$ra*/ FindClosestCar(int x /*$t4*/, int y /*$a1*/, int z /*$a2*/, int *distToCarSq /*$a3*/)
+// CAR_DATA * /*$ra*/ FindClosestCar(int x /*$t4*/, int y /*$a1*/, int z /*$a2*/, int *distToCarSq /*$a3*/)
  // line 891, offset 0x0002d11c
 	/* begin block 1 */
 		// Start line: 892
 		// Start offset: 0x0002D11C
 		// Variables:
-	// 		struct _CAR_DATA *retCar; // $t2
-	// 		struct _CAR_DATA *lcp; // $t0
+	// 		CAR_DATA *retCar; // $t2
+	// 		CAR_DATA *lcp; // $t0
 	// 		unsigned int retDistSq; // $t1
 	// 		int distSq; // $v0
 	// 		int dx; // $a0
@@ -201,12 +214,12 @@ int InitCar(_CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char cont
 	// End Line: 6498
 
 // [D] [T]
-_CAR_DATA* FindClosestCar(int x, int y, int z, int* distToCarSq)
+CAR_DATA* FindClosestCar(int x, int y, int z, int* distToCarSq)
 {
 	uint distSq;
-	_CAR_DATA* lcp;
+	CAR_DATA* lcp;
 	uint retDistSq;
-	_CAR_DATA* retCar;
+	CAR_DATA* retCar;
 	int dx; // $a0
 	int dz; // $v1
 
@@ -248,7 +261,7 @@ _CAR_DATA* FindClosestCar(int x, int y, int z, int* distToCarSq)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ NotTravellingAlongCurve(int x /*$a0*/, int z /*$a1*/, int dir /*$s0*/, struct DRIVER2_CURVE *cv /*$a3*/)
+// int /*$ra*/ NotTravellingAlongCurve(int x /*$a0*/, int z /*$a1*/, int dir /*$s0*/, DRIVER2_CURVE *cv /*$a3*/)
  // line 918, offset 0x0002d24c
 	/* begin block 1 */
 		// Start line: 919
@@ -286,7 +299,7 @@ int NotTravellingAlongCurve(int x, int z, int dir, DRIVER2_CURVE* cv)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivCarFX(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ CivCarFX(CAR_DATA *cp /*$s0*/)
  // line 930, offset 0x0002d084
 	/* begin block 1 */
 		// Start line: 1860
@@ -294,7 +307,7 @@ int NotTravellingAlongCurve(int x, int z, int dir, DRIVER2_CURVE* cv)
 	// End Line: 1861
 
 // [D] [T]
-void CivCarFX(_CAR_DATA* cp)
+void CivCarFX(CAR_DATA* cp)
 {
 	if (cp->ai.c.thrustState != 3)
 	{
@@ -314,7 +327,7 @@ void CivCarFX(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GetNextRoadInfo(struct _CAR_DATA *cp /*$s7*/, int randomExit /*$a1*/, int *turnAngle /*stack 8*/, int *startDist /*stack 12*/, struct CIV_ROUTE_ENTRY *oldNode /*stack 16*/)
+// int /*$ra*/ GetNextRoadInfo(CAR_DATA *cp /*$s7*/, int randomExit /*$a1*/, int *turnAngle /*stack 8*/, int *startDist /*stack 12*/, CIV_ROUTE_ENTRY *oldNode /*stack 16*/)
  // line 981, offset 0x00024028
 	/* begin block 1 */
 		// Start line: 982
@@ -329,11 +342,11 @@ void CivCarFX(_CAR_DATA* cp)
 	// 		int newNumLanes; // $a3
 	// 		int newDir; // stack offset -84
 	// 		int oppDir; // $s0
-	// 		struct DRIVER2_JUNCTION *jn; // $t5
-	// 		struct DRIVER2_CURVE *cv; // $s1
-	// 		struct DRIVER2_STRAIGHT *st; // $s5
-	// 		struct DRIVER2_STRAIGHT *tmpSt; // $a2
-	// 		struct DRIVER2_CURVE *tmpCv; // $s1
+	// 		DRIVER2_JUNCTION *jn; // $t5
+	// 		DRIVER2_CURVE *cv; // $s1
+	// 		DRIVER2_STRAIGHT *st; // $s5
+	// 		DRIVER2_STRAIGHT *tmpSt; // $a2
+	// 		DRIVER2_CURVE *tmpCv; // $s1
 	// 		short *jnExit; // $a2
 	// 		int newLane; // $s2
 	// 		char leftLane; // stack offset -80
@@ -374,7 +387,7 @@ void CivCarFX(_CAR_DATA* cp)
 			// 		int x; // $v1
 			// 		int z; // $v0
 			// 		int dir; // stack offset -84
-			// 		struct DRIVER2_CURVE *cv; // $s1
+			// 		DRIVER2_CURVE *cv; // $s1
 
 				/* begin block 1.1.2.1 */
 					// Start line: 1091
@@ -427,11 +440,11 @@ void CivCarFX(_CAR_DATA* cp)
 				// Start line: 982
 				// Start offset: 0x000251EC
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *jn; // $t5
+			// 		DRIVER2_JUNCTION *jn; // $t5
 			// 		int currentExit; // $a2
 			// 		int turnAngle; // $t1
-			// 		struct _CAR_DATA *cp; // $s7
-			// 		struct CIV_ROUTE_ENTRY *oldNode; // $t7
+			// 		CAR_DATA *cp; // $s7
+			// 		CIV_ROUTE_ENTRY *oldNode; // $t7
 
 				/* begin block 1.1.4.1 */
 					// Start line: 982
@@ -458,7 +471,7 @@ void CivCarFX(_CAR_DATA* cp)
 				// 		int x; // $v1
 				// 		int z; // $v0
 				// 		int dir; // stack offset -84
-				// 		struct DRIVER2_CURVE *cv; // $s1
+				// 		DRIVER2_CURVE *cv; // $s1
 
 					/* begin block 1.1.5.1.1 */
 						// Start line: 1173
@@ -509,7 +522,7 @@ void CivCarFX(_CAR_DATA* cp)
 					// Variables:
 				// 		int x; // $v1
 				// 		int z; // $v0
-				// 		struct DRIVER2_CURVE *cv; // $s1
+				// 		DRIVER2_CURVE *cv; // $s1
 
 					/* begin block 1.2.2.1.1 */
 						// Start line: 1286
@@ -544,7 +557,7 @@ void CivCarFX(_CAR_DATA* cp)
 
 // [D] [T]
 // BUGS: sometimes not getting right lane when road direction switched
-int GetNextRoadInfo(_CAR_DATA* cp, int randomExit, int* turnAngle, int* startDist, CIV_ROUTE_ENTRY* oldNode)
+int GetNextRoadInfo(CAR_DATA* cp, int randomExit, int* turnAngle, int* startDist, CIV_ROUTE_ENTRY* oldNode)
 {
 	unsigned long junctionFlags;
 	DRIVER2_JUNCTION* jn;
@@ -1386,14 +1399,14 @@ int GetNextRoadInfo(_CAR_DATA* cp, int randomExit, int* turnAngle, int* startDis
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitNodeList(struct _CAR_DATA *cp /*$s6*/, char *extraData /*$s7*/)
+// void /*$ra*/ InitNodeList(CAR_DATA *cp /*$s6*/, char *extraData /*$s7*/)
  // line 1365, offset 0x00026964
 	/* begin block 1 */
 		// Start line: 1366
 		// Start offset: 0x00026964
 		// Variables:
 	// 		int i; // $v1
-	// 		struct CIV_ROUTE_ENTRY *cr; // $s5
+	// 		CIV_ROUTE_ENTRY *cr; // $s5
 	// 		int dx; // $s1
 	// 		int dz; // $s2
 	// 		int surfInd; // $s4
@@ -1404,7 +1417,7 @@ int GetNextRoadInfo(_CAR_DATA* cp, int randomExit, int* turnAngle, int* startDis
 			// Variables:
 		// 		int theta; // $s0
 		// 		int laneDist; // $s1
-		// 		struct DRIVER2_STRAIGHT *str; // $s3
+		// 		DRIVER2_STRAIGHT *str; // $s3
 		/* end block 1.1 */
 		// End offset: 0x00026B60
 		// End Line: 1406
@@ -1413,7 +1426,7 @@ int GetNextRoadInfo(_CAR_DATA* cp, int randomExit, int* turnAngle, int* startDis
 			// Start line: 1411
 			// Start offset: 0x00026B9C
 			// Variables:
-		// 		struct DRIVER2_CURVE *crv; // $s0
+		// 		DRIVER2_CURVE *crv; // $s0
 		/* end block 1.2 */
 		// End offset: 0x00026C4C
 		// End Line: 1415
@@ -1432,7 +1445,7 @@ int GetNextRoadInfo(_CAR_DATA* cp, int randomExit, int* turnAngle, int* startDis
 	// End Line: 2989
 
 // [D] [T]
-void InitNodeList(_CAR_DATA* cp, EXTRA_CIV_DATA* extraData)
+void InitNodeList(CAR_DATA* cp, EXTRA_CIV_DATA* extraData)
 {
 	int dx; // $s1
 	int dz; // $s2
@@ -1517,7 +1530,7 @@ void InitNodeList(_CAR_DATA* cp, EXTRA_CIV_DATA* extraData)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GetNodePos(struct DRIVER2_STRAIGHT *straight /*$t1*/, struct DRIVER2_JUNCTION *junction /*$a1*/, struct DRIVER2_CURVE *curve /*$t0*/, int distAlongPath /*$a3*/, struct _CAR_DATA *cp /*stack 16*/, int *x /*stack 20*/, int *z /*stack 24*/, int laneNo /*stack 28*/)
+// int /*$ra*/ GetNodePos(DRIVER2_STRAIGHT *straight /*$t1*/, DRIVER2_JUNCTION *junction /*$a1*/, DRIVER2_CURVE *curve /*$t0*/, int distAlongPath /*$a3*/, CAR_DATA *cp /*stack 16*/, int *x /*stack 20*/, int *z /*stack 24*/, int laneNo /*stack 28*/)
  // line 1441, offset 0x00026cac
 	/* begin block 1 */
 		// Start line: 1442
@@ -1542,7 +1555,7 @@ void InitNodeList(_CAR_DATA* cp, EXTRA_CIV_DATA* extraData)
 
 
 // [D] [T]
-int GetNodePos(DRIVER2_STRAIGHT* straight, DRIVER2_JUNCTION* junction, DRIVER2_CURVE* curve, int distAlongPath, _CAR_DATA* cp, int* x, int* z, int laneNo)
+int GetNodePos(DRIVER2_STRAIGHT* straight, DRIVER2_JUNCTION* junction, DRIVER2_CURVE* curve, int distAlongPath, CAR_DATA* cp, int* x, int* z, int laneNo)
 {
 	unsigned char oldLane;
 	unsigned char changeLaneCount;
@@ -1622,7 +1635,7 @@ int GetNodePos(DRIVER2_STRAIGHT* straight, DRIVER2_JUNCTION* junction, DRIVER2_C
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckChangeLanes(struct DRIVER2_STRAIGHT *straight /*$s4*/, struct DRIVER2_CURVE *curve /*$s6*/, int distAlongSegment /*$a2*/, struct _CAR_DATA *cp /*$s3*/, int tryToPark /*stack 16*/)
+// int /*$ra*/ CheckChangeLanes(DRIVER2_STRAIGHT *straight /*$s4*/, DRIVER2_CURVE *curve /*$s6*/, int distAlongSegment /*$a2*/, CAR_DATA *cp /*$s3*/, int tryToPark /*stack 16*/)
  // line 1507, offset 0x00026f20
 	/* begin block 1 */
 		// Start line: 1508
@@ -1634,14 +1647,14 @@ int GetNodePos(DRIVER2_STRAIGHT* straight, DRIVER2_JUNCTION* junction, DRIVER2_C
 	// 		unsigned char canProceed; // stack offset -88
 	// 		unsigned char travelAlongRoad; // $s5
 	// 		unsigned char turnRight; // stack offset -84
-	// 		struct _CAR_DATA *cp1; // $s0
-	// 		struct CIV_ROUTE_ENTRY tmpNode; // stack offset -120
+	// 		CAR_DATA *cp1; // $s0
+	// 		CIV_ROUTE_ENTRY tmpNode; // stack offset -120
 
 		/* begin block 1.1 */
 			// Start line: 1572
 			// Start offset: 0x00027290
 			// Variables:
-		// 		struct VECTOR pos; // stack offset -104
+		// 		VECTOR pos; // stack offset -104
 		// 		int theta; // $a0
 		// 		int length; // $a1
 
@@ -1674,7 +1687,7 @@ int GetNodePos(DRIVER2_STRAIGHT* straight, DRIVER2_JUNCTION* junction, DRIVER2_C
 	// End Line: 3338
 
 // [D] [T]
-int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distAlongSegment, _CAR_DATA* cp, int tryToPark)
+int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distAlongSegment, CAR_DATA* cp, int tryToPark)
 {
 	int oldLane;
 	int currentLane;
@@ -1685,7 +1698,7 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 	int dz;
 	uint theta;
 	int length;
-	_CAR_DATA* lcp;
+	CAR_DATA* lcp;
 
 	int oldLaneDir;
 	VECTOR pos;
@@ -1836,7 +1849,7 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CreateNewNode(struct _CAR_DATA *cp /*$s4*/)
+// int /*$ra*/ CreateNewNode(CAR_DATA *cp /*$s4*/)
 	// line 1637, offset 0x00027530
 	/* begin block 1 */
 		// Start line: 1638
@@ -1844,24 +1857,24 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 		// Variables:
 	// 		int oldRoad; // $s1
 	// 		int cr; // $a3
-	// 		struct CIV_ROUTE_ENTRY *newNode; // $s6
-	// 		struct CIV_ROUTE_ENTRY *oldNode; // $s3
-	// 		struct DRIVER2_CURVE *curve; // $s0
-	// 		struct DRIVER2_STRAIGHT *straight; // $s5
+	// 		CIV_ROUTE_ENTRY *newNode; // $s6
+	// 		CIV_ROUTE_ENTRY *oldNode; // $s3
+	// 		DRIVER2_CURVE *curve; // $s0
+	// 		DRIVER2_STRAIGHT *straight; // $s5
 	// 		int turnAngle; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 1638
 			// Start offset: 0x00027530
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
-		// 		struct CIV_ROUTE_ENTRY *currentNode; // $v1
+		// 		CAR_DATA *cp; // $s4
+		// 		CIV_ROUTE_ENTRY *currentNode; // $v1
 
 			/* begin block 1.1.1 */
 				// Start line: 1638
 				// Start offset: 0x00027530
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+			// 		CIV_ROUTE_ENTRY *retNode; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x0002757C
 			// End Line: 1638
@@ -1873,13 +1886,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1638
 			// Start offset: 0x0002758C
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
+		// 		CAR_DATA *cp; // $s4
 
 			/* begin block 1.2.1 */
 				// Start line: 1638
 				// Start offset: 0x0002758C
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+			// 		CIV_ROUTE_ENTRY *retNode; // $a0
 			/* end block 1.2.1 */
 			// End offset: 0x0002759C
 			// End Line: 1638
@@ -1891,13 +1904,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1638
 			// Start offset: 0x000275A8
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
+		// 		CAR_DATA *cp; // $s4
 
 			/* begin block 1.3.1 */
 				// Start line: 1638
 				// Start offset: 0x000275A8
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+			// 		CIV_ROUTE_ENTRY *retNode; // $a0
 			/* end block 1.3.1 */
 			// End offset: 0x000275B8
 			// End Line: 1638
@@ -1909,13 +1922,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1638
 			// Start offset: 0x000275C4
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
+		// 		CAR_DATA *cp; // $s4
 
 			/* begin block 1.4.1 */
 				// Start line: 1638
 				// Start offset: 0x000275C4
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+			// 		CIV_ROUTE_ENTRY *retNode; // $a0
 			/* end block 1.4.1 */
 			// End offset: 0x000275D4
 			// End Line: 1638
@@ -1927,14 +1940,14 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1653
 			// Start offset: 0x000275F0
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
-		// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+		// 		CAR_DATA *cp; // $s4
+		// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 			/* begin block 1.5.1 */
 				// Start line: 1653
 				// Start offset: 0x000275F0
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+			// 		CIV_ROUTE_ENTRY *retNode; // $v1
 			/* end block 1.5.1 */
 			// End offset: 0x000275F0
 			// End Line: 1653
@@ -1950,13 +1963,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 				// Start line: 1638
 				// Start offset: 0x000275F0
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s4
+			// 		CAR_DATA *cp; // $s4
 
 				/* begin block 1.6.1.1 */
 					// Start line: 1638
 					// Start offset: 0x000275F0
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.6.1.1 */
 				// End offset: 0x00027600
 				// End Line: 1638
@@ -1971,14 +1984,14 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1659
 			// Start offset: 0x00027634
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s4
-		// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+		// 		CAR_DATA *cp; // $s4
+		// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 			/* begin block 1.7.1 */
 				// Start line: 1659
 				// Start offset: 0x00027634
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $s2
+			// 		CIV_ROUTE_ENTRY *retNode; // $s2
 			/* end block 1.7.1 */
 			// End offset: 0x0002764C
 			// End Line: 1659
@@ -2028,7 +2041,7 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 			// Start line: 1717
 			// Start offset: 0x00027A18
 			// Variables:
-		// 		struct CIV_ROUTE_ENTRY tmpNode; // stack offset -72
+		// 		CIV_ROUTE_ENTRY tmpNode; // stack offset -72
 
 			/* begin block 1.10.1 */
 				// Start line: 1721
@@ -2043,7 +2056,7 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 				// Start line: 1739
 				// Start offset: 0x00027B90
 				// Variables:
-			// 		struct _CAR_DATA *playerCar; // $v0
+			// 		CAR_DATA *playerCar; // $v0
 			// 		int dx; // $v1
 			// 		int dz; // $a0
 			/* end block 1.10.2 */
@@ -2074,13 +2087,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 					// Start line: 1789
 					// Start offset: 0x00027EBC
 					// Variables:
-				// 		struct _CAR_DATA *cp; // $s4
+				// 		CAR_DATA *cp; // $s4
 
 					/* begin block 1.10.4.1.1 */
 						// Start line: 1789
 						// Start offset: 0x00027EBC
 						// Variables:
-					// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+					// 		CIV_ROUTE_ENTRY *retNode; // $a0
 					/* end block 1.10.4.1.1 */
 					// End offset: 0x00027F44
 					// End Line: 1792
@@ -2092,13 +2105,13 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 					// Start line: 1800
 					// Start offset: 0x00027F78
 					// Variables:
-				// 		struct _CAR_DATA *cp; // $s4
+				// 		CAR_DATA *cp; // $s4
 
 					/* begin block 1.10.4.2.1 */
 						// Start line: 1800
 						// Start offset: 0x00027F78
 						// Variables:
-					// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+					// 		CIV_ROUTE_ENTRY *retNode; // $a0
 					/* end block 1.10.4.2.1 */
 					// End offset: 0x0002800C
 					// End Line: 1803
@@ -2117,14 +2130,14 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 					// Start line: 1638
 					// Start offset: 0x0002800C
 					// Variables:
-				// 		struct _CAR_DATA *cp; // $s4
-				// 		struct CIV_ROUTE_ENTRY *currentNode; // $s6
+				// 		CAR_DATA *cp; // $s4
+				// 		CIV_ROUTE_ENTRY *currentNode; // $s6
 
 					/* begin block 1.10.5.1.1 */
 						// Start line: 1638
 						// Start offset: 0x0002800C
 						// Variables:
-					// 		struct CIV_ROUTE_ENTRY *retNode; // $v0
+					// 		CIV_ROUTE_ENTRY *retNode; // $v0
 					/* end block 1.10.5.1.1 */
 					// End offset: 0x0002800C
 					// End Line: 1638
@@ -2156,7 +2169,7 @@ int CheckChangeLanes(DRIVER2_STRAIGHT* straight, DRIVER2_CURVE* curve, int distA
 int makeNextNodeCtrlNode = -1;
 
 // [D] [T]
-int CreateNewNode(_CAR_DATA * cp)
+int CreateNewNode(CAR_DATA * cp)
 {
 	CIV_ROUTE_ENTRY* start;
 	CIV_ROUTE_ENTRY* newNode;
@@ -2290,7 +2303,7 @@ int CreateNewNode(_CAR_DATA * cp)
 					if (gCurrentMissionNumber == 33 && cp->ap.model == 4)
 					{
 						int dx, dz;
-						_CAR_DATA* playerCar = &car_data[player[0].playerCarId];
+						CAR_DATA* playerCar = &car_data[player[0].playerCarId];
 
 						dx = playerCar->hd.where.t[0] - cp->hd.where.t[0];
 						dz = playerCar->hd.where.t[1] - cp->hd.where.t[1];
@@ -2437,13 +2450,13 @@ int CreateNewNode(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ InitCivState(struct _CAR_DATA *cp /*$s1*/, char *extraData /*$s2*/)
+// int /*$ra*/ InitCivState(CAR_DATA *cp /*$s1*/, char *extraData /*$s2*/)
 	// line 1843, offset 0x000280d8
 	/* begin block 1 */
 		// Start line: 1844
 		// Start offset: 0x000280D8
 		// Variables:
-	// 		struct CIV_STATE *cs; // $s0
+	// 		CIV_STATE *cs; // $s0
 	/* end block 1 */
 	// End offset: 0x000282E8
 	// End Line: 1887
@@ -2459,7 +2472,7 @@ int CreateNewNode(_CAR_DATA * cp)
 	// End Line: 4218
 
 // [D] [T]
-int InitCivState(_CAR_DATA * cp, EXTRA_CIV_DATA * extraData)
+int InitCivState(CAR_DATA * cp, EXTRA_CIV_DATA * extraData)
 {
 	CIV_STATE* cs = &cp->ai.c;
 
@@ -2519,7 +2532,7 @@ int InitCivState(_CAR_DATA * cp, EXTRA_CIV_DATA * extraData)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ PingOutCar(struct _CAR_DATA *cp /*$s0*/)
+// int /*$ra*/ PingOutCar(CAR_DATA *cp /*$s0*/)
 	// line 1977, offset 0x0002cf80
 	/* begin block 1 */
 		// Start line: 7534
@@ -2537,7 +2550,7 @@ int InitCivState(_CAR_DATA * cp, EXTRA_CIV_DATA * extraData)
 	// End Line: 7536
 
 // [D] [T]
-int PingOutCar(_CAR_DATA * cp)
+int PingOutCar(CAR_DATA * cp)
 {
 	testNumPingedOut++;
 
@@ -2559,7 +2572,7 @@ int PingOutCar(_CAR_DATA * cp)
 	if (cp->inform)
 		*cp->inform ^= 0x40000000;
 
-	ClearMem((char*)cp, sizeof(_CAR_DATA));
+	ClearMem((char*)cp, sizeof(CAR_DATA));
 
 	cp->controlType = CONTROL_TYPE_NONE;
 
@@ -2576,13 +2589,13 @@ int PingOutCar(_CAR_DATA * cp)
 		// Start line: 2018
 		// Start offset: 0x000282E8
 		// Variables:
-	// 		struct _CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *lcp; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 2017
 			// Start offset: 0x00028348
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 		/* end block 1.1 */
 		// End offset: 0x000283E4
 		// End Line: 2017
@@ -2616,7 +2629,7 @@ int PingOutCar(_CAR_DATA * cp)
 // used when secret car is requested
 int PingOutAllSpecialCivCars(void)
 {
-	_CAR_DATA* lcp;
+	CAR_DATA* lcp;
 
 	lcp = car_data;
 
@@ -2641,13 +2654,13 @@ int PingOutAllSpecialCivCars(void)
 		// Start line: 2030
 		// Start offset: 0x0002840C
 		// Variables:
-	// 		struct _CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *lcp; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 2029
 			// Start offset: 0x0002844C
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 		/* end block 1.1 */
 		// End offset: 0x0002852C
 		// End Line: 2029
@@ -2681,7 +2694,7 @@ int PingOutAllSpecialCivCars(void)
 // used by cutscenes
 int PingOutAllCivCarsAndCopCars(void)
 {
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 
 	cp = car_data;
 
@@ -2700,7 +2713,7 @@ int PingOutAllCivCarsAndCopCars(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckPingOut(struct _CAR_DATA *cp /*$s0*/)
+// int /*$ra*/ CheckPingOut(CAR_DATA *cp /*$s0*/)
 	// line 2050, offset 0x00028554
 	/* begin block 1 */
 		// Start line: 2051
@@ -2714,7 +2727,7 @@ int PingOutAllCivCarsAndCopCars(void)
 			// Start line: 2051
 			// Start offset: 0x000285B8
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 		/* end block 1.1 */
 		// End offset: 0x00028694
 		// End Line: 2051
@@ -2740,7 +2753,7 @@ int PingOutAllCivCarsAndCopCars(void)
 // [D] [T]
 // called by civ car.
 // checks distance from player and removes car if too far
-int CheckPingOut(_CAR_DATA * cp)
+int CheckPingOut(CAR_DATA * cp)
 {
 	int dz;
 	int dx;
@@ -2900,10 +2913,10 @@ void InitCivCars(void)
 		// Start line: 2177
 		// Start offset: 0x000286E0
 		// Variables:
-	// 		struct _EXTRA_CIV_DATA civDat; // stack offset -56
-	// 		struct _CAR_DATA *newCar; // $s1
-	// 		struct CIV_ROUTE_ENTRY *stopNode; // $a0
-	// 		struct CIV_ROUTE_ENTRY *spareNode; // $a1
+	// 		EXTRA_CIV_DATA civDat; // stack offset -56
+	// 		CAR_DATA *newCar; // $s1
+	// 		CIV_ROUTE_ENTRY *stopNode; // $a0
+	// 		CIV_ROUTE_ENTRY *spareNode; // $a1
 
 		/* begin block 1.1 */
 			// Start line: 2177
@@ -2914,7 +2927,7 @@ void InitCivCars(void)
 				// Start offset: 0x000286E0
 				// Variables:
 			// 		char *slot; // $v1
-			// 		struct _CAR_DATA *carCnt; // $a0
+			// 		CAR_DATA *carCnt; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x00028774
 			// End Line: 2184
@@ -2942,12 +2955,12 @@ const int DistanceTriggerCarMoves = 700; // 5000;
 int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*stopPos)[4], unsigned char internalModel, int palette)
 {
 	unsigned char* slot;
-	_CAR_DATA* carCnt;
-	_CAR_DATA* pNewCar;
+	CAR_DATA* carCnt;
+	CAR_DATA* pNewCar;
 	CIV_ROUTE_ENTRY* stopNode; // $a0
 	CIV_ROUTE_ENTRY* spareNode; // $a1
 
-	_EXTRA_CIV_DATA civDat;
+	EXTRA_CIV_DATA civDat;
 	ClearMem((char*)&civDat, sizeof(civDat));
 
 	carCnt = car_data;
@@ -3021,8 +3034,8 @@ int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*
 		// Start line: 2249
 		// Start offset: 0x00028960
 		// Variables:
-	// 		struct _EXTRA_CIV_DATA civDat; // stack offset -72
-	// 		struct _CAR_DATA *newCar; // $s0
+	// 		EXTRA_CIV_DATA civDat; // stack offset -72
+	// 		CAR_DATA *newCar; // $s0
 	// 		long tmpRes[4]; // stack offset -48
 	// 		long tmpQ[4]; // stack offset -32
 
@@ -3035,7 +3048,7 @@ int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*
 				// Start offset: 0x00028A1C
 				// Variables:
 			// 		char *slot; // $v1
-			// 		struct _CAR_DATA *carCnt; // $a0
+			// 		CAR_DATA *carCnt; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x00028A68
 			// End Line: 2249
@@ -3060,10 +3073,10 @@ int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*
 int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*startPos)[4], int externalModel, int palette, int controlFlags)
 {
 	unsigned char* slot;
-	_CAR_DATA* newCar;
-	_CAR_DATA* carCnt;
+	CAR_DATA* newCar;
+	CAR_DATA* carCnt;
 	int model;
-	_EXTRA_CIV_DATA civDat;
+	EXTRA_CIV_DATA civDat;
 	long tmpQ[4];
 
 	model = -1;
@@ -3164,13 +3177,13 @@ int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*star
 		// Start line: 2324
 		// Start offset: 0x00028DB4
 		// Variables:
-	// 		struct _EXTRA_CIV_DATA civDat; // stack offset -128
+	// 		EXTRA_CIV_DATA civDat; // stack offset -128
 	// 		int dir; // stack offset -52
 	// 		int distAlongSegment; // $fp
 	// 		int lane; // $s7
-	// 		struct _CAR_DATA *newCar; // $s1
-	// 		struct DRIVER2_STRAIGHT *str; // $s6
-	// 		struct DRIVER2_CURVE *crv; // $s5
+	// 		CAR_DATA *newCar; // $s1
+	// 		DRIVER2_STRAIGHT *str; // $s6
+	// 		DRIVER2_CURVE *crv; // $s5
 	// 		unsigned char cookieCountStart; // $s4
 	// 		int curveLength; // stack offset -48
 	// 		unsigned char model; // $s4
@@ -3188,7 +3201,7 @@ int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*star
 				// Start offset: 0x00028EEC
 				// Variables:
 			// 		char *slot; // $a1
-			// 		struct _CAR_DATA *carCnt; // $a0
+			// 		CAR_DATA *carCnt; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x00028F40
 			// End Line: 2324
@@ -3206,7 +3219,7 @@ int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*star
 				// Start line: 2324
 				// Start offset: 0x00029058
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s1
+			// 		CAR_DATA *cp; // $s1
 			/* end block 1.2.1 */
 			// End offset: 0x00029140
 			// End Line: 2324
@@ -3292,7 +3305,7 @@ int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*star
 				// 		int dx; // $a0
 				// 		int distSq; // $v0
 				// 		unsigned int retDistSq; // $a2
-				// 		struct _CAR_DATA *lcp; // $a1
+				// 		CAR_DATA *lcp; // $a1
 				/* end block 1.8.1.1 */
 				// End offset: 0x0002A228
 				// End Line: 2601
@@ -3316,7 +3329,7 @@ int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*star
 				// 		int dz; // $v1
 				// 		int dx; // $a0
 				// 		int ret; // $t0
-				// 		struct _CAR_DATA *lcp; // $a1
+				// 		CAR_DATA *lcp; // $a1
 				/* end block 1.8.2.1 */
 				// End offset: 0x0002A340
 				// End Line: 2611
@@ -3359,15 +3372,15 @@ int dz = 0; // offset 0xAAB48
 int PingInCivCar(int minPingInDist)
 {
 	int model;
-	_CAR_DATA* carCnt;
-	_CAR_DATA* newCar;
+	CAR_DATA* carCnt;
+	CAR_DATA* newCar;
 	
 	//DRIVER2_CURVE* curve;
 	//DRIVER2_STRAIGHT* straight;
 
 	DRIVER2_ROAD_INFO roadInfo;
 	
-	_EXTRA_CIV_DATA civDat;
+	EXTRA_CIV_DATA civDat;
 	unsigned char possibleLanes[12];
 	// carDistLanes removed as it's unused
 	long pos[4];
@@ -3914,14 +3927,14 @@ int PingInCivCar(int minPingInDist)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AttemptUnPark(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ AttemptUnPark(CAR_DATA *cp /*$s1*/)
 	// line 2659, offset 0x0002a4c4
 	/* begin block 1 */
 		// Start line: 2660
 		// Start offset: 0x0002A4C4
 		// Variables:
-	// 		struct DRIVER2_STRAIGHT *str; // $s2
-	// 		struct DRIVER2_CURVE *crv; // $s3
+	// 		DRIVER2_STRAIGHT *str; // $s2
+	// 		DRIVER2_CURVE *crv; // $s3
 	/* end block 1 */
 	// End offset: 0x0002A5FC
 	// End Line: 2690
@@ -3942,7 +3955,7 @@ int PingInCivCar(int minPingInDist)
 	// End Line: 6116
 
 // [D] [T]
-void AttemptUnPark(_CAR_DATA * cp)
+void AttemptUnPark(CAR_DATA * cp)
 {
 	unsigned char oldLane;
 	DRIVER2_ROAD_INFO roadInfo;
@@ -3967,7 +3980,7 @@ void AttemptUnPark(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivControl(struct _CAR_DATA *cp /*$s0*/)
+// int /*$ra*/ CivControl(CAR_DATA *cp /*$s0*/)
 	// line 2699, offset 0x0002ce10
 	/* begin block 1 */
 		// Start line: 2700
@@ -4001,7 +4014,7 @@ void AttemptUnPark(_CAR_DATA * cp)
 	// End Line: 8190
 
 // [D] [T]
-int CivControl(_CAR_DATA * cp)
+int CivControl(CAR_DATA * cp)
 {
 	CheckPingOut(cp);
 
@@ -4142,7 +4155,7 @@ int CivControl(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivAccelTrafficRules(struct _CAR_DATA *cp /*$t3*/, int *distToNode /*$a1*/)
+// int /*$ra*/ CivAccelTrafficRules(CAR_DATA *cp /*$t3*/, int *distToNode /*$a1*/)
 	// line 2798, offset 0x0002a5fc
 	/* begin block 1 */
 		// Start line: 2799
@@ -4150,7 +4163,7 @@ int CivControl(_CAR_DATA * cp)
 		// Variables:
 	// 		int lbody; // $t1
 	// 		int wbody; // $t2
-	// 		struct CIV_STATE *cs; // $a2
+	// 		CIV_STATE *cs; // $a2
 
 		/* begin block 1.1 */
 			// Start line: 2844
@@ -4203,13 +4216,13 @@ int CivControl(_CAR_DATA * cp)
 				// Start line: 2932
 				// Start offset: 0x0002AA0C
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $t3
+			// 		CAR_DATA *cp; // $t3
 
 				/* begin block 1.3.1.1 */
 					// Start line: 2932
 					// Start offset: 0x0002AA0C
 					// Variables:
-				// 		struct _CAR_DATA *lcp; // $a3
+				// 		CAR_DATA *lcp; // $a3
 				// 		int normal; // $v0
 				// 		int tangent; // $a0
 				// 		int distToObstacle; // $t0
@@ -4226,13 +4239,13 @@ int CivControl(_CAR_DATA * cp)
 				// Start line: 2799
 				// Start offset: 0x0002AB44
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $t3
+			// 		CAR_DATA *cp; // $t3
 
 				/* begin block 1.3.2.1 */
 					// Start line: 2799
 					// Start offset: 0x0002AB44
 					// Variables:
-				// 		struct CIV_STATE *cs; // $v1
+				// 		CIV_STATE *cs; // $v1
 				/* end block 1.3.2.1 */
 				// End offset: 0x0002AB44
 				// End Line: 2799
@@ -4271,10 +4284,10 @@ int carnum = 0;
 const int newAccel = 2000;
 
 // [D] [T]
-int CivAccelTrafficRules(_CAR_DATA * cp, int* distToNode)
+int CivAccelTrafficRules(CAR_DATA * cp, int* distToNode)
 {
 	CAR_COSMETICS* car_cos;
-	_CAR_DATA* lcp;
+	CAR_DATA* lcp;
 	int tangent;
 	int normal;
 	int lbody;
@@ -4518,10 +4531,10 @@ int CivAccelTrafficRules(_CAR_DATA * cp, int* distToNode)
 		// Start line: 2952
 		// Start offset: 0x0002ABA8
 		// Variables:
-	// 		struct SVECTOR boxDisp; // stack offset -72
+	// 		SVECTOR boxDisp; // stack offset -72
 	// 		int carLength[2]; // stack offset -64
-	// 		struct _CAR_DATA *cp0; // $s5
-	// 		struct _CAR_DATA *cp1; // $s2
+	// 		CAR_DATA *cp0; // $s5
+	// 		CAR_DATA *cp1; // $s2
 	// 		unsigned int dNewLBODY[2]; // stack offset -56
 	// 		int dx; // $s0
 	// 		int dz; // stack offset -48
@@ -4569,7 +4582,7 @@ int CivAccelTrafficRules(_CAR_DATA * cp, int* distToNode)
 				// 		int i; // $a1
 				// 		int h; // $a3
 				// 		int rnd; // $a2
-				// 		struct _CAR_DATA *cp; // $s0
+				// 		CAR_DATA *cp; // $s0
 
 					/* begin block 1.2.2.2.1 */
 						// Start line: 3040
@@ -4635,17 +4648,17 @@ int CivAccelTrafficRules(_CAR_DATA * cp, int* distToNode)
 int brakeLength[MAX_CARS];
 
 int CAR_PAUSE_START = 100;
-static _CAR_DATA(*horncarflag[2]) = { 0 };
+static CAR_DATA(*horncarflag[2]) = { 0 };
 static unsigned char hornchanflag[2] = { 0 };
 
 // [D] [T]
 void SetUpCivCollFlags(void)
 {
-	_CAR_DATA** pp_Var9;
+	CAR_DATA** pp_Var9;
 	CAR_COSMETICS* car_cos;
-	_CAR_DATA* cp1;
+	CAR_DATA* cp1;
 	SVECTOR boxDisp;
-	_CAR_DATA* cp0;
+	CAR_DATA* cp0;
 	int carLength[2];
 	int i;
 	int brake;
@@ -4875,7 +4888,7 @@ void SetUpCivCollFlags(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivAccel(struct _CAR_DATA *cp /*$s0*/)
+// int /*$ra*/ CivAccel(CAR_DATA *cp /*$s0*/)
 	// line 3074, offset 0x0002b26c
 	/* begin block 1 */
 		// Start line: 3075
@@ -4941,7 +4954,7 @@ void SetUpCivCollFlags(void)
 	// End Line: 7085
 
 // [D] [T]
-int CivAccel(_CAR_DATA * cp)
+int CivAccel(CAR_DATA * cp)
 {
 	CIV_ROUTE_ENTRY* node;
 	int distToNode;
@@ -5045,7 +5058,7 @@ int CivAccel(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivSteerAngle(struct _CAR_DATA *cp /*$s0*/)
+// int /*$ra*/ CivSteerAngle(CAR_DATA *cp /*$s0*/)
 	// line 3166, offset 0x0002b53c
 	/* begin block 1 */
 		// Start line: 3167
@@ -5054,8 +5067,8 @@ int CivAccel(_CAR_DATA * cp)
 	// 		int station; // $a3
 	// 		int step; // $s2
 	// 		int ret; // $a0
-	// 		struct VECTOR locPath; // stack offset -56
-	// 		struct VECTOR pathPoint; // stack offset -40
+	// 		VECTOR locPath; // stack offset -56
+	// 		VECTOR pathPoint; // stack offset -40
 	// 		int lbody; // $s3
 
 		/* begin block 1.1 */
@@ -5066,13 +5079,13 @@ int CivAccel(_CAR_DATA * cp)
 				// Start line: 3167
 				// Start offset: 0x0002B53C
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 
 				/* begin block 1.1.1.1 */
 					// Start line: 3167
 					// Start offset: 0x0002B53C
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.1.1.1 */
 				// End offset: 0x0002B590
 				// End Line: 3175
@@ -5084,13 +5097,13 @@ int CivAccel(_CAR_DATA * cp)
 				// Start line: 3167
 				// Start offset: 0x0002B5A0
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 
 				/* begin block 1.1.2.1 */
 					// Start line: 3167
 					// Start offset: 0x0002B5A0
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.1.2.1 */
 				// End offset: 0x0002B5B0
 				// End Line: 3167
@@ -5102,13 +5115,13 @@ int CivAccel(_CAR_DATA * cp)
 				// Start line: 3167
 				// Start offset: 0x0002B5C0
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 
 				/* begin block 1.1.3.1 */
 					// Start line: 3167
 					// Start offset: 0x0002B5C0
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.1.3.1 */
 				// End offset: 0x0002B5D0
 				// End Line: 3167
@@ -5120,13 +5133,13 @@ int CivAccel(_CAR_DATA * cp)
 				// Start line: 3167
 				// Start offset: 0x0002B5E0
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 
 				/* begin block 1.1.4.1 */
 					// Start line: 3167
 					// Start offset: 0x0002B5E0
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.1.4.1 */
 				// End offset: 0x0002B5F0
 				// End Line: 3167
@@ -5141,13 +5154,13 @@ int CivAccel(_CAR_DATA * cp)
 			// Start line: 3167
 			// Start offset: 0x0002B67C
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 
 			/* begin block 1.2.1 */
 				// Start line: 3167
 				// Start offset: 0x0002B67C
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $a0
+			// 		CIV_ROUTE_ENTRY *retNode; // $a0
 			/* end block 1.2.1 */
 			// End offset: 0x0002B690
 			// End Line: 3167
@@ -5159,8 +5172,8 @@ int CivAccel(_CAR_DATA * cp)
 			// Start line: 3201
 			// Start offset: 0x0002B6A0
 			// Variables:
-		// 		struct CIV_ROUTE_ENTRY *crLoc; // $a1
-		// 		struct CIV_ROUTE_ENTRY *cr; // $a0
+		// 		CIV_ROUTE_ENTRY *crLoc; // $a1
+		// 		CIV_ROUTE_ENTRY *cr; // $a0
 		/* end block 1.3 */
 		// End offset: 0x0002B700
 		// End Line: 3212
@@ -5169,13 +5182,13 @@ int CivAccel(_CAR_DATA * cp)
 			// Start line: 3167
 			// Start offset: 0x0002B748
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 
 			/* begin block 1.4.1 */
 				// Start line: 3167
 				// Start offset: 0x0002B748
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+			// 		CIV_ROUTE_ENTRY *retNode; // $v1
 			/* end block 1.4.1 */
 			// End offset: 0x0002B758
 			// End Line: 3167
@@ -5187,19 +5200,19 @@ int CivAccel(_CAR_DATA * cp)
 			// Start line: 3236
 			// Start offset: 0x0002B870
 			// Variables:
-		// 		struct CIV_ROUTE_ENTRY *cr; // $a0
+		// 		CIV_ROUTE_ENTRY *cr; // $a0
 
 			/* begin block 1.5.1 */
 				// Start line: 3167
 				// Start offset: 0x0002B8A0
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 
 				/* begin block 1.5.1.1 */
 					// Start line: 3167
 					// Start offset: 0x0002B8A0
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.5.1.1 */
 				// End offset: 0x0002B8B0
 				// End Line: 3167
@@ -5229,7 +5242,7 @@ const int checkFrames = 20;
 const int maxSteer = 512;
 
 // [D] [T] [A] - removed copying of car. Still works okay
-int CivSteerAngle(_CAR_DATA * cp)
+int CivSteerAngle(CAR_DATA * cp)
 {
 	CIV_ROUTE_ENTRY* startNode;
 	short lbody;
@@ -5322,13 +5335,13 @@ int CivSteerAngle(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivFindStation(struct _CAR_DATA *cp /*$s6*/)
+// int /*$ra*/ CivFindStation(CAR_DATA *cp /*$s6*/)
 	// line 3265, offset 0x0002b8e4
 	/* begin block 1 */
 		// Start line: 3266
 		// Start offset: 0x0002B8E4
 		// Variables:
-	// 		struct CIV_ROUTE_ENTRY *rep; // $s3
+	// 		CIV_ROUTE_ENTRY *rep; // $s3
 	// 		int cx; // stack offset -48
 	// 		int cz; // $fp
 
@@ -5342,13 +5355,13 @@ int CivSteerAngle(_CAR_DATA * cp)
 				// Start line: 3266
 				// Start offset: 0x0002B93C
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s6
+			// 		CAR_DATA *cp; // $s6
 
 				/* begin block 1.1.1.1 */
 					// Start line: 3266
 					// Start offset: 0x0002B93C
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.1.1.1 */
 				// End offset: 0x0002B950
 				// End Line: 3266
@@ -5363,14 +5376,14 @@ int CivSteerAngle(_CAR_DATA * cp)
 			// Start line: 3280
 			// Start offset: 0x0002B964
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s6
-		// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+		// 		CAR_DATA *cp; // $s6
+		// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 			/* begin block 1.2.1 */
 				// Start line: 3280
 				// Start offset: 0x0002B964
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $s0
+			// 		CIV_ROUTE_ENTRY *retNode; // $s0
 			/* end block 1.2.1 */
 			// End offset: 0x0002B964
 			// End Line: 3280
@@ -5393,14 +5406,14 @@ int CivSteerAngle(_CAR_DATA * cp)
 				// Start line: 3309
 				// Start offset: 0x0002BA28
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s6
-			// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+			// 		CAR_DATA *cp; // $s6
+			// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 				/* begin block 1.3.1.1 */
 					// Start line: 3309
 					// Start offset: 0x0002BA28
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.3.1.1 */
 				// End offset: 0x0002BA38
 				// End Line: 3309
@@ -5412,14 +5425,14 @@ int CivSteerAngle(_CAR_DATA * cp)
 				// Start line: 3266
 				// Start offset: 0x0002BA48
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s6
-			// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+			// 		CAR_DATA *cp; // $s6
+			// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 				/* begin block 1.3.2.1 */
 					// Start line: 3266
 					// Start offset: 0x0002BA48
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.3.2.1 */
 				// End offset: 0x0002BA58
 				// End Line: 3266
@@ -5431,14 +5444,14 @@ int CivSteerAngle(_CAR_DATA * cp)
 				// Start line: 3266
 				// Start offset: 0x0002BA68
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s6
-			// 		struct CIV_ROUTE_ENTRY *currentNode; // $s3
+			// 		CAR_DATA *cp; // $s6
+			// 		CIV_ROUTE_ENTRY *currentNode; // $s3
 
 				/* begin block 1.3.3.1 */
 					// Start line: 3266
 					// Start offset: 0x0002BA68
 					// Variables:
-				// 		struct CIV_ROUTE_ENTRY *retNode; // $v1
+				// 		CIV_ROUTE_ENTRY *retNode; // $v1
 				/* end block 1.3.3.1 */
 				// End offset: 0x0002BA78
 				// End Line: 3266
@@ -5463,7 +5476,7 @@ int CivSteerAngle(_CAR_DATA * cp)
 	// End Line: 7499
 
 // [D] [T]
-int CivFindStation(_CAR_DATA * cp)
+int CivFindStation(CAR_DATA * cp)
 {
 
 	int loop;
@@ -5546,27 +5559,27 @@ int CivFindStation(_CAR_DATA * cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CivFindPointOnPath(struct _CAR_DATA *cp /*$s7*/, int station /*$s2*/, struct VECTOR *ppoint /*$fp*/)
+// int /*$ra*/ CivFindPointOnPath(CAR_DATA *cp /*$s7*/, int station /*$s2*/, VECTOR *ppoint /*$fp*/)
 	// line 3337, offset 0x0002baec
 	/* begin block 1 */
 		// Start line: 3338
 		// Start offset: 0x0002BAEC
 		// Variables:
-	// 		struct CIV_ROUTE_ENTRY *cprep; // $a0
-	// 		struct CIV_ROUTE_ENTRY *start; // stack offset -48
+	// 		CIV_ROUTE_ENTRY *cprep; // $a0
+	// 		CIV_ROUTE_ENTRY *start; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 3346
 			// Start offset: 0x0002BB50
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s7
-		// 		struct CIV_ROUTE_ENTRY *currentNode; // $a0
+		// 		CAR_DATA *cp; // $s7
+		// 		CIV_ROUTE_ENTRY *currentNode; // $a0
 
 			/* begin block 1.1.1 */
 				// Start line: 3346
 				// Start offset: 0x0002BB50
 				// Variables:
-			// 		struct CIV_ROUTE_ENTRY *retNode; // $s0
+			// 		CIV_ROUTE_ENTRY *retNode; // $s0
 			/* end block 1.1.1 */
 			// End offset: 0x0002BB50
 			// End Line: 3346
@@ -5601,7 +5614,7 @@ int CivFindStation(_CAR_DATA * cp)
 	// End Line: 7705
 
 // [D] [T]
-int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
+int CivFindPointOnPath(CAR_DATA * cp, int station, VECTOR * ppoint)
 {
 	int stepSize;
 	CIV_ROUTE_ENTRY* start;
@@ -5682,11 +5695,11 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 		// Start line: 3400
 		// Start offset: 0x0002BCF4
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $v1
-	// 		struct _CAR_DATA *lcp; // $s0
-	// 		struct _CAR_DATA *newCar; // $s0
-	// 		struct DRIVER2_STRAIGHT *str; // stack offset -72
-	// 		struct DRIVER2_CURVE *crv; // $s7
+	// 		CAR_DATA *cp; // $v1
+	// 		CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *newCar; // $s0
+	// 		DRIVER2_STRAIGHT *str; // stack offset -72
+	// 		DRIVER2_CURVE *crv; // $s7
 	// 		int distAlongSegment; // $s2
 	// 		int lbody; // $s4
 	// 		int dir; // $s6
@@ -5739,7 +5752,7 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 				// Start line: 3399
 				// Start offset: 0x0002C590
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 			/* end block 1.4.2 */
 			// End offset: 0x0002C674
 			// End Line: 3399
@@ -5748,7 +5761,7 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 				// Start line: 3399
 				// Start offset: 0x0002C708
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s0
+			// 		CAR_DATA *cp; // $s0
 			/* end block 1.4.3 */
 			// End offset: 0x0002C7E4
 			// End Line: 3399
@@ -5760,7 +5773,7 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 			// Start line: 3515
 			// Start offset: 0x0002C830
 			// Variables:
-		// 		struct VECTOR startPos2; // stack offset -88
+		// 		VECTOR startPos2; // stack offset -88
 		// 		int deltaAngle; // $a0
 		// 		int dir2NextRow; // $a1
 		// 		int faceDir; // $s1
@@ -5782,7 +5795,7 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 						// Start line: 3399
 						// Start offset: 0x0002CAC4
 						// Variables:
-					// 		struct _CAR_DATA *cp; // $s0
+					// 		CAR_DATA *cp; // $s0
 					/* end block 1.5.1.1.1 */
 					// End offset: 0x0002CBA8
 					// End Line: 3399
@@ -5791,7 +5804,7 @@ int CivFindPointOnPath(_CAR_DATA * cp, int station, VECTOR * ppoint)
 						// Start line: 3399
 						// Start offset: 0x0002CC3C
 						// Variables:
-					// 		struct _CAR_DATA *cp; // $s0
+					// 		CAR_DATA *cp; // $s0
 					/* end block 1.5.1.1.2 */
 					// End offset: 0x0002CD18
 					// End Line: 3399
@@ -5835,7 +5848,7 @@ void CreateRoadblock(void)
 {
 	int laneNo;
 	CAR_COSMETICS* car_cos;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	int distAlongSegment;
 	
 	DRIVER2_CURVE* crv;
@@ -5855,7 +5868,7 @@ void CreateRoadblock(void)
 	int dir2NextRow;
 
 	int newSlot;
-	_CAR_DATA* newCar;
+	CAR_DATA* newCar;
 
 	crv = NULL;
 	str = NULL;

--- a/src_rebuild/GAME/C/CIV_AI.C
+++ b/src_rebuild/GAME/C/CIV_AI.C
@@ -87,7 +87,7 @@ int test555 = 0;
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ InitCar(CAR_DATA *cp /*$s0*/, int direction /*$s6*/, long (*startPos)[4] /*$s2*/, unsigned char control /*$s4*/, int model /*stack 16*/, int palette /*stack 20*/, char *extraData /*stack 24*/)
+// int /*$ra*/ InitCar(CAR_DATA *cp /*$s0*/, int direction /*$s6*/, LONGVECTOR* startPos /*$s2*/, unsigned char control /*$s4*/, int model /*stack 16*/, int palette /*stack 20*/, char *extraData /*stack 24*/)
  // line 717, offset 0x00023de8
 	/* begin block 1 */
 		// Start line: 718
@@ -104,7 +104,7 @@ int test555 = 0;
 	// End Line: 1435
 
 // [D] [T]
-int InitCar(CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char control, int model, int palette, char* extraData)
+int InitCar(CAR_DATA* cp, int direction, LONGVECTOR* startPos, unsigned char control, int model, int palette, char* extraData)
 {
 	VECTOR tmpStart;
 
@@ -132,7 +132,7 @@ int InitCar(CAR_DATA* cp, int direction, long(*startPos)[4], unsigned char contr
 	if (control == CONTROL_TYPE_NONE)
 		return 1;
 
-	InitCarPhysics(cp, (long(*)[4]) & tmpStart, direction);
+	InitCarPhysics(cp, (LONGVECTOR *)&tmpStart, direction);
 	cp->ap.palette = palette;
 
 	cp->controlType = control;
@@ -2907,7 +2907,7 @@ void InitCivCars(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CreateCivCarWotDrivesABitThenStops(int direction /*$s5*/, long (*startPos)[4] /*$s2*/, long (*stopPos)[4] /*$a2*/, unsigned char internalModel /*$s4*/, int palette /*stack 16*/)
+// int /*$ra*/ CreateCivCarWotDrivesABitThenStops(int direction /*$s5*/, LONGVECTOR* startPos /*$s2*/, LONGVECTOR* stopPos /*$a2*/, unsigned char internalModel /*$s4*/, int palette /*stack 16*/)
 	// line 2176, offset 0x000286e0
 	/* begin block 1 */
 		// Start line: 2177
@@ -2952,7 +2952,7 @@ const int EVENT_CAR_SPEED = 60;
 const int DistanceTriggerCarMoves = 700; // 5000;
 
 // [D] [T] [A]
-int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*stopPos)[4], unsigned char internalModel, int palette)
+int CreateCivCarWotDrivesABitThenStops(int direction, LONGVECTOR* startPos, LONGVECTOR* stopPos, unsigned char internalModel, int palette)
 {
 	unsigned char* slot;
 	CAR_DATA* carCnt;
@@ -3028,7 +3028,7 @@ int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CreateStationaryCivCar(int direction /*$t4*/, long orientX /*$s2*/, long orientZ /*$s1*/, long (*startPos)[4] /*$a2*/, int externalModel /*stack 16*/, int palette /*stack 20*/, int controlFlags /*stack 24*/)
+// int /*$ra*/ CreateStationaryCivCar(int direction /*$t4*/, long orientX /*$s2*/, long orientZ /*$s1*/, LONGVECTOR* startPos /*$a2*/, int externalModel /*stack 16*/, int palette /*stack 20*/, int controlFlags /*stack 24*/)
 	// line 2248, offset 0x00028960
 	/* begin block 1 */
 		// Start line: 2249
@@ -3070,7 +3070,7 @@ int CreateCivCarWotDrivesABitThenStops(int direction, long(*startPos)[4], long(*
 	// End Line: 5132
 
 // [D] [T]
-int CreateStationaryCivCar(int direction, long orientX, long orientZ, long(*startPos)[4], int externalModel, int palette, int controlFlags)
+int CreateStationaryCivCar(int direction, long orientX, long orientZ, LONGVECTOR* startPos, int externalModel, int palette, int controlFlags)
 {
 	unsigned char* slot;
 	CAR_DATA* newCar;
@@ -6016,7 +6016,7 @@ void CreateRoadblock(void)
 		if((str && ROAD_IS_AI_LANE(str, laneNo) || crv && ROAD_IS_AI_LANE(crv, laneNo)) && 
 			CellEmpty(&currentPos, lbody))
 		{
-			newSlot = CreateStationaryCivCar(dir2NextRow + (Random2(0) * 0x10001 >> (laneNo) & 0x3ffU) - 512, 0, 0, (long(*)[4]) & currentPos, externalCopModel, 0, 2);
+			newSlot = CreateStationaryCivCar(dir2NextRow + (Random2(0) * 0x10001 >> (laneNo) & 0x3ffU) - 512, 0, 0, (LONGVECTOR *)&currentPos, externalCopModel, 0, 2);
 
 			if (newSlot == -1)
 				break;
@@ -6093,7 +6093,7 @@ void CreateRoadblock(void)
 
 			test42 = delta;
 
-			newSlot = CreateStationaryCivCar(faceDir + (Random2(0) * 0x10001 >> (delta >> 9 & 0x1fU) & 0x3ffU) - 512, 0, 0, (long(*)[4]) & currentPos, externalCopModel, 0, 2);
+			newSlot = CreateStationaryCivCar(faceDir + (Random2(0) * 0x10001 >> (delta >> 9 & 0x1fU) & 0x3ffU) - 512, 0, 0, (LONGVECTOR *)&currentPos, externalCopModel, 0, 2);
 
 			if (newSlot == -1)
 				break;

--- a/src_rebuild/GAME/C/CIV_AI.H
+++ b/src_rebuild/GAME/C/CIV_AI.H
@@ -12,33 +12,33 @@ extern char makeLimoPullOver;
 
 extern char junctionLightsPhase[2];
 
-extern int InitCar(_CAR_DATA *cp, int direction, long (*startPos)[4], unsigned char control, int model, int palette, char *extraData); // 0x00023DE8
+extern int InitCar(CAR_DATA *cp, int direction, long (*startPos)[4], unsigned char control, int model, int palette, char *extraData); // 0x00023DE8
 
-extern _CAR_DATA * FindClosestCar(int x, int y, int z, int *distToCarSq); // 0x0002D11C
+extern CAR_DATA * FindClosestCar(int x, int y, int z, int *distToCarSq); // 0x0002D11C
 
 extern int NotTravellingAlongCurve(int x, int z, int dir, DRIVER2_CURVE *cv); // 0x0002D24C
 
-extern void CivCarFX(_CAR_DATA *cp); // 0x0002D084
+extern void CivCarFX(CAR_DATA *cp); // 0x0002D084
 
-extern int GetNextRoadInfo(_CAR_DATA *cp, int randomExit, int *turnAngle, int *startDist, CIV_ROUTE_ENTRY *oldNode); // 0x00024028
+extern int GetNextRoadInfo(CAR_DATA *cp, int randomExit, int *turnAngle, int *startDist, CIV_ROUTE_ENTRY *oldNode); // 0x00024028
 
-extern void InitNodeList(_CAR_DATA *cp, EXTRA_CIV_DATA *extraData); // 0x00026964
+extern void InitNodeList(CAR_DATA *cp, EXTRA_CIV_DATA *extraData); // 0x00026964
 
-extern int GetNodePos(DRIVER2_STRAIGHT *straight, DRIVER2_JUNCTION *junction, DRIVER2_CURVE *curve, int distAlongPath, _CAR_DATA *cp, int *x, int *z, int laneNo); // 0x00026CAC
+extern int GetNodePos(DRIVER2_STRAIGHT *straight, DRIVER2_JUNCTION *junction, DRIVER2_CURVE *curve, int distAlongPath, CAR_DATA *cp, int *x, int *z, int laneNo); // 0x00026CAC
 
-extern int CheckChangeLanes(DRIVER2_STRAIGHT *straight, DRIVER2_CURVE *curve, int distAlongSegment, _CAR_DATA *cp, int tryToPark); // 0x00026F20
+extern int CheckChangeLanes(DRIVER2_STRAIGHT *straight, DRIVER2_CURVE *curve, int distAlongSegment, CAR_DATA *cp, int tryToPark); // 0x00026F20
 
-extern int CreateNewNode(_CAR_DATA *cp); // 0x00027530
+extern int CreateNewNode(CAR_DATA *cp); // 0x00027530
 
-extern int InitCivState(_CAR_DATA *cp, EXTRA_CIV_DATA *extraData); // 0x000280D8
+extern int InitCivState(CAR_DATA *cp, EXTRA_CIV_DATA *extraData); // 0x000280D8
 
-extern int PingOutCar(_CAR_DATA *cp); // 0x0002CF80
+extern int PingOutCar(CAR_DATA *cp); // 0x0002CF80
 
 extern int PingOutAllSpecialCivCars(); // 0x000282E8
 
 extern int PingOutAllCivCarsAndCopCars(); // 0x0002840C
 
-extern int CheckPingOut(_CAR_DATA *cp); // 0x00028554
+extern int CheckPingOut(CAR_DATA *cp); // 0x00028554
 
 extern void SetUpTrafficLightPhase(); // 0x0002D220
 
@@ -52,21 +52,21 @@ extern int CreateStationaryCivCar(int direction, long orientX, long orientZ, lon
 
 extern int PingInCivCar(int minPingInDist); // 0x00028DB4
 
-extern void AttemptUnPark(_CAR_DATA *cp); // 0x0002A4C4
+extern void AttemptUnPark(CAR_DATA *cp); // 0x0002A4C4
 
-extern int CivControl(_CAR_DATA *cp); // 0x0002CE10
+extern int CivControl(CAR_DATA *cp); // 0x0002CE10
 
-extern int CivAccelTrafficRules(_CAR_DATA *cp, int *distToNode); // 0x0002A5FC
+extern int CivAccelTrafficRules(CAR_DATA *cp, int *distToNode); // 0x0002A5FC
 
 extern void SetUpCivCollFlags(); // 0x0002ABA8
 
-extern int CivAccel(_CAR_DATA *cp); // 0x0002B26C
+extern int CivAccel(CAR_DATA *cp); // 0x0002B26C
 
-extern int CivSteerAngle(_CAR_DATA *cp); // 0x0002B53C
+extern int CivSteerAngle(CAR_DATA *cp); // 0x0002B53C
 
-extern int CivFindStation(_CAR_DATA *cp); // 0x0002B8E4
+extern int CivFindStation(CAR_DATA *cp); // 0x0002B8E4
 
-extern int CivFindPointOnPath(_CAR_DATA *cp, int station, VECTOR *ppoint); // 0x0002BAEC
+extern int CivFindPointOnPath(CAR_DATA *cp, int station, VECTOR *ppoint); // 0x0002BAEC
 
 extern void CreateRoadblock(); // 0x0002BCF4
 

--- a/src_rebuild/GAME/C/CIV_AI.H
+++ b/src_rebuild/GAME/C/CIV_AI.H
@@ -12,7 +12,7 @@ extern char makeLimoPullOver;
 
 extern char junctionLightsPhase[2];
 
-extern int InitCar(CAR_DATA *cp, int direction, long (*startPos)[4], unsigned char control, int model, int palette, char *extraData); // 0x00023DE8
+extern int InitCar(CAR_DATA *cp, int direction, LONGVECTOR* startPos, unsigned char control, int model, int palette, char *extraData); // 0x00023DE8
 
 extern CAR_DATA * FindClosestCar(int x, int y, int z, int *distToCarSq); // 0x0002D11C
 
@@ -46,9 +46,9 @@ extern int TrafficLightCycle(int exit); // 0x0002CF18
 
 extern void InitCivCars(); // 0x0002CDA4
 
-extern int CreateCivCarWotDrivesABitThenStops(int direction, long (*startPos)[4], long (*stopPos)[4], unsigned char internalModel, int palette); // 0x000286E0
+extern int CreateCivCarWotDrivesABitThenStops(int direction, LONGVECTOR* startPos, LONGVECTOR* stopPos, unsigned char internalModel, int palette); // 0x000286E0
 
-extern int CreateStationaryCivCar(int direction, long orientX, long orientZ, long (*startPos)[4], int externalModel, int palette, int controlFlags); // 0x00028960
+extern int CreateStationaryCivCar(int direction, long orientX, long orientZ, LONGVECTOR* startPos, int externalModel, int palette, int controlFlags); // 0x00028960
 
 extern int PingInCivCar(int minPingInDist); // 0x00028DB4
 

--- a/src_rebuild/GAME/C/CONVERT.C
+++ b/src_rebuild/GAME/C/CONVERT.C
@@ -5,7 +5,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Calc_Object_MatrixYZX(struct MATRIX *mat /*$s0*/, struct SVECTOR *angles /*$s1*/)
+// void /*$ra*/ Calc_Object_MatrixYZX(MATRIX *mat /*$s0*/, SVECTOR *angles /*$s1*/)
  // line 149, offset 0x0002d3f8
 	/* begin block 1 */
 		// Start line: 298
@@ -36,7 +36,7 @@ void Calc_Object_MatrixYZX(MATRIX *mat, SVECTOR *angles)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ _RotMatrixX(struct MATRIX *m /*$v0*/, short ang /*$a1*/)
+// void /*$ra*/ _RotMatrixX(MATRIX *m /*$v0*/, short ang /*$a1*/)
  // line 182, offset 0x0002d470
 	/* begin block 1 */
 		// Start line: 508
@@ -53,7 +53,7 @@ void _RotMatrixX(MATRIX *m, short ang)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ _RotMatrixY(struct MATRIX *m /*$v0*/, short ang /*$a1*/)
+// void /*$ra*/ _RotMatrixY(MATRIX *m /*$v0*/, short ang /*$a1*/)
  // line 187, offset 0x0002d49c
 	/* begin block 1 */
 		// Start line: 519
@@ -70,7 +70,7 @@ void _RotMatrixY(MATRIX *m, short ang)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ _RotMatrixZ(struct MATRIX *m /*$v0*/, short ang /*$a1*/)
+// void /*$ra*/ _RotMatrixZ(MATRIX *m /*$v0*/, short ang /*$a1*/)
  // line 192, offset 0x0002d4c8
 	/* begin block 1 */
 		// Start line: 530
@@ -87,7 +87,7 @@ void _RotMatrixZ(MATRIX *m, short ang)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RotMatrixXYZ(struct MATRIX *m /*$v0*/, struct SVECTOR *r /*$a1*/)
+// void /*$ra*/ RotMatrixXYZ(MATRIX *m /*$v0*/, SVECTOR *r /*$a1*/)
  // line 199, offset 0x0002d4f4
 	/* begin block 1 */
 		// Start line: 545
@@ -104,13 +104,13 @@ void RotMatrixXYZ(MATRIX *m, SVECTOR *r)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ _MatrixRotate(struct VECTOR *pos /*$s0*/)
+// void /*$ra*/ _MatrixRotate(VECTOR *pos /*$s0*/)
  // line 205, offset 0x0002d51c
 	/* begin block 1 */
 		// Start line: 206
 		// Start offset: 0x0002D51C
 		// Variables:
-	// 		struct VECTOR temp; // stack offset -24
+	// 		VECTOR temp; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x0002D55C
 	// End Line: 214
@@ -136,7 +136,7 @@ void _MatrixRotate(VECTOR *pos)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InvertMatrix(struct MATRIX *a /*$a0*/, struct MATRIX *b /*$a1*/)
+// void /*$ra*/ InvertMatrix(MATRIX *a /*$a0*/, MATRIX *b /*$a1*/)
  // line 240, offset 0x0002d55c
 	/* begin block 1 */
 		// Start line: 620
@@ -177,7 +177,7 @@ void InvertMatrix(MATRIX *a, MATRIX *b)
 		// Start line: 274
 		// Start offset: 0x0002D304
 		// Variables:
-	// 		struct MATRIX newmatrix; // stack offset -48
+	// 		MATRIX newmatrix; // stack offset -48
 	/* end block 1 */
 	// End offset: 0x0002D3F8
 	// End Line: 289
@@ -242,12 +242,12 @@ void BuildWorldMatrix(void)
 		// Start line: 336
 		// Start offset: 0x0002D5C8
 		// Variables:
-	// 		struct MATRIX temp; // stack offset -160
-	// 		struct MATRIX temp2; // stack offset -128
-	// 		struct MATRIX scale; // stack offset -96
-	// 		struct MATRIX scaledcammat; // stack offset -64
-	// 		struct VECTOR pos; // stack offset -32
-	// 		struct SVECTOR tempang; // stack offset -16
+	// 		MATRIX temp; // stack offset -160
+	// 		MATRIX temp2; // stack offset -128
+	// 		MATRIX scale; // stack offset -96
+	// 		MATRIX scaledcammat; // stack offset -64
+	// 		VECTOR pos; // stack offset -32
+	// 		SVECTOR tempang; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0002D678
 	// End Line: 361

--- a/src_rebuild/GAME/C/COP_AI.C
+++ b/src_rebuild/GAME/C/COP_AI.C
@@ -60,7 +60,7 @@ COP_SIGHT_DATA copSightData;
 int player_position_known = 0;
 VECTOR lastKnownPosition;
 VECTOR CarTail;
-_CAR_DATA *targetVehicle;
+CAR_DATA *targetVehicle;
 
 int numActiveCops = 0;
 int pathStraight = 0;
@@ -70,7 +70,7 @@ int OutOfSightCount = 0;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitCopState(struct _CAR_DATA *cp /*$s0*/, char *extraData /*$a1*/)
+// void /*$ra*/ InitCopState(CAR_DATA *cp /*$s0*/, char *extraData /*$a1*/)
  // line 577, offset 0x0002f680
 	/* begin block 1 */
 		// Start line: 2675
@@ -83,7 +83,7 @@ int OutOfSightCount = 0;
 	// End Line: 1155
 
 // [D] [T]
-void InitCopState(_CAR_DATA *cp, char *extraData)
+void InitCopState(CAR_DATA *cp, char *extraData)
 {
 	ClearMem((char *)&cp->ai.p, sizeof(COP));
 
@@ -121,7 +121,7 @@ int ReplayLog_Fnarr_He_Said_Log(int val)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WibbleDownTheRoad(struct VECTOR *from /*$a0*/, int distance /*$s1*/, struct VECTOR *to /*$s5*/)
+// void /*$ra*/ WibbleDownTheRoad(VECTOR *from /*$a0*/, int distance /*$s1*/, VECTOR *to /*$s5*/)
  // line 593, offset 0x0002d78c
 	/* begin block 1 */
 		// Start line: 594
@@ -130,15 +130,15 @@ int ReplayLog_Fnarr_He_Said_Log(int val)
 	// 		int th; // $s0
 	// 		int j; // $s3
 	// 		int thl[4]; // stack offset -136
-	// 		struct VECTOR pos; // stack offset -120
-	// 		struct VECTOR dir; // stack offset -104
+	// 		VECTOR pos; // stack offset -120
+	// 		VECTOR dir; // stack offset -104
 
 		/* begin block 1.1 */
 			// Start line: 604
 			// Start offset: 0x0002D810
 			// Variables:
-		// 		struct VECTOR p2; // stack offset -88
-		// 		struct VECTOR d2; // stack offset -72
+		// 		VECTOR p2; // stack offset -88
+		// 		VECTOR d2; // stack offset -72
 		// 		int colour[3]; // stack offset -56
 		/* end block 1.1 */
 		// End offset: 0x0002D89C
@@ -542,7 +542,7 @@ void ControlCops(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CopControl(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ CopControl(CAR_DATA *cp /*$s1*/)
  // line 824, offset 0x0002f60c
 	/* begin block 1 */
 		// Start line: 825
@@ -562,7 +562,7 @@ void ControlCops(void)
 	// End Line: 1649
 
 // [D] [T]
-void CopControl(_CAR_DATA *cp)
+void CopControl(CAR_DATA *cp)
 {
 	CopControl1(cp);
 
@@ -579,7 +579,7 @@ void CopControl(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CopControl1(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ CopControl1(CAR_DATA *cp /*$s1*/)
  // line 845, offset 0x0002defc
 	/* begin block 1 */
 		// Start line: 846
@@ -609,7 +609,7 @@ void CopControl(_CAR_DATA *cp)
 			// Start line: 912
 			// Start offset: 0x0002E070
 			// Variables:
-		// 		struct VECTOR pos; // stack offset -88
+		// 		VECTOR pos; // stack offset -88
 		/* end block 1.2 */
 		// End offset: 0x0002E23C
 		// End Line: 922
@@ -618,8 +618,8 @@ void CopControl(_CAR_DATA *cp)
 			// Start line: 935
 			// Start offset: 0x0002E23C
 			// Variables:
-		// 		enum AIZone targetZone; // $a0
-		// 		struct VECTOR doordir; // stack offset -72
+		// 		AIZone targetZone; // $a0
+		// 		VECTOR doordir; // stack offset -72
 		// 		int targetFound; // $a1
 		// 		int cx; // $s5
 		// 		int cz; // $s6
@@ -643,7 +643,7 @@ void CopControl(_CAR_DATA *cp)
 				// Start line: 1049
 				// Start offset: 0x0002E5E4
 				// Variables:
-			// 		struct iVectNT path[2]; // stack offset -56
+			// 		iVectNT path[2]; // stack offset -56
 			// 		int slidevel; // $a3
 
 				/* begin block 1.3.2.1 */
@@ -708,7 +708,7 @@ void CopControl(_CAR_DATA *cp)
 VECTOR targetPoint = { 0,0,0 };
 
 // [D]
-void CopControl1(_CAR_DATA *cp)
+void CopControl1(CAR_DATA *cp)
 {
 	int targetFound;
 	int steeringFac;
@@ -1099,7 +1099,7 @@ void CopControl1(_CAR_DATA *cp)
 	if (cp->ai.p.justPinged == 1)
 	{
 		cp->hd.direction = getHeadingToPlayer(cp->hd.where.t[0], cp->hd.where.t[1], cp->hd.where.t[2]);
-		TempBuildHandlingMatrix((_CAR_DATA*)cp, 0);
+		TempBuildHandlingMatrix((CAR_DATA*)cp, 0);
 
 		cp->ai.p.justPinged = 0;
 	}
@@ -1181,7 +1181,7 @@ int FindCost(int x, int z, int dvx, int dvz)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitCopData(struct COP_DATA *pCopData /*$a0*/)
+// void /*$ra*/ InitCopData(COP_DATA *pCopData /*$a0*/)
  // line 1267, offset 0x0002f7f8
 	/* begin block 1 */
 		// Start line: 1268
@@ -1296,11 +1296,11 @@ void UpdateCopSightData(void)
 		// Variables:
 	// 		int dx; // $v1
 	// 		int dz; // $a0
-	// 		struct VECTOR vec; // stack offset -64
+	// 		VECTOR vec; // stack offset -64
 	// 		int ccx; // stack offset -32
 	// 		int ccz; // stack offset -28
 	// 		char *scratch; // $s4
-	// 		struct _CAR_DATA *lcp; // $s1
+	// 		CAR_DATA *lcp; // $s1
 
 		/* begin block 1.1 */
 			// Start line: 1385
@@ -1339,7 +1339,7 @@ void UpdateCopSightData(void)
 				// Start line: 1369
 				// Start offset: 0x0002EF70
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $s1
+			// 		CAR_DATA *cp; // $s1
 			// 		int distanceToPlayer; // $s0
 
 				/* begin block 1.3.1.1 */
@@ -1355,7 +1355,7 @@ void UpdateCopSightData(void)
 						// Start offset: 0x0002EF90
 						// Variables:
 					// 		int theta; // $v1
-					// 		struct VECTOR delta; // stack offset -48
+					// 		VECTOR delta; // stack offset -48
 
 						/* begin block 1.3.1.1.1.1 */
 							// Start line: 1369
@@ -1451,7 +1451,7 @@ void ControlCopDetection(void)
 	uint distanceToPlayer;
 	int heading;
 	int dx;
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 	VECTOR vec;
 	int ccx;
 	int ccz;
@@ -1657,7 +1657,7 @@ void ControlCopDetection(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PassiveCopTasks(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ PassiveCopTasks(CAR_DATA *cp /*$s0*/)
  // line 1562, offset 0x0002f6fc
 	/* begin block 1 */
 		// Start line: 1563
@@ -1667,7 +1667,7 @@ void ControlCopDetection(void)
 			// Start line: 1563
 			// Start offset: 0x0002F76C
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 		/* end block 1.1 */
 		// End offset: 0x0002F7C4
 		// End Line: 1563
@@ -1686,7 +1686,7 @@ void ControlCopDetection(void)
 	// End Line: 4655
 
 // [D] [T]
-void PassiveCopTasks(_CAR_DATA *cp)
+void PassiveCopTasks(CAR_DATA *cp)
 {
 	short *playerFelony;
 
@@ -1763,7 +1763,7 @@ void PassiveCopTasks(_CAR_DATA *cp)
 				// Start line: 1638
 				// Start offset: 0x0002F580
 				// Variables:
-			// 		struct _CAR_DATA *lcp; // $a0
+			// 		CAR_DATA *lcp; // $a0
 			// 		int tempDist; // $a3
 
 				/* begin block 1.3.1.1 */
@@ -1812,7 +1812,7 @@ void ControlNumberOfCops(void)
 	short *pTrigger;
 	short *playerFelony;
 	int tempDist;
-	_CAR_DATA *lcp;
+	CAR_DATA *lcp;
 	int respawnTime;
 	int num_closer;
 	int cutOffDistance;

--- a/src_rebuild/GAME/C/COP_AI.H
+++ b/src_rebuild/GAME/C/COP_AI.H
@@ -27,7 +27,7 @@ extern char first_offence;
 extern int player_position_known;
 extern int numActiveCops;
 
-extern void InitCopState(_CAR_DATA *cp, char *extraData); // 0x0002F680
+extern void InitCopState(CAR_DATA *cp, char *extraData); // 0x0002F680
 
 extern void WibbleDownTheRoad(VECTOR *from, int distance, VECTOR *to); // 0x0002D78C
 
@@ -35,9 +35,9 @@ extern void InitCops(); // 0x0002D99C
 
 extern void ControlCops(); // 0x0002DAD8
 
-extern void CopControl(_CAR_DATA *cp); // 0x0002F60C
+extern void CopControl(CAR_DATA *cp); // 0x0002F60C
 
-extern void CopControl1(_CAR_DATA *cp); // 0x0002DEFC
+extern void CopControl1(CAR_DATA *cp); // 0x0002DEFC
 
 extern int FindCost(int x, int z, int dvx, int dvz); // 0x0002F8DC
 
@@ -47,7 +47,7 @@ extern void UpdateCopSightData(); // 0x0002F844
 
 extern void ControlCopDetection(); // 0x0002ECD8
 
-extern void PassiveCopTasks(_CAR_DATA *cp); // 0x0002F6FC
+extern void PassiveCopTasks(CAR_DATA *cp); // 0x0002F6FC
 
 extern void ControlNumberOfCops(); // 0x0002F3CC
 

--- a/src_rebuild/GAME/C/COSMETIC.C
+++ b/src_rebuild/GAME/C/COSMETIC.C
@@ -150,15 +150,15 @@ void ProcessCosmeticsLump(char *lump_ptr, int lump_size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddReverseLight(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ AddReverseLight(CAR_DATA *cp /*$s1*/)
  // line 252, offset 0x0002f994
 	/* begin block 1 */
 		// Start line: 253
 		// Start offset: 0x0002F994
 		// Variables:
-	// 		struct CAR_COSMETICS *car_cos; // $a1
-	// 		struct SVECTOR v1; // stack offset -32
-	// 		struct CVECTOR col; // stack offset -24
+	// 		CAR_COSMETICS *car_cos; // $a1
+	// 		SVECTOR v1; // stack offset -32
+	// 		CVECTOR col; // stack offset -24
 	// 		short cogOffset; // $s2
 	/* end block 1 */
 	// End offset: 0x0002FAEC
@@ -177,7 +177,7 @@ void ProcessCosmeticsLump(char *lump_ptr, int lump_size)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-void AddReverseLight(_CAR_DATA *cp)
+void AddReverseLight(CAR_DATA *cp)
 {
 	CAR_COSMETICS *car_cos;
 	SVECTOR v1;
@@ -256,16 +256,16 @@ void SetupSpecCosmetics(char *loadbuffer)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddIndicatorLight(struct _CAR_DATA *cp /*$s0*/, int Type /*$s6*/)
+// void /*$ra*/ AddIndicatorLight(CAR_DATA *cp /*$s0*/, int Type /*$s6*/)
  // line 325, offset 0x0002faec
 	/* begin block 1 */
 		// Start line: 326
 		// Start offset: 0x0002FAEC
 		// Variables:
-	// 		struct CAR_COSMETICS *car_cos; // $a1
-	// 		struct CVECTOR col; // stack offset -56
-	// 		struct SVECTOR vfrnt; // stack offset -48
-	// 		struct SVECTOR vback; // stack offset -40
+	// 		CAR_COSMETICS *car_cos; // $a1
+	// 		CVECTOR col; // stack offset -56
+	// 		SVECTOR vfrnt; // stack offset -48
+	// 		SVECTOR vback; // stack offset -40
 	// 		char tempcol; // $s1
 	// 		char *life; // $a0
 	// 		char *life2; // $s3
@@ -287,7 +287,7 @@ void SetupSpecCosmetics(char *loadbuffer)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-void AddIndicatorLight(_CAR_DATA *cp, int Type)
+void AddIndicatorLight(CAR_DATA *cp, int Type)
 {
 	uint brightness;
 	char *life;
@@ -366,17 +366,17 @@ void AddIndicatorLight(_CAR_DATA *cp, int Type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddBrakeLight(struct _CAR_DATA *cp /*$s5*/)
+// void /*$ra*/ AddBrakeLight(CAR_DATA *cp /*$s5*/)
  // line 407, offset 0x0002fde4
 	/* begin block 1 */
 		// Start line: 408
 		// Start offset: 0x0002FDE4
 		// Variables:
-	// 		struct CAR_COSMETICS *car_cos; // $a1
-	// 		struct SVECTOR v1; // stack offset -88
-	// 		struct SVECTOR v2; // stack offset -80
-	// 		struct SVECTOR vec; // stack offset -72
-	// 		struct CVECTOR col; // stack offset -64
+	// 		CAR_COSMETICS *car_cos; // $a1
+	// 		SVECTOR v1; // stack offset -88
+	// 		SVECTOR v2; // stack offset -80
+	// 		SVECTOR vec; // stack offset -72
+	// 		CVECTOR col; // stack offset -64
 	// 		char *life2; // $s2
 	// 		short doubleFlag; // stack offset -56
 	// 		short verticalFlag; // stack offset -52
@@ -396,7 +396,7 @@ void AddIndicatorLight(_CAR_DATA *cp, int Type)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-void AddBrakeLight(_CAR_DATA *cp)
+void AddBrakeLight(CAR_DATA *cp)
 {
 	short damageFac;
 	int damIndex;
@@ -505,7 +505,7 @@ void AddBrakeLight(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddCopCarLight(struct _CAR_DATA *cp /*$t0*/)
+// void /*$ra*/ AddCopCarLight(CAR_DATA *cp /*$t0*/)
  // line 514, offset 0x00030148
 	/* begin block 1 */
 		// Start line: 515
@@ -522,9 +522,9 @@ void AddBrakeLight(_CAR_DATA *cp)
 	// 		static char xpos1[8]; // offset 0x10
 	// 		int sign; // $t1
 	// 		char *coplife; // $s2
-	// 		struct SVECTOR v1; // stack offset -88
-	// 		struct CVECTOR col; // stack offset -80
-	// 		struct CAR_COSMETICS *car_cos; // $s0
+	// 		SVECTOR v1; // stack offset -88
+	// 		CVECTOR col; // stack offset -80
+	// 		CAR_COSMETICS *car_cos; // $s0
 	// 		short cogOffset; // $fp
 	/* end block 1 */
 	// End offset: 0x00030514
@@ -541,7 +541,7 @@ void AddBrakeLight(_CAR_DATA *cp)
 	// End Line: 1348
 
 // [D] [T]
-void AddCopCarLight(_CAR_DATA *cp)
+void AddCopCarLight(CAR_DATA *cp)
 {
 	static char xpos1[8] = {
 		48, 32, 16,  0,
@@ -659,18 +659,18 @@ void AddCopCarLight(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddNightLights(struct _CAR_DATA *cp /*$s6*/)
+// void /*$ra*/ AddNightLights(CAR_DATA *cp /*$s6*/)
  // line 653, offset 0x00030544
 	/* begin block 1 */
 		// Start line: 654
 		// Start offset: 0x00030544
 		// Variables:
-	// 		static struct MATRIX work_matrix; // offset 0x0
-	// 		struct CAR_COSMETICS *car_cos; // $fp
-	// 		struct SVECTOR Position1; // stack offset -104
-	// 		struct SVECTOR Position2; // stack offset -96
-	// 		struct SVECTOR vec; // stack offset -88
-	// 		struct CVECTOR col; // stack offset -80
+	// 		static MATRIX work_matrix; // offset 0x0
+	// 		CAR_COSMETICS *car_cos; // $fp
+	// 		SVECTOR Position1; // stack offset -104
+	// 		SVECTOR Position2; // stack offset -96
+	// 		SVECTOR vec; // stack offset -88
+	// 		CVECTOR col; // stack offset -80
 	// 		int lit; // stack offset -72
 	// 		int lightFlag; // $t0
 	// 		char *life2; // stack offset -68
@@ -700,7 +700,7 @@ int gPlayerCarLights = 0;
 int gcar_num = 0;
 
 // [D] [T]
-void AddNightLights(_CAR_DATA *cp)
+void AddNightLights(CAR_DATA *cp)
 {
 	short offset;
 	int lightFlag;
@@ -911,16 +911,16 @@ void AddNightLights(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddSmokingEngine(struct _CAR_DATA *cp /*$s0*/, int black_smoke /*$s2*/, int WheelSpeed /*$s3*/)
+// void /*$ra*/ AddSmokingEngine(CAR_DATA *cp /*$s0*/, int black_smoke /*$s2*/, int WheelSpeed /*$s3*/)
  // line 989, offset 0x00030d9c
 	/* begin block 1 */
 		// Start line: 990
 		// Start offset: 0x00030D9C
 		// Variables:
-	// 		struct VECTOR SmokePos; // stack offset -64
-	// 		struct CAR_COSMETICS *car_cos; // $a0
-	// 		struct VECTOR Drift; // stack offset -48
-	// 		struct SVECTOR svec; // stack offset -32
+	// 		VECTOR SmokePos; // stack offset -64
+	// 		CAR_COSMETICS *car_cos; // $a0
+	// 		VECTOR Drift; // stack offset -48
+	// 		SVECTOR svec; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x00030F90
 	// End Line: 1038
@@ -935,7 +935,7 @@ void AddNightLights(_CAR_DATA *cp)
 int gDoSmoke = 1;
 
 // [D] [T]
-void AddSmokingEngine(_CAR_DATA *cp, int black_smoke, int WheelSpeed)
+void AddSmokingEngine(CAR_DATA *cp, int black_smoke, int WheelSpeed)
 {
 	CAR_COSMETICS *car_cos;
 	VECTOR SmokePos;
@@ -970,7 +970,7 @@ void AddSmokingEngine(_CAR_DATA *cp, int black_smoke, int WheelSpeed)
 }
 
 // [A] custom function for bringing back exhaust
-void AddExhaustSmoke(_CAR_DATA *cp, int black_smoke, int WheelSpeed)
+void AddExhaustSmoke(CAR_DATA *cp, int black_smoke, int WheelSpeed)
 {
 	CAR_COSMETICS *car_cos;
 	VECTOR SmokePos;
@@ -1026,16 +1026,16 @@ void AddExhaustSmoke(_CAR_DATA *cp, int black_smoke, int WheelSpeed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddFlamingEngine(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ AddFlamingEngine(CAR_DATA *cp /*$s1*/)
  // line 1048, offset 0x00030fac
 	/* begin block 1 */
 		// Start line: 1049
 		// Start offset: 0x00030FAC
 		// Variables:
-	// 		struct VECTOR SmokePos; // stack offset -56
-	// 		struct SVECTOR svec; // stack offset -40
-	// 		struct CAR_COSMETICS *car_cos; // $a0
-	// 		struct VECTOR Drift; // stack offset -32
+	// 		VECTOR SmokePos; // stack offset -56
+	// 		SVECTOR svec; // stack offset -40
+	// 		CAR_COSMETICS *car_cos; // $a0
+	// 		VECTOR Drift; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x0003114C
 	// End Line: 1084
@@ -1048,7 +1048,7 @@ void AddExhaustSmoke(_CAR_DATA *cp, int black_smoke, int WheelSpeed)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-void AddFlamingEngine(_CAR_DATA *cp)
+void AddFlamingEngine(CAR_DATA *cp)
 {
 	CAR_COSMETICS *car_cos;
 	VECTOR SmokePos;

--- a/src_rebuild/GAME/C/COSMETIC.H
+++ b/src_rebuild/GAME/C/COSMETIC.H
@@ -10,23 +10,23 @@ extern void LoadCosmetics(int level); // 0x00031160
 
 extern void ProcessCosmeticsLump(char *lump_ptr, int lump_size); // 0x000311B0
 
-extern void AddReverseLight(_CAR_DATA *cp); // 0x0002F994
+extern void AddReverseLight(CAR_DATA *cp); // 0x0002F994
 
 extern void SetupSpecCosmetics(char *loadbuffer); // 0x00031360
 
-extern void AddIndicatorLight(_CAR_DATA *cp, int Type); // 0x0002FAEC
+extern void AddIndicatorLight(CAR_DATA *cp, int Type); // 0x0002FAEC
 
-extern void AddBrakeLight(_CAR_DATA *cp); // 0x0002FDE4
+extern void AddBrakeLight(CAR_DATA *cp); // 0x0002FDE4
 
-extern void AddCopCarLight(_CAR_DATA *cp); // 0x00030148
+extern void AddCopCarLight(CAR_DATA *cp); // 0x00030148
 
-extern void AddNightLights(_CAR_DATA *cp); // 0x00030544
+extern void AddNightLights(CAR_DATA *cp); // 0x00030544
 
-extern void AddSmokingEngine(_CAR_DATA *cp, int black_smoke, int WheelSpeed); // 0x00030D9C
+extern void AddSmokingEngine(CAR_DATA *cp, int black_smoke, int WheelSpeed); // 0x00030D9C
 
-extern void AddExhaustSmoke(_CAR_DATA *cp, int black_smoke, int WheelSpeed);
+extern void AddExhaustSmoke(CAR_DATA *cp, int black_smoke, int WheelSpeed);
 
-extern void AddFlamingEngine(_CAR_DATA *cp); // 0x00030FAC
+extern void AddFlamingEngine(CAR_DATA *cp); // 0x00030FAC
 
 
 #endif

--- a/src_rebuild/GAME/C/CUTSCENE.C
+++ b/src_rebuild/GAME/C/CUTSCENE.C
@@ -914,7 +914,7 @@ int TriggerInGameCutsceneSystem(int cutscene)
 						InitPlayer(&player[player_id], cp,
 							stream->SourceType.controlType, 
 							stream->SourceType.rotation,
-							(long(*)[4])&stream->SourceType.position,
+							(LONGVECTOR* )&stream->SourceType.position,
 							stream->SourceType.model,
 							stream->SourceType.palette,
 							&padid[player_id]);
@@ -940,7 +940,7 @@ int TriggerInGameCutsceneSystem(int cutscene)
 					else 
 					{
 						slot = CreateStationaryCivCar(stream->SourceType.rotation, 0, 1024, 
-							(long(*)[4])&stream->SourceType.position,
+							(LONGVECTOR* )&stream->SourceType.position,
 							stream->SourceType.model, 
 							stream->SourceType.palette, 0);
 

--- a/src_rebuild/GAME/C/CUTSCENE.C
+++ b/src_rebuild/GAME/C/CUTSCENE.C
@@ -223,7 +223,7 @@ void HandleInGameCutscene(void)
 		// Start line: 648
 		// Start offset: 0x00031398
 		// Variables:
-	// 		struct TILE *tile; // $s0
+	// 		TILE *tile; // $s0
 	/* end block 1 */
 	// End offset: 0x000314E8
 	// End Line: 676
@@ -464,7 +464,7 @@ void TriggerInGameCutscene(int cutscene)
 		// Start line: 817
 		// Start offset: 0x0003283C
 		// Variables:
-	// 		struct CUTSCENE_HEADER header; // stack offset -136
+	// 		CUTSCENE_HEADER header; // stack offset -136
 	// 		char filename[64]; // stack offset -72
 	/* end block 1 */
 	// End offset: 0x000328C8
@@ -520,7 +520,7 @@ int CalcInGameCutsceneSize(void)
 			// Start line: 845
 			// Start offset: 0x00031748
 			// Variables:
-		// 		struct STREAM_SOURCE *pinfo; // $a0
+		// 		STREAM_SOURCE *pinfo; // $a0
 		// 		int i; // $s0
 		/* end block 1.1 */
 		// End offset: 0x00031978
@@ -565,7 +565,7 @@ void ReleaseInGameCutscene(void)
 		{
 			if (PlayerStartInfo[i]->flags & 4)
 			{
-				memcpy(&player[0], &player[i], sizeof(_PLAYER));
+				memcpy(&player[0], &player[i], sizeof(PLAYER));
 
 				if (player[0].playerType == 2)
 				{
@@ -843,7 +843,7 @@ int TriggerInGameCutsceneSystem(int cutscene)
 	static char padid[8];
 
 	int slot;
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 	REPLAY_STREAM *stream;
 	int player_id;
 	int bDamageOverride;
@@ -1188,8 +1188,8 @@ void FindNextCutChange(int cameracnt)
 		// Start line: 1301
 		// Start offset: 0x00032118
 		// Variables:
-	// 		struct REPLAY_SAVE_HEADER *rheader; // $a1
-	// 		struct REPLAY_STREAM_HEADER *sheader; // $t1
+	// 		REPLAY_SAVE_HEADER *rheader; // $a1
+	// 		REPLAY_STREAM_HEADER *sheader; // $t1
 	// 		char filename[64]; // stack offset -88
 	// 		char *pt; // $s1
 	// 		int i; // $a0
@@ -1274,7 +1274,7 @@ int LoadCutsceneToReplayBuffer(int residentCutscene)
 
 	pt += sizeof(PLAYBACKCAMERA) * MAX_REPLAY_CAMERAS;
 
-	memcpy(PingBuffer, pt, sizeof(_PING_PACKET) * MAX_REPLAY_PINGS);
+	memcpy(PingBuffer, pt, sizeof(PING_PACKET) * MAX_REPLAY_PINGS);
 
 	PingBufferPos = 0;
 
@@ -1291,8 +1291,8 @@ int LoadCutsceneToReplayBuffer(int residentCutscene)
 		// Start line: 1363
 		// Start offset: 0x0003243C
 		// Variables:
-	// 		struct CUTSCENE_HEADER header; // stack offset -440
-	// 		struct REPLAY_SAVE_HEADER rheader; // stack offset -376
+	// 		CUTSCENE_HEADER header; // stack offset -440
+	// 		REPLAY_SAVE_HEADER rheader; // stack offset -376
 	// 		char filename[64]; // stack offset -88
 	// 		int offset; // $a2
 	// 		int size; // $s0

--- a/src_rebuild/GAME/C/DEBRIS.C
+++ b/src_rebuild/GAME/C/DEBRIS.C
@@ -368,7 +368,7 @@ MATRIX leaf_mat;
 			// Start line: 954
 			// Start offset: 0x000330A4
 			// Variables:
-		// 		long n[4]; // stack offset -128
+		// 		LONGVECTOR n; // stack offset -128
 		/* end block 1.4 */
 		// End offset: 0x0003316C
 		// End Line: 960
@@ -452,7 +452,7 @@ void PlacePoolForCar(CAR_DATA *cp, CVECTOR *col, int front, int in_car)
 	VECTOR averagepos;
 	VECTOR mid_position;
 	VECTOR toss;
-	long n[4];
+	LONGVECTOR n;
 	long z[15];
 	int local_30;
 

--- a/src_rebuild/GAME/C/DEBRIS.C
+++ b/src_rebuild/GAME/C/DEBRIS.C
@@ -316,26 +316,26 @@ MATRIX leaf_mat;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlacePoolForCar(struct _CAR_DATA *cp /*$s4*/, struct CVECTOR *col /*stack 4*/, int front /*$a2*/)
+// void /*$ra*/ PlacePoolForCar(CAR_DATA *cp /*$s4*/, CVECTOR *col /*stack 4*/, int front /*$a2*/)
  // line 790, offset 0x00032c10
 	/* begin block 1 */
 		// Start line: 791
 		// Start offset: 0x00032C10
 		// Variables:
 	// 		int car_road_height; // $s2
-	// 		struct SVECTOR s[27]; // stack offset -832
-	// 		struct SVECTOR *ptr; // $s1
-	// 		struct SVECTOR sout[27]; // stack offset -616
-	// 		struct VECTOR s1[12]; // stack offset -400
-	// 		struct VECTOR *ptr1; // $s0
-	// 		struct POLY_FT4 *poly; // $t0
-	// 		struct MATRIX final_matrix; // stack offset -208
-	// 		struct VECTOR averagepos; // stack offset -176
+	// 		SVECTOR s[27]; // stack offset -832
+	// 		SVECTOR *ptr; // $s1
+	// 		SVECTOR sout[27]; // stack offset -616
+	// 		VECTOR s1[12]; // stack offset -400
+	// 		VECTOR *ptr1; // $s0
+	// 		POLY_FT4 *poly; // $t0
+	// 		MATRIX final_matrix; // stack offset -208
+	// 		VECTOR averagepos; // stack offset -176
 	// 		int in_car; // $t0
 	// 		int z; // stack offset -48
 	// 		int sub_level; // $fp
 	// 		int count; // $s3
-	// 		struct VECTOR mid_position; // stack offset -160
+	// 		VECTOR mid_position; // stack offset -160
 
 		/* begin block 1.1 */
 			// Start line: 813
@@ -358,7 +358,7 @@ MATRIX leaf_mat;
 			// Start line: 937
 			// Start offset: 0x00032FB4
 			// Variables:
-		// 		struct VECTOR toss; // stack offset -144
+		// 		VECTOR toss; // stack offset -144
 		// 		int temp_y; // $a1
 		/* end block 1.3 */
 		// End offset: 0x0003306C
@@ -426,7 +426,7 @@ MATRIX leaf_mat;
 //short light_col = 0;
 
 // [D]
-void PlacePoolForCar(_CAR_DATA *cp, CVECTOR *col, int front, int in_car)
+void PlacePoolForCar(CAR_DATA *cp, CVECTOR *col, int front, int in_car)
 {
 	unsigned char bVar1;
 	DB *pDVar3;
@@ -804,13 +804,13 @@ void ReleaseLeaf(short num)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddLeaf(struct VECTOR *Position /*$s1*/, int num_leaves /*$s5*/, int Type /*$s3*/)
+// void /*$ra*/ AddLeaf(VECTOR *Position /*$s1*/, int num_leaves /*$s5*/, int Type /*$s3*/)
  // line 1327, offset 0x00033574
 	/* begin block 1 */
 		// Start line: 1328
 		// Start offset: 0x00033574
 		// Variables:
-	// 		struct LEAF *myleaf; // $a1
+	// 		LEAF *myleaf; // $a1
 	// 		int num; // $v1
 	// 		int loop; // $s2
 	// 		int temprand; // $s0
@@ -968,17 +968,17 @@ void AddLeaf(VECTOR *Position, int num_leaves, int Type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SwirlLeaves(struct _CAR_DATA *cp /*$a0*/)
+// void /*$ra*/ SwirlLeaves(CAR_DATA *cp /*$a0*/)
  // line 1437, offset 0x00039e54
 	/* begin block 1 */
 		// Start line: 1438
 		// Start offset: 0x00039E54
 		// Variables:
 	// 		int count; // $s2
-	// 		struct LEAF *lpLeaf; // $s0
+	// 		LEAF *lpLeaf; // $s0
 	// 		int XDiff; // $v0
 	// 		int ZDiff; // $a1
-	// 		struct VECTOR *CarPos; // $s1
+	// 		VECTOR *CarPos; // $s1
 	// 		int WheelSpeed; // $a1
 
 		/* begin block 1.1 */
@@ -1007,7 +1007,7 @@ void AddLeaf(VECTOR *Position, int num_leaves, int Type)
 	// End Line: 17534
 
 // [D]
-void SwirlLeaves(_CAR_DATA *cp)
+void SwirlLeaves(CAR_DATA *cp)
 {
 	int XDiff;
 	int ZDiff;
@@ -1141,9 +1141,9 @@ void InitDebrisNames(void)
 		// Variables:
 	// 		int loop; // $v1
 	// 		int count; // $s0
-	// 		struct TPAN texnum; // stack offset -88
-	// 		struct TRI_POINT_LONG temptri; // stack offset -80
-	// 		struct BVECTOR *debrisPTR; // $a0
+	// 		TPAN texnum; // stack offset -88
+	// 		TRI_POINT_LONG temptri; // stack offset -80
+	// 		BVECTOR *debrisPTR; // $a0
 
 		/* begin block 1.1 */
 			// Start line: 1601
@@ -1422,15 +1422,15 @@ void ReleaseSmoke(short num)
 		// Start line: 1755
 		// Start offset: 0x00033FA8
 		// Variables:
-	// 		struct VECTOR Position; // stack offset -48
+	// 		VECTOR Position; // stack offset -48
 	// 		int seed; // $s0
 	// 		int number; // $v0
 	// 		int count; // $s3
 	// 		int xbound; // $a1
 	// 		int zbound; // $a0
 	// 		int type; // $a2
-	// 		struct CELL_OBJECT *cop; // $s1
-	// 		struct MODEL *model; // $s2
+	// 		CELL_OBJECT *cop; // $s1
+	// 		MODEL *model; // $s2
 
 		/* begin block 1.1 */
 			// Start line: 1783
@@ -1534,17 +1534,17 @@ void AddGroundDebris(void)
 		// Start offset: 0x00034138
 		// Variables:
 	// 		int count; // $s6
-	// 		struct VECTOR pos; // stack offset -128
-	// 		struct DAMAGED_OBJECT *dam; // $s2
+	// 		VECTOR pos; // stack offset -128
+	// 		DAMAGED_OBJECT *dam; // $s2
 
 		/* begin block 1.1 */
 			// Start line: 1826
 			// Start offset: 0x000341A4
 			// Variables:
-		// 		struct MATRIX object_matrix; // stack offset -112
-		// 		struct MATRIX spritematrix; // stack offset -80
-		// 		struct MATRIX *finalmatrix; // $s0
-		// 		struct MODEL *model; // $s3
+		// 		MATRIX object_matrix; // stack offset -112
+		// 		MATRIX spritematrix; // stack offset -80
+		// 		MATRIX *finalmatrix; // $s0
+		// 		MODEL *model; // $s3
 
 			/* begin block 1.1.1 */
 				// Start line: 1861
@@ -1672,7 +1672,7 @@ void DrawSmashable_sprites(void)
 		// Start offset: 0x0003A234
 		// Variables:
 	// 		int count; // $a3
-	// 		struct DAMAGED_OBJECT *dam; // $a1
+	// 		DAMAGED_OBJECT *dam; // $a1
 
 		/* begin block 1.1 */
 			// Start line: 1896
@@ -1741,24 +1741,24 @@ int MoveSmashable_object(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddSmallStreetLight(struct CELL_OBJECT *cop /*$s1*/, int x /*$s3*/, int y /*$s6*/, int z /*$s4*/, int type /*stack 16*/)
+// void /*$ra*/ AddSmallStreetLight(CELL_OBJECT *cop /*$s1*/, int x /*$s3*/, int y /*$s6*/, int z /*$s4*/, int type /*stack 16*/)
  // line 1925, offset 0x00034424
 	/* begin block 1 */
 		// Start line: 1926
 		// Start offset: 0x00034424
 		// Variables:
-	// 		struct VECTOR v1; // stack offset -112
-	// 		struct VECTOR v2; // stack offset -96
-	// 		struct VECTOR v3; // stack offset -80
-	// 		struct SVECTOR pos; // stack offset -64
-	// 		struct CVECTOR col; // stack offset -56
-	// 		struct CVECTOR col1; // stack offset -48
+	// 		VECTOR v1; // stack offset -112
+	// 		VECTOR v2; // stack offset -96
+	// 		VECTOR v3; // stack offset -80
+	// 		SVECTOR pos; // stack offset -64
+	// 		CVECTOR col; // stack offset -56
+	// 		CVECTOR col1; // stack offset -48
 	// 		int count; // $v1
 	// 		short angle; // $s2
 	// 		int halo_size; // $fp
 	// 		int size; // $s5
 	// 		int LampId; // $s7
-	// 		struct DAMAGED_LAMP *dam; // $s0
+	// 		DAMAGED_LAMP *dam; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 1961
@@ -1912,18 +1912,18 @@ void AddSmallStreetLight(CELL_OBJECT *cop, int x, int y, int z, int type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddLightEffect(struct CELL_OBJECT *cop /*$t0*/, int x /*$t2*/, int y /*$a2*/, int z /*$a3*/, int type /*stack 16*/, int colour /*stack 20*/)
+// void /*$ra*/ AddLightEffect(CELL_OBJECT *cop /*$t0*/, int x /*$t2*/, int y /*$a2*/, int z /*$a3*/, int type /*stack 16*/, int colour /*stack 20*/)
  // line 2049, offset 0x00034858
 	/* begin block 1 */
 		// Start line: 2050
 		// Start offset: 0x00034858
 		// Variables:
-	// 		struct VECTOR v1; // stack offset -88
-	// 		struct VECTOR v2; // stack offset -72
-	// 		struct VECTOR v3; // stack offset -56
-	// 		struct SVECTOR pos; // stack offset -40
-	// 		struct CVECTOR col; // stack offset -32
-	// 		struct CVECTOR col1; // stack offset -24
+	// 		VECTOR v1; // stack offset -88
+	// 		VECTOR v2; // stack offset -72
+	// 		VECTOR v3; // stack offset -56
+	// 		SVECTOR pos; // stack offset -40
+	// 		CVECTOR col; // stack offset -32
+	// 		CVECTOR col1; // stack offset -24
 	// 		short angle; // $v1
 	// 		int size; // $s1
 	/* end block 1 */
@@ -2173,7 +2173,7 @@ int find_lamp_streak(int LampId)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ damage_lamp(struct CELL_OBJECT *cop /*$a2*/)
+// int /*$ra*/ damage_lamp(CELL_OBJECT *cop /*$a2*/)
  // line 2230, offset 0x00034d1c
 	/* begin block 1 */
 		// Start line: 2231
@@ -2234,19 +2234,19 @@ int damage_lamp(CELL_OBJECT *cop)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ damage_object(struct CELL_OBJECT *cop /*$s1*/, struct VECTOR *velocity /*$a1*/)
+// int /*$ra*/ damage_object(CELL_OBJECT *cop /*$s1*/, VECTOR *velocity /*$a1*/)
  // line 2255, offset 0x00034dac
 	/* begin block 1 */
 		// Start line: 2256
 		// Start offset: 0x00034DAC
 		// Variables:
-	// 		struct DAMAGED_OBJECT *dam; // $s0
+	// 		DAMAGED_OBJECT *dam; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 2256
 			// Start offset: 0x00034DAC
 			// Variables:
-		// 		struct PACKED_CELL_OBJECT *pcop; // $a0
+		// 		PACKED_CELL_OBJECT *pcop; // $a0
 		/* end block 1.1 */
 		// End offset: 0x00034DAC
 		// End Line: 2256
@@ -2326,17 +2326,17 @@ int damage_object(CELL_OBJECT *cop, VECTOR *velocity)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddTrafficLight(struct CELL_OBJECT *cop /*$t4*/, int x /*$t6*/, int y /*$t7*/, int z /*$a3*/, int flag /*stack 16*/, int yang /*stack 20*/)
+// void /*$ra*/ AddTrafficLight(CELL_OBJECT *cop /*$t4*/, int x /*$t6*/, int y /*$t7*/, int z /*$a3*/, int flag /*stack 16*/, int yang /*stack 20*/)
  // line 2326, offset 0x00034f64
 	/* begin block 1 */
 		// Start line: 2327
 		// Start offset: 0x00034F64
 		// Variables:
-	// 		struct CVECTOR a; // stack offset -80
-	// 		struct CVECTOR b; // stack offset -72
-	// 		struct CVECTOR c; // stack offset -64
-	// 		struct VECTOR v1; // stack offset -56
-	// 		struct VECTOR v2; // stack offset -40
+	// 		CVECTOR a; // stack offset -80
+	// 		CVECTOR b; // stack offset -72
+	// 		CVECTOR c; // stack offset -64
+	// 		VECTOR v1; // stack offset -56
+	// 		VECTOR v2; // stack offset -40
 	// 		int lDiffAnglesX; // $s2
 	// 		int lDiffAnglesY; // $s1
 	// 		int AbsX; // $a2
@@ -2477,13 +2477,13 @@ LAB_00035098:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitFXPos(struct VECTOR *vec /*$a0*/, struct SVECTOR *svec /*$a1*/, struct _CAR_DATA *cp /*$a2*/)
+// void /*$ra*/ InitFXPos(VECTOR *vec /*$a0*/, SVECTOR *svec /*$a1*/, CAR_DATA *cp /*$a2*/)
  // line 2428, offset 0x00039c90
 	/* begin block 1 */
 		// Start line: 2429
 		// Start offset: 0x00039C90
 		// Variables:
-	// 		struct SVECTOR svectmp; // stack offset -8
+	// 		SVECTOR svectmp; // stack offset -8
 	/* end block 1 */
 	// End offset: 0x00039D68
 	// End Line: 2437
@@ -2504,7 +2504,7 @@ LAB_00035098:
 	// End Line: 13203
 
 // [D] [T]
-void InitFXPos(VECTOR *vec, SVECTOR *svec, _CAR_DATA *cp)
+void InitFXPos(VECTOR *vec, SVECTOR *svec, CAR_DATA *cp)
 {
 	SVECTOR svectmp;
 
@@ -2528,7 +2528,7 @@ void InitFXPos(VECTOR *vec, SVECTOR *svec, _CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ FindCarLightFade(struct MATRIX *carToCamera /*$a0*/)
+// void /*$ra*/ FindCarLightFade(MATRIX *carToCamera /*$a0*/)
  // line 2447, offset 0x00039c68
 	/* begin block 1 */
 		// Start line: 2449
@@ -2567,16 +2567,16 @@ void FindCarLightFade(MATRIX *carToCamera)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ShowCarlight(struct SVECTOR *v1 /*$s6*/, struct _CAR_DATA *cp /*$s3*/, struct CVECTOR *col /*$s1*/, short size /*$s5*/, struct TEXTURE_DETAILS *texture /*stack 16*/, int flag /*stack 20*/)
+// void /*$ra*/ ShowCarlight(SVECTOR *v1 /*$s6*/, CAR_DATA *cp /*$s3*/, CVECTOR *col /*$s1*/, short size /*$s5*/, TEXTURE_DETAILS *texture /*stack 16*/, int flag /*stack 20*/)
  // line 2462, offset 0x000352cc
 	/* begin block 1 */
 		// Start line: 2463
 		// Start offset: 0x000352CC
 		// Variables:
 	// 		int CarLightFade; // $a1
-	// 		struct VECTOR v1t; // stack offset -72
-	// 		struct VECTOR v1l; // stack offset -56
-	// 		struct CVECTOR flareCol; // stack offset -40
+	// 		VECTOR v1t; // stack offset -72
+	// 		VECTOR v1l; // stack offset -56
+	// 		CVECTOR flareCol; // stack offset -40
 	// 		int front; // $a0
 	/* end block 1 */
 	// End offset: 0x00035534
@@ -2588,7 +2588,7 @@ void FindCarLightFade(MATRIX *carToCamera)
 	// End Line: 6202
 
 // [D] [T
-void ShowCarlight(SVECTOR *v1, _CAR_DATA *cp, CVECTOR *col, short size, TEXTURE_DETAILS *texture,int flag)
+void ShowCarlight(SVECTOR *v1, CAR_DATA *cp, CVECTOR *col, short size, TEXTURE_DETAILS *texture,int flag)
 {
 	int CarLightFade;
 	VECTOR v1t;
@@ -2657,14 +2657,14 @@ void ShowCarlight(SVECTOR *v1, _CAR_DATA *cp, CVECTOR *col, short size, TEXTURE_
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ShowLight1(struct VECTOR *v1 /*$a0*/, struct CVECTOR *col /*$a1*/, short size /*$a2*/, struct TEXTURE_DETAILS *texture /*$a3*/)
+// void /*$ra*/ ShowLight1(VECTOR *v1 /*$a0*/, CVECTOR *col /*$a1*/, short size /*$a2*/, TEXTURE_DETAILS *texture /*$a3*/)
  // line 2523, offset 0x0003555c
 	/* begin block 1 */
 		// Start line: 2524
 		// Start offset: 0x0003555C
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -40
-	// 		struct POLY_FT4 *poly; // $t0
+	// 		SVECTOR vert[4]; // stack offset -40
+	// 		POLY_FT4 *poly; // $t0
 	// 		int z; // stack offset -8
 	/* end block 1 */
 	// End offset: 0x00035748
@@ -2751,14 +2751,14 @@ void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ShowLight(struct VECTOR *v1 /*$s0*/, struct CVECTOR *col /*$s3*/, short size /*$s4*/, struct TEXTURE_DETAILS *texture /*$s2*/)
+// void /*$ra*/ ShowLight(VECTOR *v1 /*$s0*/, CVECTOR *col /*$s3*/, short size /*$s4*/, TEXTURE_DETAILS *texture /*$s2*/)
  // line 2579, offset 0x00035750
 	/* begin block 1 */
 		// Start line: 2580
 		// Start offset: 0x00035750
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -88
-	// 		struct POLY_FT4 *poly; // $s1
+	// 		SVECTOR vert[4]; // stack offset -88
+	// 		POLY_FT4 *poly; // $s1
 	// 		int z; // stack offset -40
 	// 		int index; // $a1
 	// 		int tail_width; // $s5
@@ -2776,7 +2776,7 @@ void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 			// Start line: 2654
 			// Start offset: 0x00035AD4
 			// Variables:
-		// 		struct POLY_G4 *poly1; // $s0
+		// 		POLY_G4 *poly1; // $s0
 		// 		int dx; // $a0
 		// 		int dy; // $v0
 		// 		int angle; // $v0
@@ -2784,8 +2784,8 @@ void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 		// 		int c; // $a0
 		// 		int s; // $a2
 		// 		int length; // $v0
-		// 		struct SVECTOR tail; // stack offset -56
-		// 		struct SVECTOR head; // stack offset -48
+		// 		SVECTOR tail; // stack offset -56
+		// 		SVECTOR head; // stack offset -48
 		/* end block 1.2 */
 		// End offset: 0x00035EB8
 		// End Line: 2709
@@ -2803,7 +2803,7 @@ void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 			// Start line: 2737
 			// Start offset: 0x00036024
 			// Variables:
-		// 		struct POLY_G4 *poly1; // $s0
+		// 		POLY_G4 *poly1; // $s0
 		// 		int dx; // $a2
 		// 		int dy; // $a1
 		// 		int angle; // $v0
@@ -2811,8 +2811,8 @@ void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 		// 		int c; // $a2
 		// 		int s; // $a1
 		// 		int length; // $v0
-		// 		struct SVECTOR tail; // stack offset -56
-		// 		struct SVECTOR head; // stack offset -48
+		// 		SVECTOR tail; // stack offset -56
+		// 		SVECTOR head; // stack offset -48
 		/* end block 1.4 */
 		// End offset: 0x00036408
 		// End Line: 2792
@@ -3226,14 +3226,14 @@ void ShowLight(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ShowGroundLight(struct VECTOR *v1 /*$a0*/, struct CVECTOR *col /*$a1*/, short size /*$a2*/)
+// void /*$ra*/ ShowGroundLight(VECTOR *v1 /*$a0*/, CVECTOR *col /*$a1*/, short size /*$a2*/)
  // line 2804, offset 0x0003642c
 	/* begin block 1 */
 		// Start line: 2805
 		// Start offset: 0x0003642C
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -40
-	// 		struct POLY_FT4 *poly; // $t0
+	// 		SVECTOR vert[4]; // stack offset -40
+	// 		POLY_FT4 *poly; // $t0
 	// 		int z; // stack offset -8
 	/* end block 1 */
 	// End offset: 0x00036680
@@ -3316,14 +3316,14 @@ void ShowGroundLight(VECTOR *v1, CVECTOR *col, short size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RoundShadow(struct VECTOR *v1 /*$a0*/, struct CVECTOR *col /*$a1*/, short size /*$a2*/)
+// void /*$ra*/ RoundShadow(VECTOR *v1 /*$a0*/, CVECTOR *col /*$a1*/, short size /*$a2*/)
  // line 2869, offset 0x00036688
 	/* begin block 1 */
 		// Start line: 2870
 		// Start offset: 0x00036688
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -40
-	// 		struct POLY_FT4 *poly; // $t0
+	// 		SVECTOR vert[4]; // stack offset -40
+	// 		POLY_FT4 *poly; // $t0
 	// 		int z; // stack offset -8
 	/* end block 1 */
 	// End offset: 0x000368D0
@@ -3411,16 +3411,16 @@ void RoundShadow(VECTOR *v1, CVECTOR *col, short size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ShowFlare(struct VECTOR *v1 /*$a0*/, struct CVECTOR *col /*$s2*/, short size /*$a2*/, int rotation /*$a3*/)
+// void /*$ra*/ ShowFlare(VECTOR *v1 /*$a0*/, CVECTOR *col /*$s2*/, short size /*$a2*/, int rotation /*$a3*/)
  // line 2945, offset 0x000368d8
 	/* begin block 1 */
 		// Start line: 2946
 		// Start offset: 0x000368D8
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -96
-	// 		struct POLY_FT4 *poly; // $t0
-	// 		struct SVECTOR direction; // stack offset -64
-	// 		struct MATRIX temp_matrix; // stack offset -56
+	// 		SVECTOR vert[4]; // stack offset -96
+	// 		POLY_FT4 *poly; // $t0
+	// 		SVECTOR direction; // stack offset -64
+	// 		MATRIX temp_matrix; // stack offset -56
 	// 		int z; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00036B54
@@ -3518,15 +3518,15 @@ void ShowFlare(VECTOR *v1, CVECTOR *col, short size, int rotation)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplayWater(struct SMOKE *smoke /*$a0*/)
+// void /*$ra*/ DisplayWater(SMOKE *smoke /*$a0*/)
  // line 3029, offset 0x00036b6c
 	/* begin block 1 */
 		// Start line: 3030
 		// Start offset: 0x00036B6C
 		// Variables:
-	// 		struct POLY_FT4 *poly; // $t1
-	// 		struct VECTOR v; // stack offset -64
-	// 		struct SVECTOR vert[4]; // stack offset -48
+	// 		POLY_FT4 *poly; // $t1
+	// 		VECTOR v; // stack offset -64
+	// 		SVECTOR vert[4]; // stack offset -48
 	// 		int size; // $t1
 	// 		int z; // $v0
 	// 		int z1; // stack offset -16
@@ -3631,16 +3631,16 @@ void DisplayWater(SMOKE *smoke)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplaySpark(struct SMOKE *spark /*$t1*/)
+// void /*$ra*/ DisplaySpark(SMOKE *spark /*$t1*/)
  // line 3102, offset 0x00036e18
 	/* begin block 1 */
 		// Start line: 3103
 		// Start offset: 0x00036E18
 		// Variables:
 	// 		int z; // stack offset -8
-	// 		struct SVECTOR v[3]; // stack offset -40
-	// 		struct SVECTOR TrailPos; // stack offset -16
-	// 		struct POLY_G3 *poly; // $t0
+	// 		SVECTOR v[3]; // stack offset -40
+	// 		SVECTOR TrailPos; // stack offset -16
+	// 		POLY_G3 *poly; // $t0
 
 		/* begin block 1.1 */
 			// Start line: 3135
@@ -3762,7 +3762,7 @@ void DisplaySpark(SMOKE *spark)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetSmokeDrift(struct VECTOR *Wind /*$t2*/)
+// void /*$ra*/ GetSmokeDrift(VECTOR *Wind /*$t2*/)
  // line 3182, offset 0x00037158
 	/* begin block 1 */
 		// Start line: 3183
@@ -3822,13 +3822,13 @@ void GetSmokeDrift(VECTOR *Wind)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Setup_Debris(struct VECTOR *ipos /*$fp*/, struct VECTOR *ispeed /*$s6*/, int num_debris /*$s7*/, int type /*$s5*/)
+// void /*$ra*/ Setup_Debris(VECTOR *ipos /*$fp*/, VECTOR *ispeed /*$s6*/, int num_debris /*$s7*/, int type /*$s5*/)
  // line 3227, offset 0x00037250
 	/* begin block 1 */
 		// Start line: 3228
 		// Start offset: 0x00037250
 		// Variables:
-	// 		struct DEBRIS *mydebris; // $s1
+	// 		DEBRIS *mydebris; // $s1
 	// 		int num; // $v1
 	// 		int loop; // $s4
 	// 		int vx; // $s2
@@ -3941,13 +3941,13 @@ void Setup_Debris(VECTOR *ipos, VECTOR *ispeed, int num_debris, int type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Setup_Smoke(struct VECTOR *ipos /*$s1*/, int start_w /*$s3*/, int end_w /*$s4*/, int SmokeType /*$s7*/, int WheelSpeed /*stack 16*/, struct VECTOR *Drift /*stack 20*/, int Exhaust /*stack 24*/)
+// void /*$ra*/ Setup_Smoke(VECTOR *ipos /*$s1*/, int start_w /*$s3*/, int end_w /*$s4*/, int SmokeType /*$s7*/, int WheelSpeed /*stack 16*/, VECTOR *Drift /*stack 20*/, int Exhaust /*stack 24*/)
  // line 3296, offset 0x00037474
 	/* begin block 1 */
 		// Start line: 3297
 		// Start offset: 0x00037474
 		// Variables:
-	// 		struct SMOKE *mysmoke; // $s0
+	// 		SMOKE *mysmoke; // $s0
 	// 		int num; // $v1
 
 		/* begin block 1.1 */
@@ -4166,13 +4166,13 @@ LAB_00037884:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Setup_Sparks(struct VECTOR *ipos /*$fp*/, struct VECTOR *ispeed /*$s7*/, int num_sparks /*stack 8*/, char SparkType /*$s5*/)
+// void /*$ra*/ Setup_Sparks(VECTOR *ipos /*$fp*/, VECTOR *ispeed /*$s7*/, int num_sparks /*stack 8*/, char SparkType /*$s5*/)
  // line 3475, offset 0x00037950
 	/* begin block 1 */
 		// Start line: 3476
 		// Start offset: 0x00037950
 		// Variables:
-	// 		struct SMOKE *mysmoke; // $s2
+	// 		SMOKE *mysmoke; // $s2
 	// 		int num; // $s0
 	// 		int loop; // $s4
 	// 		int vx; // $s1
@@ -4280,7 +4280,7 @@ void Setup_Sparks(VECTOR *ipos, VECTOR *ispeed, int num_sparks, char SparkType)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplayDebris(struct DEBRIS *debris /*$t2*/, char type /*$t3*/)
+// void /*$ra*/ DisplayDebris(DEBRIS *debris /*$t2*/, char type /*$t3*/)
  // line 3564, offset 0x00037b14
 	/* begin block 1 */
 		// Start line: 3565
@@ -4288,11 +4288,11 @@ void Setup_Sparks(VECTOR *ipos, VECTOR *ispeed, int num_sparks, char SparkType)
 		// Variables:
 	// 		int pos; // $a1
 	// 		int z; // stack offset -8
-	// 		struct SVECTOR v[4]; // stack offset -56
-	// 		struct TRI_POINT *tv; // $t1
-	// 		struct VECTOR debrisvec; // stack offset -24
-	// 		struct POLY_FT3 *poly; // $t0
-	// 		struct POLY_GT4 *poly1; // $t0
+	// 		SVECTOR v[4]; // stack offset -56
+	// 		TRI_POINT *tv; // $t1
+	// 		VECTOR debrisvec; // stack offset -24
+	// 		POLY_FT3 *poly; // $t0
+	// 		POLY_GT4 *poly1; // $t0
 
 		/* begin block 1.1 */
 			// Start line: 3607
@@ -4430,21 +4430,21 @@ void DisplayDebris(DEBRIS *debris, char type)
 		// Variables:
 	// 		int count; // $s0
 	// 		int i; // $s3
-	// 		struct DEBRIS *lpDebris; // $s1
-	// 		struct SMOKE *smokeptr; // $s0
-	// 		struct VECTOR dummy; // stack offset -80
-	// 		struct LEAF *lpLeaf; // $s1
+	// 		DEBRIS *lpDebris; // $s1
+	// 		SMOKE *smokeptr; // $s0
+	// 		VECTOR dummy; // stack offset -80
+	// 		LEAF *lpLeaf; // $s1
 	// 		int Height; // $v0
 	// 		int SinX; // $s2
 	// 		int CosX; // $v1
-	// 		struct VECTOR Drift; // stack offset -64
+	// 		VECTOR Drift; // stack offset -64
 
 		/* begin block 1.1 */
 			// Start line: 3852
 			// Start offset: 0x0003841C
 			// Variables:
 		// 		int offshore; // $s1
-		// 		struct ROUTE_DATA routeData; // stack offset -48
+		// 		ROUTE_DATA routeData; // stack offset -48
 		/* end block 1.1 */
 		// End offset: 0x000384B4
 		// End Line: 3864
@@ -4785,15 +4785,15 @@ void HandleDebris(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplaySmoke(struct SMOKE *smoke /*$s0*/)
+// void /*$ra*/ DisplaySmoke(SMOKE *smoke /*$s0*/)
  // line 3983, offset 0x0003877c
 	/* begin block 1 */
 		// Start line: 3984
 		// Start offset: 0x0003877C
 		// Variables:
-	// 		struct POLY_FT4 *poly; // $t0
-	// 		struct VECTOR v; // stack offset -80
-	// 		struct SVECTOR smokemesh[4]; // stack offset -64
+	// 		POLY_FT4 *poly; // $t0
+	// 		VECTOR v; // stack offset -80
+	// 		SVECTOR smokemesh[4]; // stack offset -64
 	// 		int x; // $s2
 	// 		int negx; // $s1
 	// 		int z; // stack offset -32
@@ -5050,7 +5050,7 @@ void DisplaySmoke(SMOKE *smoke)
 		// Start line: 4119
 		// Start offset: 0x00038CB4
 		// Variables:
-	// 		struct TILE *polys; // $a1
+	// 		TILE *polys; // $a1
 	/* end block 1 */
 	// End offset: 0x00038E00
 	// End Line: 4141
@@ -5216,12 +5216,12 @@ void ReleaseRainDrop(int RainIndex)
 		// Start line: 4210
 		// Start offset: 0x00038E08
 		// Variables:
-	// 		struct RAIN_TYPE *RainPtr; // $s0
-	// 		struct POLY_GT3 *poly; // $a3
+	// 		RAIN_TYPE *RainPtr; // $s0
+	// 		POLY_GT3 *poly; // $a3
 	// 		int Count; // $s2
 	// 		int z; // stack offset -48
-	// 		struct SVECTOR v[3]; // stack offset -88
-	// 		struct VECTOR drift; // stack offset -64
+	// 		SVECTOR v[3]; // stack offset -88
+	// 		VECTOR drift; // stack offset -64
 	// 		int tpage; // $fp
 	// 		int clut; // $s7
 	// 		int col; // $s1
@@ -5364,8 +5364,8 @@ void DrawRainDrops(void)
 		// Start line: 4415
 		// Start offset: 0x0003919C
 		// Variables:
-	// 		struct SVECTOR v; // stack offset -48
-	// 		struct RAIN_TYPE *RainPtr; // $a2
+	// 		SVECTOR v; // stack offset -48
+	// 		RAIN_TYPE *RainPtr; // $a2
 	// 		int RainIndex; // $s0
 	// 		int RainNo; // $s1
 	// 		int first; // $s3
@@ -5384,7 +5384,7 @@ void DrawRainDrops(void)
 			// Start line: 4466
 			// Start offset: 0x000393E4
 			// Variables:
-		// 		struct ROUTE_DATA routeData; // stack offset -40
+		// 		ROUTE_DATA routeData; // stack offset -40
 		/* end block 1.2 */
 		// End offset: 0x00039434
 		// End Line: 4474
@@ -5504,11 +5504,11 @@ void AddRainDrops(void)
 		// Variables:
 	// 		int SplashNo; // $s4
 	// 		int SplashFrac; // $v0
-	// 		struct VECTOR CamGnd; // stack offset -96
-	// 		struct VECTOR Gnd1; // stack offset -80
-	// 		struct VECTOR Gnd2; // stack offset -64
-	// 		struct VECTOR Position; // stack offset -48
-	// 		struct CVECTOR col; // stack offset -32
+	// 		VECTOR CamGnd; // stack offset -96
+	// 		VECTOR Gnd1; // stack offset -80
+	// 		VECTOR Gnd2; // stack offset -64
+	// 		VECTOR Position; // stack offset -48
+	// 		CVECTOR col; // stack offset -32
 	// 		static unsigned long rand; // offset 0x170
 	// 		int d1; // $a0
 	// 		int d2; // $a2
@@ -5596,15 +5596,15 @@ void DisplaySplashes(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplayLightReflections(struct VECTOR *v1 /*$s1*/, struct CVECTOR *col /*$s3*/, short size /*$a2*/, struct TEXTURE_DETAILS *texture /*$s2*/)
+// void /*$ra*/ DisplayLightReflections(VECTOR *v1 /*$s1*/, CVECTOR *col /*$s3*/, short size /*$a2*/, TEXTURE_DETAILS *texture /*$s2*/)
  // line 4550, offset 0x000397c0
 	/* begin block 1 */
 		// Start line: 4551
 		// Start offset: 0x000397C0
 		// Variables:
-	// 		struct SVECTOR vert[4]; // stack offset -80
-	// 		struct POLY_FT4 *poly; // $a1
-	// 		struct CVECTOR thiscol; // stack offset -48
+	// 		SVECTOR vert[4]; // stack offset -80
+	// 		POLY_FT4 *poly; // $a1
+	// 		CVECTOR thiscol; // stack offset -48
 	// 		int z; // stack offset -40
 	// 		int tpage; // $s5
 	// 		int clut; // $s4
@@ -5911,7 +5911,7 @@ void DoWeather(int weather)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GetDebrisColour(struct _CAR_DATA *cp /*$a0*/)
+// int /*$ra*/ GetDebrisColour(CAR_DATA *cp /*$a0*/)
  // line 4725, offset 0x00039fa8
 	/* begin block 1 */
 		// Start line: 4726
@@ -5934,7 +5934,7 @@ void DoWeather(int weather)
 	// End Line: 24131
 
 // [D] [T]
-int GetDebrisColour(_CAR_DATA *cp)
+int GetDebrisColour(CAR_DATA *cp)
 {
 	int car_model;
 

--- a/src_rebuild/GAME/C/DEBRIS.H
+++ b/src_rebuild/GAME/C/DEBRIS.H
@@ -35,7 +35,7 @@ extern int main_cop_light_pos;
 extern int groundDebrisIndex;
 extern CELL_OBJECT ground_debris[16];
 
-extern void PlacePoolForCar(_CAR_DATA *cp, CVECTOR *col, int front, int in_car); // 0x00032C10
+extern void PlacePoolForCar(CAR_DATA *cp, CVECTOR *col, int front, int in_car); // 0x00032C10
 
 extern int AllocateLeaf(); // 0x00039A90
 
@@ -43,7 +43,7 @@ extern void ReleaseLeaf(short num); // 0x00039D8C
 
 extern void AddLeaf(VECTOR *Position, int num_leaves, int Type); // 0x00033574
 
-extern void SwirlLeaves(_CAR_DATA *cp); // 0x00039E54
+extern void SwirlLeaves(CAR_DATA *cp); // 0x00039E54
 
 extern void InitDebrisNames(); // 0x000337AC
 
@@ -77,11 +77,11 @@ extern int damage_object(CELL_OBJECT *cop, VECTOR *velocity); // 0x00034DAC
 
 extern void AddTrafficLight(CELL_OBJECT *cop, int x, int y, int z, int flag, int yang); // 0x00034F64
 
-extern void InitFXPos(VECTOR *vec, SVECTOR *svec, _CAR_DATA *cp); // 0x00039C90
+extern void InitFXPos(VECTOR *vec, SVECTOR *svec, CAR_DATA *cp); // 0x00039C90
 
 extern void FindCarLightFade(MATRIX *carToCamera); // 0x00039C68
 
-extern void ShowCarlight(SVECTOR *v1, _CAR_DATA *cp, CVECTOR *col, short size, TEXTURE_DETAILS *texture, int flag); // 0x000352CC
+extern void ShowCarlight(SVECTOR *v1, CAR_DATA *cp, CVECTOR *col, short size, TEXTURE_DETAILS *texture, int flag); // 0x000352CC
 
 extern void ShowLight1(VECTOR *v1, CVECTOR *col, short size, TEXTURE_DETAILS *texture); // 0x0003555C
 
@@ -137,7 +137,7 @@ extern void DoThunder(); // 0x0003A144
 
 extern void DoWeather(int weather); // 0x0003A000
 
-extern int GetDebrisColour(_CAR_DATA *cp); // 0x00039FA8
+extern int GetDebrisColour(CAR_DATA *cp); // 0x00039FA8
 
 
 #endif

--- a/src_rebuild/GAME/C/DENTING.C
+++ b/src_rebuild/GAME/C/DENTING.C
@@ -52,17 +52,17 @@ void InitialiseDenting(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DentCar(struct _CAR_DATA *cp /*$t7*/)
+// void /*$ra*/ DentCar(CAR_DATA *cp /*$t7*/)
  // line 288, offset 0x0003a310
 	/* begin block 1 */
 		// Start line: 289
 		// Start offset: 0x0003A310
 		// Variables:
-	// 		struct SVECTOR *VertPtr; // $t0
+	// 		SVECTOR *VertPtr; // $t0
 	// 		int MaxDamage; // $s0
 	// 		unsigned char VertIndex; // $v0
 	// 		unsigned char PolyIndex; // $v0
-	// 		struct DENTUVS *dentptr; // $t1
+	// 		DENTUVS *dentptr; // $t1
 	// 		unsigned char *DamPtr; // $a2
 	// 		int model; // $t5
 	// 		int Poly; // $a1
@@ -70,9 +70,9 @@ void InitialiseDenting(void)
 	// 		int Zone; // $a3
 	// 		int VertNo; // $a2
 	// 		short *tempDamage; // $t1
-	// 		struct SVECTOR *DamVertPtr; // $a3
-	// 		struct SVECTOR *CleanVertPtr; // $a1
-	// 		struct MODEL *pCleanModel; // $t3
+	// 		SVECTOR *DamVertPtr; // $a3
+	// 		SVECTOR *CleanVertPtr; // $a1
+	// 		MODEL *pCleanModel; // $t3
 
 		/* begin block 1.1 */
 			// Start line: 421
@@ -95,7 +95,7 @@ void InitialiseDenting(void)
 	// End Line: 580
 
 // [D] [T]
-void DentCar(_CAR_DATA *cp)
+void DentCar(CAR_DATA *cp)
 {
 	int Zone;
 	int Damage;
@@ -225,13 +225,13 @@ void DentCar(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CreateDentableCar(struct _CAR_DATA *cp /*$t2*/)
+// void /*$ra*/ CreateDentableCar(CAR_DATA *cp /*$t2*/)
  // line 458, offset 0x0003a6e4
 	/* begin block 1 */
 		// Start line: 459
 		// Start offset: 0x0003A6E4
 		// Variables:
-	// 		struct DENTUVS *dentptr; // $a3
+	// 		DENTUVS *dentptr; // $a3
 	// 		int Zone; // $v1
 	// 		int count; // $a2
 	// 		int model; // $t3
@@ -240,8 +240,8 @@ void DentCar(_CAR_DATA *cp)
 			// Start line: 478
 			// Start offset: 0x0003A710
 			// Variables:
-		// 		struct SVECTOR *dst; // $a2
-		// 		struct SVECTOR *src; // $a3
+		// 		SVECTOR *dst; // $a2
+		// 		SVECTOR *src; // $a3
 		// 		int count; // $t0
 
 			/* begin block 1.1.1 */
@@ -277,7 +277,7 @@ void DentCar(_CAR_DATA *cp)
 	// End Line: 1139
 
 // [D] [T]
-void CreateDentableCar(_CAR_DATA *cp)
+void CreateDentableCar(CAR_DATA *cp)
 {
 	MODEL *srcModel;
 	SVECTOR *dst;
@@ -404,15 +404,15 @@ void InitHubcap(void)
 		// Start line: 601
 		// Start offset: 0x0003A8F8
 		// Variables:
-	// 		struct _CAR_DATA *car_data_pt; // $s1
-	// 		struct SVECTOR InitialLocalAngle; // stack offset -64
+	// 		CAR_DATA *car_data_pt; // $s1
+	// 		SVECTOR InitialLocalAngle; // stack offset -64
 
 		/* begin block 1.1 */
 			// Start line: 671
 			// Start offset: 0x0003AA84
 			// Variables:
-		// 		struct VECTOR R; // stack offset -56
-		// 		struct VECTOR VW; // stack offset -40
+		// 		VECTOR R; // stack offset -56
+		// 		VECTOR VW; // stack offset -40
 		// 		long AY; // $t0
 		/* end block 1.1 */
 		// End offset: 0x0003AAE0
@@ -444,7 +444,7 @@ void LoseHubcap(int car, int Hubcap, int Velocity)
 	SVECTOR InitialLocalAngle = { 0, 0, 10 };
 	VECTOR R;
 	VECTOR VW;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 
 	cp = &car_data[car];
 
@@ -500,10 +500,10 @@ void LoseHubcap(int car, int Hubcap, int Velocity)
 		// Start line: 708
 		// Start offset: 0x0003AB4C
 		// Variables:
-	// 		struct _CAR_DATA *car_data_pt; // $a1
-	// 		struct VECTOR Position; // stack offset -80
-	// 		struct MATRIX Orientation; // stack offset -64
-	// 		struct CVECTOR col; // stack offset -32
+	// 		CAR_DATA *car_data_pt; // $a1
+	// 		VECTOR Position; // stack offset -80
+	// 		MATRIX Orientation; // stack offset -64
+	// 		CVECTOR col; // stack offset -32
 	// 		int VelocityMagnitude; // $s0
 	// 		int CurrentMapHeight; // $a0
 	// 		int savecombo; // $s0
@@ -553,7 +553,7 @@ void LoseHubcap(int car, int Hubcap, int Velocity)
 void HandlePlayerHubcaps(int playerId)
 {
 	int VelocityMagnitude;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	int playerCarId;
 
 	playerCarId = player[playerId].playerCarId;

--- a/src_rebuild/GAME/C/DENTING.H
+++ b/src_rebuild/GAME/C/DENTING.H
@@ -4,9 +4,9 @@
 
 extern void InitialiseDenting(); // 0x0003B1C0
 
-extern void DentCar(struct _CAR_DATA *cp); // 0x0003A310
+extern void DentCar(CAR_DATA *cp); // 0x0003A310
 
-extern void CreateDentableCar(struct _CAR_DATA *cp); // 0x0003A6E4
+extern void CreateDentableCar(CAR_DATA *cp); // 0x0003A6E4
 
 extern void InitHubcap(); // 0x0003A874
 

--- a/src_rebuild/GAME/C/DIRECTOR.C
+++ b/src_rebuild/GAME/C/DIRECTOR.C
@@ -237,7 +237,7 @@ void DeleteCurrentCamera(int CameraCnt)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ setCamera(struct PLAYBACKCAMERA *Change /*$a0*/)
+// void /*$ra*/ setCamera(PLAYBACKCAMERA *Change /*$a0*/)
  // line 493, offset 0x0003e89c
 	/* begin block 1 */
 		// Start line: 3304
@@ -393,7 +393,7 @@ void EditCamera(int CameraCnt)
 		// Start line: 575
 		// Start offset: 0x0003B548
 		// Variables:
-	// 		struct PLAYBACKCAMERA *TempChange; // $a1
+	// 		PLAYBACKCAMERA *TempChange; // $a1
 	/* end block 1 */
 	// End offset: 0x0003B794
 	// End Line: 632
@@ -483,7 +483,7 @@ void RecordCamera(int CameraCnt)
 	// 		int count; // $a3
 	// 		int nextframe; // $a2
 	// 		int found; // $t0
-	// 		struct PLAYBACKCAMERA *RestoreChange; // $t1
+	// 		PLAYBACKCAMERA *RestoreChange; // $t1
 	/* end block 1 */
 	// End offset: 0x0003E9B8
 	// End Line: 655
@@ -609,7 +609,7 @@ int CheckCameraChange(int CameraCnt)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetPlaybackCamera(struct PLAYBACKCAMERA *camera /*$a0*/)
+// void /*$ra*/ SetPlaybackCamera(PLAYBACKCAMERA *camera /*$a0*/)
  // line 710, offset 0x0003ec0c
 	/* begin block 1 */
 		// Start line: 5354
@@ -659,13 +659,13 @@ void SetPlaybackCamera(PLAYBACKCAMERA* camera)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ IsMovingCamera(struct PLAYBACKCAMERA *lastcam /*$t3*/, struct PLAYBACKCAMERA *nextcam /*$t0*/, int cameracnt /*$a2*/)
+// int /*$ra*/ IsMovingCamera(PLAYBACKCAMERA *lastcam /*$t3*/, PLAYBACKCAMERA *nextcam /*$t0*/, int cameracnt /*$a2*/)
  // line 731, offset 0x0003b8c8
 	/* begin block 1 */
 		// Start line: 732
 		// Start offset: 0x0003B8C8
 		// Variables:
-	// 		struct PLAYBACKCAMERA cam; // stack offset -56
+	// 		PLAYBACKCAMERA cam; // stack offset -56
 	// 		long xdist; // $t5
 	// 		long ydist; // $t6
 	// 		long zdist; // $t4
@@ -768,8 +768,8 @@ int IsMovingCamera(PLAYBACKCAMERA* lastcam, PLAYBACKCAMERA* nextcam, int camerac
 		// Start line: 795
 		// Start offset: 0x0003BBA8
 		// Variables:
-	// 		struct POLY_G4 *camera; // $a2
-	// 		struct LINE_F2 *bar; // $t2
+	// 		POLY_G4 *camera; // $a2
+	// 		LINE_F2 *bar; // $t2
 	// 		int x; // $a2
 	// 		int min_x; // $t1
 	// 		int max_x; // $t0
@@ -1028,7 +1028,7 @@ void CameraBar(int CameraCnt)
 
 // decompiled code
 // original method signature: 
-// struct PLAYBACKCAMERA * /*$ra*/ FindFreeCamera()
+// PLAYBACKCAMERA * /*$ra*/ FindFreeCamera()
  // line 929, offset 0x0003e9b8
 	/* begin block 1 */
 		// Start line: 931
@@ -1118,7 +1118,7 @@ void deleteCamera(int count)
 		// Start line: 953
 		// Start offset: 0x0003EA40
 		// Variables:
-	// 		struct PLAYBACKCAMERA nextcamera; // stack offset -48
+	// 		PLAYBACKCAMERA nextcamera; // stack offset -48
 	// 		int count; // $s0
 	/* end block 1 */
 	// End offset: 0x0003EAA4
@@ -1172,15 +1172,15 @@ void DeleteAllCameras(void)
 		// Start offset: 0x0003C1B0
 		// Variables:
 	// 		static int FlashCnt; // offset 0x0
-	// 		struct REPLAY_ICON *IconPtr; // $s0
-	// 		struct SPRT *icon; // $a2
+	// 		REPLAY_ICON *IconPtr; // $s0
+	// 		SPRT *icon; // $a2
 	// 		int count; // $s6
 
 		/* begin block 1.1 */
 			// Start line: 1027
 			// Start offset: 0x0003C340
 			// Variables:
-		// 		struct TEXTURE_DETAILS *Icon_texture; // $s1
+		// 		TEXTURE_DETAILS *Icon_texture; // $s1
 		// 		int min_x; // $v1
 		// 		int min_y; // $a0
 
@@ -1571,7 +1571,7 @@ void ShowReplayMenu(void)
 				// Start line: 1327
 				// Start offset: 0x0003CC34
 				// Variables:
-			// 		struct ROUTE_DATA routeData; // stack offset -96
+			// 		ROUTE_DATA routeData; // stack offset -96
 			// 		int road_height; // $s1
 			/* end block 1.1.3 */
 			// End offset: 0x0003CCB0
@@ -1581,7 +1581,7 @@ void ShowReplayMenu(void)
 				// Start line: 1347
 				// Start offset: 0x0003CCBC
 				// Variables:
-			// 		struct VECTOR old_camera; // stack offset -88
+			// 		VECTOR old_camera; // stack offset -88
 			// 		int x; // $s5
 			// 		int z; // $s4
 			// 		int d; // $s3
@@ -1589,14 +1589,14 @@ void ShowReplayMenu(void)
 			// 		char cameraCar; // $a0
 			// 		int dx; // $s1
 			// 		int dz; // $s0
-			// 		struct VECTOR basePos; // stack offset -72
-			// 		struct VECTOR tmpPos; // stack offset -56
+			// 		VECTOR basePos; // stack offset -72
+			// 		VECTOR tmpPos; // stack offset -56
 
 				/* begin block 1.1.4.1 */
 					// Start line: 1372
 					// Start offset: 0x0003CD38
 					// Variables:
-				// 		struct _EVENT *event; // $a1
+				// 		EVENT *event; // $a1
 				/* end block 1.1.4.1 */
 				// End offset: 0x0003CD68
 				// End Line: 1376
@@ -1621,7 +1621,7 @@ void ShowReplayMenu(void)
 					// Start line: 1454
 					// Start offset: 0x0003CF74
 					// Variables:
-				// 		struct ROUTE_DATA routeData; // stack offset -40
+				// 		ROUTE_DATA routeData; // stack offset -40
 				// 		int road_height; // $s1
 				/* end block 1.1.4.4 */
 				// End offset: 0x0003D064
@@ -1855,7 +1855,7 @@ void ControlReplay(void)
 			}
 			else
 			{
-				_EVENT* ev;
+				EVENT* ev;
 				ev = events.track[-2 - cameraCar];
 				
 				basePos.vx = (ev->position).vx;
@@ -2616,7 +2616,7 @@ void ControlReplay(void)
 		// Start line: 1992
 		// Start offset: 0x0003DE60
 		// Variables:
-	// 		struct VECTOR pos; // stack offset -40
+	// 		VECTOR pos; // stack offset -40
 
 		/* begin block 1.1 */
 			// Start line: 1998
@@ -2822,9 +2822,9 @@ void DoAutoDirect(void)
 			// Start line: 2123
 			// Start offset: 0x0003E3A0
 			// Variables:
-		// 		struct _EVENT *event; // $a0
-		// 		struct _CAR_DATA *car; // $a3
-		// 		struct XZPAIR pos; // stack offset -16
+		// 		EVENT *event; // $a0
+		// 		CAR_DATA *car; // $a3
+		// 		XZPAIR pos; // stack offset -16
 
 			/* begin block 1.1.1 */
 				// Start line: 2168
@@ -2858,10 +2858,10 @@ int SelectCameraCar(int current)
 {
 	int count;
 
-	_EVENT* event;
+	EVENT* event;
 	int dz;
 	int dx;
-	_CAR_DATA* car;
+	CAR_DATA* car;
 	XZPAIR pos;
 
 	if (current >= MAX_CARS)
@@ -2964,8 +2964,8 @@ int SelectCameraCar(int current)
 				// Start offset: 0x0003E5D0
 				// Variables:
 			// 		char numEventModels; // $a0
-			// 		struct _EVENT *event; // $v1
-			// 		struct XZPAIR pos; // stack offset -24
+			// 		EVENT *event; // $v1
+			// 		XZPAIR pos; // stack offset -24
 
 				/* begin block 1.1.1.1 */
 					// Start line: 2208
@@ -3052,7 +3052,7 @@ int InvalidCamera(int car_num)
 	// check events
 	if (car_num < -1)
 	{
-		_EVENT* event;
+		EVENT* event;
 		XZPAIR pos;
 
 		numEventModels = 0;
@@ -3194,7 +3194,7 @@ int FirstCamera(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ dist(struct VECTOR *pos1 /*$a0*/, struct VECTOR *pos2 /*$a1*/)
+// int /*$ra*/ dist(VECTOR *pos1 /*$a0*/, VECTOR *pos2 /*$a1*/)
  // line 2289, offset 0x0003eb9c
 	/* begin block 1 */
 		// Start line: 2290
@@ -3243,7 +3243,7 @@ int dist(VECTOR* pos1, VECTOR* pos2)
 		// Start line: 2304
 		// Start offset: 0x0003ECC4
 		// Variables:
-	// 		struct PLAYBACKCAMERA *next; // $a1
+	// 		PLAYBACKCAMERA *next; // $a1
 	// 		int count; // $a2
 	/* end block 1 */
 	// End offset: 0x0003ED7C

--- a/src_rebuild/GAME/C/DIRECTOR.H
+++ b/src_rebuild/GAME/C/DIRECTOR.H
@@ -30,7 +30,7 @@ extern void InitDirectorVariables(); // 0x0003E79C
 
 extern void DeleteCurrentCamera(int CameraCnt); // 0x0003E808
 
-extern void setCamera(struct PLAYBACKCAMERA *Change); // 0x0003E89C
+extern void setCamera(PLAYBACKCAMERA *Change); // 0x0003E89C
 
 extern void EditCamera(int CameraCnt); // 0x0003B2E4
 
@@ -40,13 +40,13 @@ extern void FindNextChange(int CameraCnt); // 0x0003E94C
 
 extern int CheckCameraChange(int CameraCnt); // 0x0003B794
 
-extern void SetPlaybackCamera(struct PLAYBACKCAMERA *camera); // 0x0003EC0C
+extern void SetPlaybackCamera(PLAYBACKCAMERA *camera); // 0x0003EC0C
 
-extern int IsMovingCamera(struct PLAYBACKCAMERA *lastcam, struct PLAYBACKCAMERA *nextcam, int cameracnt); // 0x0003B8C8
+extern int IsMovingCamera(PLAYBACKCAMERA *lastcam, PLAYBACKCAMERA *nextcam, int cameracnt); // 0x0003B8C8
 
 extern void CameraBar(int CameraCnt); // 0x0003BBA8
 
-extern struct PLAYBACKCAMERA * FindFreeCamera(); // 0x0003E9B8
+extern PLAYBACKCAMERA * FindFreeCamera(); // 0x0003E9B8
 
 extern void deleteCamera(int count); // 0x0003E9F8
 

--- a/src_rebuild/GAME/C/DR2ROADS.C
+++ b/src_rebuild/GAME/C/DR2ROADS.C
@@ -47,7 +47,7 @@ int GetSurfaceRoadInfo(DRIVER2_ROAD_INFO* outRoadInfo, int surfId)
 	if(IS_CURVED_SURFACE(surfId))
 	{
 		outRoadInfo->curve = curve = GET_CURVE(surfId);
-		outRoadInfo->ConnectIdx = (short(*)[4])curve->ConnectIdx;
+		outRoadInfo->ConnectIdx = &curve->ConnectIdx;
 		outRoadInfo->NumLanes = curve->NumLanes;
 		outRoadInfo->LaneDirs = curve->LaneDirs;
 		outRoadInfo->AILanes = curve->AILanes;
@@ -56,7 +56,7 @@ int GetSurfaceRoadInfo(DRIVER2_ROAD_INFO* outRoadInfo, int surfId)
 	else if (IS_STRAIGHT_SURFACE(surfId))
 	{
 		outRoadInfo->straight = straight = GET_STRAIGHT(surfId);
-		outRoadInfo->ConnectIdx = (short(*)[4])straight->ConnectIdx;
+		outRoadInfo->ConnectIdx = &straight->ConnectIdx;
 		outRoadInfo->NumLanes = straight->NumLanes;
 		outRoadInfo->LaneDirs = straight->LaneDirs;
 		outRoadInfo->AILanes = straight->AILanes;

--- a/src_rebuild/GAME/C/DR2ROADS.C
+++ b/src_rebuild/GAME/C/DR2ROADS.C
@@ -139,8 +139,8 @@ void ProcessCurvesDriver2Lump(char *lump_file, int lump_size)
 			// Start offset: 0x0001375C
 			// Variables:
 		// 		int loop; // $v1
-		// 		struct OLD_DRIVER2_JUNCTION *old; // $a1
-		// 		struct DRIVER2_JUNCTION *p; // $a0
+		// 		OLD_DRIVER2_JUNCTION *old; // $a1
+		// 		DRIVER2_JUNCTION *p; // $a0
 
 			/* begin block 1.1.1 */
 				// Start line: 107
@@ -203,14 +203,14 @@ void ProcessJunctionsDriver2Lump(char *lump_file, int lump_size, int fix)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MapHeight(struct VECTOR *pos /*$s0*/)
+// int /*$ra*/ MapHeight(VECTOR *pos /*$s0*/)
  // line 146, offset 0x000137cc
 	/* begin block 1 */
 		// Start line: 147
 		// Start offset: 0x000137CC
 		// Variables:
 	// 		int height; // $v0
-	// 		struct _sdPlane *plane; // $v0
+	// 		sdPlane *plane; // $v0
 	/* end block 1 */
 	// End offset: 0x0001380C
 	// End Line: 162
@@ -228,7 +228,7 @@ void ProcessJunctionsDriver2Lump(char *lump_file, int lump_size, int fix)
 // [D] [T]
 int MapHeight(VECTOR *pos)
 {
-	_sdPlane *plane;
+	sdPlane *plane;
 
 	plane = sdGetCell(pos);
 
@@ -242,7 +242,7 @@ int MapHeight(VECTOR *pos)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ FindSurfaceD2(struct VECTOR *pos /*$s0*/, struct VECTOR *normal /*$s1*/, struct VECTOR *out /*$s3*/, struct _sdPlane **plane /*$s2*/)
+// int /*$ra*/ FindSurfaceD2(VECTOR *pos /*$s0*/, VECTOR *normal /*$s1*/, VECTOR *out /*$s3*/, sdPlane **plane /*$s2*/)
  // line 164, offset 0x00012ef4
 	/* begin block 1 */
 		// Start line: 328
@@ -250,7 +250,7 @@ int MapHeight(VECTOR *pos)
 	// End Line: 329
 
 // [D] [T]
-int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, _sdPlane **plane)
+int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, sdPlane **plane)
 {
 	*plane = sdGetCell(pos);
 	out->vx = pos->vx;
@@ -292,7 +292,7 @@ int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, _sdPlane **plane)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ sdHeightOnPlane(struct VECTOR *pos /*$t0*/, struct _sdPlane *plane /*$a1*/)
+// int /*$ra*/ sdHeightOnPlane(VECTOR *pos /*$t0*/, sdPlane *plane /*$a1*/)
  // line 205, offset 0x000130d4
 	/* begin block 1 */
 		// Start line: 206
@@ -304,7 +304,7 @@ int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, _sdPlane **plane)
 			// Variables:
 		// 		int angle; // $v0
 		// 		int i; // $v0
-		// 		struct DRIVER2_CURVE *curve; // $s0
+		// 		DRIVER2_CURVE *curve; // $s0
 		/* end block 1.1 */
 		// End offset: 0x0001319C
 		// End Line: 228
@@ -337,7 +337,7 @@ int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, _sdPlane **plane)
 	// End Line: 411
 
 // [D] [T]
-int sdHeightOnPlane(VECTOR *pos, _sdPlane *plane)
+int sdHeightOnPlane(VECTOR *pos, sdPlane *plane)
 {
 	long angle;
 	int i, d;
@@ -382,13 +382,13 @@ int sdHeightOnPlane(VECTOR *pos, _sdPlane *plane)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GetSurfaceIndex(struct VECTOR *pos /*$a0*/)
+// int /*$ra*/ GetSurfaceIndex(VECTOR *pos /*$a0*/)
  // line 250, offset 0x0001380c
 	/* begin block 1 */
 		// Start line: 252
 		// Start offset: 0x0001380C
 		// Variables:
-	// 		struct _sdPlane *plane; // $v0
+	// 		sdPlane *plane; // $v0
 	/* end block 1 */
 	// End offset: 0x00013848
 	// End Line: 260
@@ -416,7 +416,7 @@ int sdHeightOnPlane(VECTOR *pos, _sdPlane *plane)
 // [D] [T]
 int GetSurfaceIndex(VECTOR *pos)
 {
-	_sdPlane *plane = sdGetCell(pos);
+	sdPlane *plane = sdGetCell(pos);
 
 	if (plane == NULL)
 		return -32;
@@ -428,13 +428,13 @@ int GetSurfaceIndex(VECTOR *pos)
 
 // decompiled code
 // original method signature: 
-// struct _sdPlane * /*$ra*/ FindRoadInBSP(struct _sdNode *node /*$s0*/, struct _sdPlane *base /*$s1*/)
+// sdPlane * /*$ra*/ FindRoadInBSP(_sdNode *node /*$s0*/, sdPlane *base /*$s1*/)
  // line 266, offset 0x000138f0
 	/* begin block 1 */
 		// Start line: 268
 		// Start offset: 0x00013908
 		// Variables:
-	// 		struct _sdPlane *plane; // $v0
+	// 		sdPlane *plane; // $v0
 	/* end block 1 */
 	// End offset: 0x00013980
 	// End Line: 293
@@ -450,9 +450,9 @@ int GetSurfaceIndex(VECTOR *pos)
 	// End Line: 1464
 
 // [D] [T]
-_sdPlane * FindRoadInBSP(_sdNode *node, _sdPlane *base)
+sdPlane * FindRoadInBSP(_sdNode *node, sdPlane *base)
 {
-	_sdPlane *plane;
+	sdPlane *plane;
 
 	while (true)
 	{
@@ -477,17 +477,17 @@ _sdPlane * FindRoadInBSP(_sdNode *node, _sdPlane *base)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ RoadInCell(struct VECTOR *pos /*$s5*/)
+// int /*$ra*/ RoadInCell(VECTOR *pos /*$s5*/)
  // line 295, offset 0x0001322c
 	/* begin block 1 */
 		// Start line: 296
 		// Start offset: 0x0001322C
 		// Variables:
 	// 		char *buffer; // $s2
-	// 		struct XYPAIR cellPos; // stack offset -48
-	// 		struct XYPAIR cell; // stack offset -40
+	// 		XYPAIR cellPos; // stack offset -48
+	// 		XYPAIR cell; // stack offset -40
 	// 		short *surface; // $a0
-	// 		struct _sdPlane *plane; // $s0
+	// 		sdPlane *plane; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 331
@@ -495,7 +495,7 @@ _sdPlane * FindRoadInBSP(_sdNode *node, _sdPlane *base)
 			// Variables:
 		// 		int moreLevels; // $s3
 		// 		short *check; // $s1
-		// 		struct _sdPlane *base; // $s4
+		// 		sdPlane *base; // $s4
 		/* end block 1.1 */
 		// End offset: 0x000133E4
 		// End Line: 372
@@ -523,10 +523,10 @@ int RoadInCell(VECTOR *pos)
 {
 	int moreLevels;
 	short sVar2;
-	_sdPlane *plane;
+	sdPlane *plane;
 	short *check;
 	short *buffer;
-	struct XYPAIR cellPos;
+	XYPAIR cellPos;
 
 	cellPos.x = pos->vx - 512;
 	cellPos.y = pos->vz - 512;
@@ -553,14 +553,14 @@ int RoadInCell(VECTOR *pos)
 
 				if (*check & 0x4000)
 				{
-					plane = FindRoadInBSP((_sdNode *)((int)buffer + (*check & 0x3fff) * sizeof(_sdNode) + buffer[3]), (_sdPlane *)((int)buffer + buffer[1]));
+					plane = FindRoadInBSP((_sdNode *)((int)buffer + (*check & 0x3fff) * sizeof(_sdNode) + buffer[3]), (sdPlane *)((int)buffer + buffer[1]));
 
 					if (plane != NULL)
 						break;
 				}
 				else
 				{
-					plane = (_sdPlane *)((int)buffer + buffer[1]) + *check;
+					plane = (sdPlane *)((int)buffer + buffer[1]) + *check;
 
 					if (plane->surface > 31)
 						break;
@@ -571,7 +571,7 @@ int RoadInCell(VECTOR *pos)
 		}
 		else if ((*check & 0xE000) == 0)
 		{
-			plane = (_sdPlane *)((int)buffer + *check * sizeof(_sdPlane) + buffer[1]);
+			plane = (sdPlane *)((int)buffer + *check * sizeof(sdPlane) + buffer[1]);
 		}
 		else
 			plane = NULL;
@@ -593,7 +593,7 @@ int RoadInCell(VECTOR *pos)
 
 // decompiled code
 // original method signature: 
-// struct _sdPlane * /*$ra*/ sdGetCell(struct VECTOR *pos /*$s3*/)
+// sdPlane * /*$ra*/ sdGetCell(VECTOR *pos /*$s3*/)
  // line 400, offset 0x0001346c
 	/* begin block 1 */
 		// Start line: 401
@@ -602,9 +602,9 @@ int RoadInCell(VECTOR *pos)
 	// 		char *buffer; // $s1
 	// 		short *surface; // $s0
 	// 		int nextLevel; // $s2
-	// 		struct _sdPlane *plane; // $a1
-	// 		struct XYPAIR cell; // stack offset -40
-	// 		struct XYPAIR cellPos; // stack offset -32
+	// 		sdPlane *plane; // $a1
+	// 		XYPAIR cell; // stack offset -40
+	// 		XYPAIR cellPos; // stack offset -32
 
 		/* begin block 1.1 */
 			// Start line: 441
@@ -645,10 +645,10 @@ int RoadInCell(VECTOR *pos)
 int sdLevel = 0; // pathfinding value
 
 // [D] [T]
-_sdPlane * sdGetCell(VECTOR *pos)
+sdPlane * sdGetCell(VECTOR *pos)
 {
 	int nextLevel;
-	_sdPlane *plane;
+	sdPlane *plane;
 	short *surface;
 	short *BSPSurface;
 	short *buffer;
@@ -707,7 +707,7 @@ _sdPlane * sdGetCell(VECTOR *pos)
 				surface = BSPSurface;
 			} while (nextLevel);
 
-			plane = (_sdPlane *)((int)buffer + *BSPSurface * sizeof(_sdPlane) + buffer[1]);
+			plane = (sdPlane *)((int)buffer + *BSPSurface * sizeof(sdPlane) + buffer[1]);
 
 			if ((((uint)plane & 3) == 0) && (*(int *)plane != -1)) 
 			{
@@ -731,7 +731,7 @@ _sdPlane * sdGetCell(VECTOR *pos)
 
 // decompiled code
 // original method signature: 
-// short * /*$ra*/ sdGetBSP(struct _sdNode *node /*$a3*/, struct XYPAIR *pos /*$a1*/)
+// short * /*$ra*/ sdGetBSP(_sdNode *node /*$a3*/, XYPAIR *pos /*$a1*/)
  // line 505, offset 0x00013848
 	/* begin block 1 */
 		// Start line: 506

--- a/src_rebuild/GAME/C/DR2ROADS.H
+++ b/src_rebuild/GAME/C/DR2ROADS.H
@@ -74,17 +74,17 @@ extern void ProcessJunctionsDriver2Lump(char *lump_file, int lump_size, int fix)
 
 extern int MapHeight(VECTOR *pos); // 0x000137CC
 
-extern int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, _sdPlane **plane); // 0x00012EF4
+extern int FindSurfaceD2(VECTOR *pos, VECTOR *normal, VECTOR *out, sdPlane **plane); // 0x00012EF4
 
-extern int sdHeightOnPlane(VECTOR *pos, _sdPlane *plane); // 0x000130D4
+extern int sdHeightOnPlane(VECTOR *pos, sdPlane *plane); // 0x000130D4
 
 extern int GetSurfaceIndex(VECTOR *pos); // 0x0001380C
 
-extern _sdPlane * FindRoadInBSP(_sdNode *node, _sdPlane *base); // 0x000138F0
+extern sdPlane * FindRoadInBSP(_sdNode *node, sdPlane *base); // 0x000138F0
 
 extern int RoadInCell(VECTOR *pos); // 0x0001322C
 
-extern _sdPlane * sdGetCell(VECTOR *pos); // 0x0001346C
+extern sdPlane * sdGetCell(VECTOR *pos); // 0x0001346C
 
 extern short * sdGetBSP(_sdNode *node, XYPAIR *pos); // 0x00013848
 

--- a/src_rebuild/GAME/C/DRAW.C
+++ b/src_rebuild/GAME/C/DRAW.C
@@ -125,7 +125,7 @@ _pct plotContext;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ addSubdivSpriteShadow(struct POLYFT4LIT *src /*$t3*/, struct SVECTOR *verts /*$t2*/, int z /*$a2*/)
+// void /*$ra*/ addSubdivSpriteShadow(POLYFT4LIT *src /*$t3*/, SVECTOR *verts /*$t2*/, int z /*$a2*/)
  // line 651, offset 0x0003ed7c
 	/* begin block 1 */
 		// Start line: 652
@@ -133,7 +133,7 @@ _pct plotContext;
 		// Variables:
 	// 		unsigned long word0; // $a0
 	// 		unsigned long vidx; // $t1
-	// 		struct _pct *pc; // $t0
+	// 		_pct *pc; // $t0
 	// 		int w; // $s0
 	/* end block 1 */
 	// End offset: 0x0003EF64
@@ -196,8 +196,8 @@ void addSubdivSpriteShadow(POLYFT4* src, SVECTOR* verts, int z)
 		// Start line: 676
 		// Start offset: 0x0003EF64
 		// Variables:
-	// 		struct XZPAIR near; // stack offset -80
-	// 		struct PACKED_CELL_OBJECT **list; // stack offset -64
+	// 		XZPAIR near; // stack offset -80
+	// 		PACKED_CELL_OBJECT **list; // stack offset -64
 	// 		unsigned long spriteColour; // stack offset -60
 	// 		int numShadows; // stack offset -56
 
@@ -205,7 +205,7 @@ void addSubdivSpriteShadow(POLYFT4* src, SVECTOR* verts, int z)
 			// Start line: 676
 			// Start offset: 0x0003EF64
 			// Variables:
-		// 		struct SVECTOR result; // stack offset -72
+		// 		SVECTOR result; // stack offset -72
 		// 		unsigned char lightLevel; // $a1
 		/* end block 1.1 */
 		// End offset: 0x0003F0FC
@@ -224,8 +224,8 @@ void addSubdivSpriteShadow(POLYFT4* src, SVECTOR* verts, int z)
 			// Start line: 743
 			// Start offset: 0x0003F1F0
 			// Variables:
-		// 		struct PACKED_CELL_OBJECT *ppco; // $fp
-		// 		struct MODEL *model; // $s4
+		// 		PACKED_CELL_OBJECT *ppco; // $fp
+		// 		MODEL *model; // $s4
 		// 		int z; // stack offset -52
 		// 		int yang; // $a0
 
@@ -240,8 +240,8 @@ void addSubdivSpriteShadow(POLYFT4* src, SVECTOR* verts, int z)
 				// Start line: 776
 				// Start offset: 0x0003F2F0
 				// Variables:
-			// 		struct POLYFT4LIT *src; // $s0
-			// 		struct SVECTOR *verts; // $s3
+			// 		POLYFT4LIT *src; // $s0
+			// 		SVECTOR *verts; // $s3
 			// 		int i; // $s1
 
 				/* begin block 1.3.2.1 */
@@ -435,7 +435,7 @@ void DrawSprites(PACKED_CELL_OBJECT** sprites, int numFound)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ DrawAllBuildings(unsigned long *objects /*$t3*/, int num_buildings /*$s5*/, struct DB *disp /*$a2*/)
+// int /*$ra*/ DrawAllBuildings(unsigned long *objects /*$t3*/, int num_buildings /*$s5*/, DB *disp /*$a2*/)
 // line 2053, offset 0x000411f4
 /* begin block 1 */
 // Start line: 2054
@@ -444,8 +444,8 @@ void DrawSprites(PACKED_CELL_OBJECT** sprites, int numFound)
 // 		int i; // $s3
 // 		int model_number; // $v0
 // 		int prev_mat; // $s4
-// 		struct MODEL *model; // $a0
-// 		struct CELL_OBJECT *building; // $s0
+// 		MODEL *model; // $a0
+// 		CELL_OBJECT *building; // $s0
 
 /* begin block 1.1 */
 // Start line: 2091
@@ -567,8 +567,8 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 		// Start line: 884
 		// Start offset: 0x0003F6B0
 		// Variables:
-	// 		struct CELL_ITERATOR ci; // stack offset -184
-	// 		struct PACKED_CELL_OBJECT *ppco; // $s0
+	// 		CELL_ITERATOR ci; // stack offset -184
+	// 		PACKED_CELL_OBJECT *ppco; // $s0
 	// 		int i; // $s1
 	// 		int dir; // $s7
 	// 		int cellxpos; // $a0
@@ -581,7 +581,7 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 	// 		int tiles_found; // stack offset -100
 	// 		int other_models_found; // stack offset -96
 	// 		int anim_objs_found; // $s6
-	// 		struct MATRIX mRotStore; // stack offset -160
+	// 		MATRIX mRotStore; // stack offset -160
 	// 		int rightcos; // stack offset -92
 	// 		int rightsin; // stack offset -88
 	// 		int leftcos; // stack offset -84
@@ -597,7 +597,7 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 			// Start line: 967
 			// Start offset: 0x0003F964
 			// Variables:
-		// 		struct MODEL *model; // $s2
+		// 		MODEL *model; // $s2
 
 			/* begin block 1.1.1 */
 				// Start line: 975
@@ -609,19 +609,19 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 					// Start line: 986
 					// Start offset: 0x0003FA10
 					// Variables:
-				// 		struct CELL_OBJECT *cop; // $a2
+				// 		CELL_OBJECT *cop; // $a2
 
 					/* begin block 1.1.1.1.1 */
 						// Start line: 884
 						// Start offset: 0x0003FA10
 						// Variables:
-					// 		struct PACKED_CELL_OBJECT *ppco; // $s0
+					// 		PACKED_CELL_OBJECT *ppco; // $s0
 
 						/* begin block 1.1.1.1.1.1 */
 							// Start line: 884
 							// Start offset: 0x0003FA10
 							// Variables:
-						// 		struct CELL_OBJECT *pco; // $a1
+						// 		CELL_OBJECT *pco; // $a1
 						/* end block 1.1.1.1.1.1 */
 						// End offset: 0x0003FAB8
 						// End Line: 884
@@ -636,19 +636,19 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 					// Start line: 993
 					// Start offset: 0x0003FAF4
 					// Variables:
-				// 		struct CELL_OBJECT *cop; // $a2
+				// 		CELL_OBJECT *cop; // $a2
 
 					/* begin block 1.1.1.2.1 */
 						// Start line: 884
 						// Start offset: 0x0003FAF4
 						// Variables:
-					// 		struct PACKED_CELL_OBJECT *ppco; // $s0
+					// 		PACKED_CELL_OBJECT *ppco; // $s0
 
 						/* begin block 1.1.1.2.1.1 */
 							// Start line: 884
 							// Start offset: 0x0003FAF4
 							// Variables:
-						// 		struct CELL_OBJECT *pco; // $a1
+						// 		CELL_OBJECT *pco; // $a1
 						/* end block 1.1.1.2.1.1 */
 						// End offset: 0x0003FB9C
 						// End Line: 884
@@ -672,19 +672,19 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 					// Start line: 1018
 					// Start offset: 0x0003FD0C
 					// Variables:
-				// 		struct CELL_OBJECT *cop; // $a2
+				// 		CELL_OBJECT *cop; // $a2
 
 					/* begin block 1.1.1.4.1 */
 						// Start line: 884
 						// Start offset: 0x0003FD0C
 						// Variables:
-					// 		struct PACKED_CELL_OBJECT *ppco; // $s0
+					// 		PACKED_CELL_OBJECT *ppco; // $s0
 
 						/* begin block 1.1.1.4.1.1 */
 							// Start line: 884
 							// Start offset: 0x0003FD0C
 							// Variables:
-						// 		struct CELL_OBJECT *pco; // $a1
+						// 		CELL_OBJECT *pco; // $a1
 						/* end block 1.1.1.4.1.1 */
 						// End offset: 0x0003FDB4
 						// End Line: 884
@@ -699,19 +699,19 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 					// Start line: 1032
 					// Start offset: 0x0003FE34
 					// Variables:
-				// 		struct CELL_OBJECT *cop; // $a2
+				// 		CELL_OBJECT *cop; // $a2
 
 					/* begin block 1.1.1.5.1 */
 						// Start line: 884
 						// Start offset: 0x0003FE34
 						// Variables:
-					// 		struct PACKED_CELL_OBJECT *ppco; // $s0
+					// 		PACKED_CELL_OBJECT *ppco; // $s0
 
 						/* begin block 1.1.1.5.1.1 */
 							// Start line: 884
 							// Start offset: 0x0003FE34
 							// Variables:
-						// 		struct CELL_OBJECT *pco; // $a1
+						// 		CELL_OBJECT *pco; // $a1
 						/* end block 1.1.1.5.1.1 */
 						// End offset: 0x0003FEDC
 						// End Line: 884
@@ -746,8 +746,8 @@ int DrawAllBuildings(CELL_OBJECT** objects, int num_buildings)
 			// Start line: 1089
 			// Start offset: 0x00040138
 			// Variables:
-		// 		struct VECTOR newpos; // stack offset -128
-		// 		struct CELL_OBJECT *cop; // $s0
+		// 		VECTOR newpos; // stack offset -128
+		// 		CELL_OBJECT *cop; // $s0
 		/* end block 1.4 */
 		// End offset: 0x00040138
 		// End Line: 1090
@@ -1362,8 +1362,8 @@ void Set_Inv_CameraMatrix(void)
 		// Variables:
 	// 		int i; // $s1
 	// 		int j; // $a0
-	// 		struct SVECTOR ang; // stack offset -56
-	// 		struct MATRIX mat; // stack offset -48
+	// 		SVECTOR ang; // stack offset -56
+	// 		MATRIX mat; // stack offset -48
 	/* end block 1 */
 	// End offset: 0x000418BC
 	// End Line: 1341
@@ -1413,7 +1413,7 @@ void CalcObjectRotationMatrices(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlotMDL_less_than_128(struct MODEL *model /*$a0*/)
+// void /*$ra*/ PlotMDL_less_than_128(MODEL *model /*$a0*/)
  // line 1344, offset 0x000418bc
 	/* begin block 1 */
 		// Start line: 5018
@@ -1551,7 +1551,7 @@ void ProcessMapLump(char* lump_ptr, int lump_size)
 	// 		int z; // $s1
 	// 		int xd; // $a0
 	// 		int zd; // $v1
-	// 		struct _CAR_DATA (*cars_to_draw[20]); // stack offset -112
+	// 		CAR_DATA (*cars_to_draw[20]); // stack offset -112
 	// 		int num_cars_to_draw; // $s4
 	// 		static int car_distance[20]; // offset 0x0
 	// 		static int temp; // offset 0x0
@@ -1560,7 +1560,7 @@ void ProcessMapLump(char* lump_ptr, int lump_size)
 			// Start line: 1712
 			// Start offset: 0x000407D8
 			// Variables:
-		// 		struct _CAR_DATA *lcp; // $s0
+		// 		CAR_DATA *lcp; // $s0
 
 			/* begin block 1.1.1 */
 				// Start line: 1738
@@ -1584,7 +1584,7 @@ void ProcessMapLump(char* lump_ptr, int lump_size)
 				// Start line: 1762
 				// Start offset: 0x00040920
 				// Variables:
-			// 		struct _CAR_DATA *car; // $t4
+			// 		CAR_DATA *car; // $t4
 			// 		int dist; // $t0
 			// 		int j; // $a3
 			/* end block 1.2.1 */
@@ -1628,12 +1628,12 @@ int num_cars_drawn = 0;
 void DrawAllTheCars(int view)
 {
 	static int car_distance[MAX_CARS]; // offset 0x0
-	_CAR_DATA* cars_to_draw[MAX_CARS];
+	CAR_DATA* cars_to_draw[MAX_CARS];
 
 	int dx, dz;
 	int dist;
 	int i, j;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	int num_cars_to_draw;
 	int spacefree;
 	
@@ -1724,14 +1724,14 @@ void DrawAllTheCars(int view)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlotBuildingModelSubdivNxN(struct MODEL *model /*$t0*/, int rot /*stack 4*/, struct _pct *pc /*$s2*/, int n /*stack 12*/)
+// void /*$ra*/ PlotBuildingModelSubdivNxN(MODEL *model /*$t0*/, int rot /*stack 4*/, _pct *pc /*$s2*/, int n /*stack 12*/)
  // line 1857, offset 0x00040a90
 	/* begin block 1 */
 		// Start line: 1858
 		// Start offset: 0x00040A90
 		// Variables:
-	// 		struct SVECTOR *verts; // $s4
-	// 		struct PL_POLYFT4 *polys; // $s1
+	// 		SVECTOR *verts; // $s4
+	// 		PL_POLYFT4 *polys; // $s1
 	// 		int i; // $s7
 	// 		int asdf; // $fp
 
@@ -1786,7 +1786,7 @@ void DrawAllTheCars(int view)
 						// Start line: 1983
 						// Start offset: 0x00041060
 						// Variables:
-					// 		struct POLY_FT4 *prims; // $t2
+					// 		POLY_FT4 *prims; // $t2
 					// 		int uv0; // $v1
 					// 		int uv1; // $a2
 					// 		int uv2; // $t3
@@ -2009,7 +2009,7 @@ void PlotBuildingModelSubdivNxN(MODEL* model, int rot, _pct* pc, int n)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RenderModel(struct MODEL *model /*$s2*/, struct MATRIX *matrix /*$a1*/, struct VECTOR *pos /*$a2*/, int zBias /*$s0*/, int flags /*stack 16*/)
+// void /*$ra*/ RenderModel(MODEL *model /*$s2*/, MATRIX *matrix /*$a1*/, VECTOR *pos /*$a2*/, int zBias /*$s0*/, int flags /*stack 16*/)
  // line 2181, offset 0x0004143c
 	/* begin block 1 */
 		// Start line: 2182
@@ -2022,7 +2022,7 @@ void PlotBuildingModelSubdivNxN(MODEL* model, int rot, _pct* pc, int n)
 			// Start line: 2191
 			// Start offset: 0x00041468
 			// Variables:
-		// 		struct MATRIX comb; // stack offset -48
+		// 		MATRIX comb; // stack offset -48
 		/* end block 1.1 */
 		// End offset: 0x00041498
 		// End Line: 2196
@@ -2101,7 +2101,7 @@ void RenderModel(MODEL* model, MATRIX* matrix, VECTOR* pos, int zBias, int flags
 
 // decompiled code
 // original method signature: 
-// unsigned long /*$ra*/ normalIndex(struct SVECTOR *verts /*$a0*/, unsigned int vidx /*$a1*/)
+// unsigned long /*$ra*/ normalIndex(SVECTOR *verts /*$a0*/, unsigned int vidx /*$a1*/)
  // line 2267, offset 0x000415e4
 	/* begin block 1 */
 		// Start line: 2268
@@ -2111,8 +2111,8 @@ void RenderModel(MODEL* model, MATRIX* matrix, VECTOR* pos, int zBias, int flags
 	// 		int nx; // $t4
 	// 		int ny; // $v1
 	// 		int nz; // $a2
-	// 		struct SVECTOR p; // stack offset -16
-	// 		struct SVECTOR q; // stack offset -8
+	// 		SVECTOR p; // stack offset -16
+	// 		SVECTOR q; // stack offset -8
 
 		/* begin block 1.1 */
 			// Start line: 2268

--- a/src_rebuild/GAME/C/DRAW.H
+++ b/src_rebuild/GAME/C/DRAW.H
@@ -45,7 +45,7 @@ extern int num_cars_drawn;
 
 extern char CurrentPVS[444];
 
-extern void addSubdivSpriteShadow(struct POLYFT4*src, struct SVECTOR *verts, int z); // 0x0003ED7C
+extern void addSubdivSpriteShadow(POLYFT4*src, SVECTOR *verts, int z); // 0x0003ED7C
 
 extern void DrawMapPSX(int *comp_val); // 0x0003F6B0
 
@@ -61,13 +61,13 @@ extern void Set_Inv_CameraMatrix(); // 0x000417DC
 
 extern void CalcObjectRotationMatrices(); // 0x00041814
 
-extern void PlotMDL_less_than_128(struct MODEL *model); // 0x000418BC
+extern void PlotMDL_less_than_128(MODEL *model); // 0x000418BC
 
 extern void ProcessMapLump(char *lump_ptr, int lump_size); // 0x00040608
 
 extern void DrawAllTheCars(int view); // 0x000407D8
 
-extern void PlotBuildingModelSubdivNxN(MODEL *model, int rot, struct _pct *pc, int n); // 0x00040A90
+extern void PlotBuildingModelSubdivNxN(MODEL *model, int rot, _pct *pc, int n); // 0x00040A90
 
 extern void RenderModel(MODEL *model, MATRIX *matrix, VECTOR *pos, int zBias, int flags, int subdiv, int nrot); // 0x0004143C
 

--- a/src_rebuild/GAME/C/DRIVINGGAMES.C
+++ b/src_rebuild/GAME/C/DRIVINGGAMES.C
@@ -132,8 +132,8 @@ void InitDrivingGames(void)
 		// Start line: 292
 		// Start offset: 0x0004326C
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $a2
-	// 		struct VECTOR vel; // stack offset -96
+	// 		CAR_DATA *cp; // $a2
+	// 		VECTOR vel; // stack offset -96
 	// 		int i; // $s3
 	// 		int j; // $v1
 	// 		int k; // $a0
@@ -144,8 +144,8 @@ void InitDrivingGames(void)
 			// Start line: 351
 			// Start offset: 0x00043354
 			// Variables:
-		// 		struct VECTOR pos1; // stack offset -80
-		// 		struct VECTOR pos2; // stack offset -64
+		// 		VECTOR pos1; // stack offset -80
+		// 		VECTOR pos2; // stack offset -64
 		// 		int x; // $t0
 		// 		int z; // $a1
 		// 		int r; // $v0
@@ -159,7 +159,7 @@ void InitDrivingGames(void)
 			// Start line: 435
 			// Start offset: 0x00043700
 			// Variables:
-		// 		struct VECTOR pos; // stack offset -80
+		// 		VECTOR pos; // stack offset -80
 		/* end block 1.2 */
 		// End offset: 0x00043800
 		// End Line: 456
@@ -409,7 +409,7 @@ LAB_00043668:
 		// Start line: 479
 		// Start offset: 0x000438DC
 		// Variables:
-	// 		struct VECTOR wpos; // stack offset -24
+	// 		VECTOR wpos; // stack offset -24
 	// 		int i; // $s0
 	/* end block 1 */
 	// End offset: 0x000439FC
@@ -495,14 +495,14 @@ void DrawDrivingGames(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CarConeCollision(struct VECTOR *pPos /*$a0*/, int car /*$a1*/)
+// int /*$ra*/ CarConeCollision(VECTOR *pPos /*$a0*/, int car /*$a1*/)
  // line 545, offset 0x000439fc
 	/* begin block 1 */
 		// Start line: 546
 		// Start offset: 0x000439FC
 		// Variables:
-	// 		struct CDATA2D cd[2]; // stack offset -216
-	// 		struct _CAR_DATA *cp1; // $t0
+	// 		CDATA2D cd[2]; // stack offset -216
+	// 		CAR_DATA *cp1; // $t0
 	// 		int carLength[2]; // stack offset -16
 
 		/* begin block 1.1 */
@@ -561,13 +561,13 @@ int CarConeCollision(VECTOR *pPos, int car)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetSmashedCone(int cone /*$s1*/, struct VECTOR *velocity /*$a1*/, int player /*$s2*/, int side /*$a3*/)
+// void /*$ra*/ SetSmashedCone(int cone /*$s1*/, VECTOR *velocity /*$a1*/, int player /*$s2*/, int side /*$a3*/)
  // line 578, offset 0x00043ae8
 	/* begin block 1 */
 		// Start line: 579
 		// Start offset: 0x00043AE8
 		// Variables:
-	// 		struct SMASHED_CONE *sc; // $s0
+	// 		SMASHED_CONE *sc; // $s0
 	// 		int chan; // $s0
 	/* end block 1 */
 	// End offset: 0x00043CE0
@@ -730,8 +730,8 @@ void MoveSmashedCones(void)
 		// Start line: 664
 		// Start offset: 0x00044168
 		// Variables:
-	// 		struct SMASHED_CONE *sc; // $s0
-	// 		struct VECTOR wpos; // stack offset -40
+	// 		SMASHED_CONE *sc; // $s0
+	// 		VECTOR wpos; // stack offset -40
 	// 		int i; // $s1
 	/* end block 1 */
 	// End offset: 0x00044228
@@ -794,14 +794,14 @@ void DrawSmashedCones(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawCone(struct VECTOR *position /*$s0*/, int cone /*$s1*/)
+// void /*$ra*/ DrawCone(VECTOR *position /*$s0*/, int cone /*$s1*/)
  // line 703, offset 0x00044034
 	/* begin block 1 */
 		// Start line: 704
 		// Start offset: 0x00044034
 		// Variables:
-	// 		struct MATRIX matrix; // stack offset -64
-	// 		struct VECTOR pos; // stack offset -32
+	// 		MATRIX matrix; // stack offset -64
+	// 		VECTOR pos; // stack offset -32
 
 		/* begin block 1.1 */
 			// Start line: 713
@@ -874,15 +874,15 @@ void DrawCone(VECTOR *position, int cone)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawSmashedCone(struct SMASHED_CONE *sc /*$s0*/, struct VECTOR *wpos /*$s1*/)
+// void /*$ra*/ DrawSmashedCone(SMASHED_CONE *sc /*$s0*/, VECTOR *wpos /*$s1*/)
  // line 730, offset 0x00043dec
 	/* begin block 1 */
 		// Start line: 731
 		// Start offset: 0x00043DEC
 		// Variables:
-	// 		struct MATRIX object_matrix; // stack offset -64
-	// 		struct MATRIX *finalmatrix; // $s2
-	// 		struct VECTOR pos; // stack offset -32
+	// 		MATRIX object_matrix; // stack offset -64
+	// 		MATRIX *finalmatrix; // $s2
+	// 		VECTOR pos; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x00043F34
 	// End Line: 750
@@ -932,13 +932,13 @@ void DrawSmashedCone(SMASHED_CONE *sc, VECTOR *wpos)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetConePos(int cone /*$a0*/, struct VECTOR *pos /*$t2*/, int side /*$a2*/)
+// void /*$ra*/ GetConePos(int cone /*$a0*/, VECTOR *pos /*$t2*/, int side /*$a2*/)
  // line 757, offset 0x00043f34
 	/* begin block 1 */
 		// Start line: 758
 		// Start offset: 0x00043F34
 		// Variables:
-	// 		struct VECTOR offset; // stack offset -16
+	// 		VECTOR offset; // stack offset -16
 	// 		int x; // $t3
 	// 		int z; // $t4
 	// 		int r; // $v1

--- a/src_rebuild/GAME/C/E3STUFF.C
+++ b/src_rebuild/GAME/C/E3STUFF.C
@@ -80,11 +80,11 @@ void ShowHiresScreens(char **names, int delay, int wait)
 		// Start line: 172
 		// Start offset: 0x00044244
 		// Variables:
-	// 		struct DISPENV disp; // stack offset -488
-	// 		struct DRAWENV draw; // stack offset -464
-	// 		struct SPRT prims[6]; // stack offset -368
-	// 		struct POLY_FT3 nulls[6]; // stack offset -248
-	// 		struct RECT rect; // stack offset -56
+	// 		DISPENV disp; // stack offset -488
+	// 		DRAWENV draw; // stack offset -464
+	// 		SPRT prims[6]; // stack offset -368
+	// 		POLY_FT3 nulls[6]; // stack offset -248
+	// 		RECT rect; // stack offset -56
 	// 		unsigned long ot; // stack offset -48
 	// 		int i; // $t5
 	// 		int col; // $s1
@@ -228,11 +228,11 @@ void FadeInHiresScreen(char *filename)
 		// Start line: 260
 		// Start offset: 0x000445F4
 		// Variables:
-	// 		struct DISPENV disp; // stack offset -496
-	// 		struct DRAWENV draw; // stack offset -472
-	// 		struct SPRT prims[6]; // stack offset -376
-	// 		struct POLY_FT3 nulls[6]; // stack offset -256
-	// 		struct RECT rect; // stack offset -64
+	// 		DISPENV disp; // stack offset -496
+	// 		DRAWENV draw; // stack offset -472
+	// 		SPRT prims[6]; // stack offset -376
+	// 		POLY_FT3 nulls[6]; // stack offset -256
+	// 		RECT rect; // stack offset -64
 	// 		unsigned long ot; // stack offset -56
 	// 		int i; // $t5
 	// 		int col; // $s1
@@ -360,7 +360,7 @@ void FadeOutHiresScreen(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupDefDrawEnv(struct DRAWENV *env /*$a0*/, int x /*$a1*/, int y /*$a2*/, int w /*$a3*/, int h /*stack 16*/)
+// void /*$ra*/ SetupDefDrawEnv(DRAWENV *env /*$a0*/, int x /*$a1*/, int y /*$a2*/, int w /*$a3*/, int h /*stack 16*/)
  // line 325, offset 0x00044e40
 	/* begin block 1 */
 		// Start line: 650
@@ -380,7 +380,7 @@ void SetupDefDrawEnv(DRAWENV *env, int x, int y, int w, int h)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupDefDispEnv(struct DISPENV *env /*$s0*/, int x /*$a1*/, int y /*$a2*/, int w /*$a3*/, int h /*stack 16*/)
+// void /*$ra*/ SetupDefDispEnv(DISPENV *env /*$s0*/, int x /*$a1*/, int y /*$a2*/, int w /*$a3*/, int h /*stack 16*/)
  // line 350, offset 0x00044da0
 	/* begin block 1 */
 		// Start line: 1213
@@ -429,9 +429,9 @@ void SetupDefDispEnv(DISPENV *env, int x, int y, int w, int h)
 		// Start line: 392
 		// Start offset: 0x000448CC
 		// Variables:
-	// 		struct DISPENV disp; // stack offset -144
-	// 		struct DRAWENV draw; // stack offset -120
-	// 		struct RECT rect; // stack offset -24
+	// 		DISPENV disp; // stack offset -144
+	// 		DRAWENV draw; // stack offset -120
+	// 		RECT rect; // stack offset -24
 	// 		char *exe; // $a0
 	/* end block 1 */
 	// End offset: 0x00044A40
@@ -523,9 +523,9 @@ void SetPleaseWait(char *buffer)
 		// Start line: 444
 		// Start offset: 0x00044A40
 		// Variables:
-	// 		struct DISPENV disp; // stack offset -160
-	// 		struct DRAWENV draw; // stack offset -136
-	// 		struct RECT rect; // stack offset -40
+	// 		DISPENV disp; // stack offset -160
+	// 		DRAWENV draw; // stack offset -136
+	// 		RECT rect; // stack offset -40
 	// 		char *mess1; // $s6
 	// 		char *mess2; // $s3
 	// 		char *exe; // $s4

--- a/src_rebuild/GAME/C/ENVIRO.C
+++ b/src_rebuild/GAME/C/ENVIRO.C
@@ -61,7 +61,7 @@ void Env_MakeColourAddTable(short *shinysrc, char *polytable, int length)
 		// Start line: 74
 		// Start offset: 0x00044F08
 		// Variables:
-	// 		struct TPAN pos; // stack offset -16
+	// 		TPAN pos; // stack offset -16
 	// 		int count; // $v1
 	/* end block 1 */
 	// End offset: 0x00044F60

--- a/src_rebuild/GAME/C/EVENT.C
+++ b/src_rebuild/GAME/C/EVENT.C
@@ -382,8 +382,8 @@ EventGlobal events;
 CELL_OBJECT* EventCop;
 int event_models_active = 0;
 
-static struct _EVENT(*trackingEvent[2]);
-static struct _TARGET(*carEvent[8]);
+static EVENT(*trackingEvent[2]);
+static MS_TARGET(*carEvent[8]);
 static int cameraEventsActive = 0;
 static CameraDelay cameraDelay;
 static Detonator detonator;
@@ -391,14 +391,15 @@ static int eventHaze = 0;
 static int carsOnBoat = 0;
 static int doneFirstHavanaCameraHack = 0;
 static SVECTOR boatOffset;
-static struct FixedEvent* fixedEvent = NULL;
+static FixedEvent* fixedEvent = NULL;
 
-static MultiCar multiCar;
-struct _EVENT* firstEvent;
-static _EVENT* firstMissionEvent;
-struct _EVENT* event;
+MultiCar multiCar;
 
-static struct EventCamera eventCamera;
+EVENT* firstEvent;
+EVENT* firstMissionEvent;
+EVENT* event;
+
+static EventCamera eventCamera;
 
 // decompiled code
 // original method signature: 
@@ -424,14 +425,14 @@ static struct EventCamera eventCamera;
 			// Start line: 263
 			// Start offset: 0x00045B30
 			// Variables:
-		// 		struct _EVENT *ev; // $a0
+		// 		EVENT *ev; // $a0
 		// 		int multiple; // $a2
 
 			/* begin block 1.2.1 */
 				// Start line: 274
 				// Start offset: 0x00045BBC
 				// Variables:
-			// 		struct VECTOR pos; // stack offset -16
+			// 		VECTOR pos; // stack offset -16
 			/* end block 1.2.1 */
 			// End offset: 0x00045C3C
 			// End Line: 281
@@ -452,7 +453,7 @@ int GetVisValue(int index, int zDir)
 {
 	int camera;
 	int radius;
-	_EVENT* ev;
+	EVENT* ev;
 	VECTOR pos;
 
 	if (index & 0xC000)
@@ -475,7 +476,7 @@ int GetVisValue(int index, int zDir)
 		int multiple;
 
 		if (index & 0x80)
-			ev = (_EVENT*)&fixedEvent[index & 0x7f];
+			ev = (EVENT*)&fixedEvent[index & 0x7f];
 		else
 			ev = &event[index & 0x7f];
 
@@ -526,7 +527,7 @@ int GetVisValue(int index, int zDir)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ VisibilityLists(enum VisType type /*$a0*/, int i /*$s2*/)
+// void /*$ra*/ VisibilityLists(VisType type /*$a0*/, int i /*$s2*/)
  // line 297, offset 0x00045c68
 	/* begin block 1 */
 		// Start line: 298
@@ -572,7 +573,7 @@ int GetVisValue(int index, int zDir)
 			// Start line: 365
 			// Start offset: 0x00045F90
 			// Variables:
-		// 		struct _EVENT *ev; // $a0
+		// 		EVENT *ev; // $a0
 		/* end block 1.3 */
 		// End offset: 0x00046068
 		// End Line: 384
@@ -581,7 +582,7 @@ int GetVisValue(int index, int zDir)
 			// Start line: 387
 			// Start offset: 0x00046068
 			// Variables:
-		// 		struct _EVENT *ev; // $v1
+		// 		EVENT *ev; // $v1
 		/* end block 1.4 */
 		// End offset: 0x000460BC
 		// End Line: 398
@@ -618,7 +619,7 @@ void VisibilityLists(VisType type, int i)
 	};
 
 	int k;
-	_EVENT* ev;
+	EVENT* ev;
 	int tempList;
 	int num;
 	int n;
@@ -715,7 +716,7 @@ void VisibilityLists(VisType type, int i)
 	else if (type == VIS_ADD)
 	{
 		if (i & 0x80)
-			ev = (_EVENT*)&fixedEvent[i & 0x7f];
+			ev = (EVENT*)&fixedEvent[i & 0x7f];
 		else
 			ev = &event[i & 0x7f];
 
@@ -756,7 +757,7 @@ void VisibilityLists(VisType type, int i)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetElTrainRotation(struct _EVENT *ev /*$a1*/)
+// void /*$ra*/ SetElTrainRotation(EVENT *ev /*$a1*/)
  // line 402, offset 0x0004be5c
 	/* begin block 1 */
 		// Start line: 804
@@ -764,7 +765,7 @@ void VisibilityLists(VisType type, int i)
 	// End Line: 805
 
 // [D] [T]
-void SetElTrainRotation(_EVENT* ev)
+void SetElTrainRotation(EVENT* ev)
 {
 	if (ev->flags & 0x8000)
 		ev->rotation = 0x400;
@@ -779,7 +780,7 @@ void SetElTrainRotation(_EVENT* ev)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitTrain(struct _EVENT *ev /*$s0*/, int count /*$s3*/, int type /*$a2*/)
+// void /*$ra*/ InitTrain(EVENT *ev /*$s0*/, int count /*$s3*/, int type /*$a2*/)
  // line 422, offset 0x000460ec
 	/* begin block 1 */
 		// Start line: 423
@@ -803,7 +804,7 @@ void SetElTrainRotation(_EVENT* ev)
 	// End Line: 942
 
 // [D] [T]
-void InitTrain(_EVENT* ev, int count, int type)
+void InitTrain(EVENT* ev, int count, int type)
 {
 	ushort uVar1;
 	uint mv;
@@ -861,7 +862,7 @@ void InitTrain(_EVENT* ev, int count, int type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitDoor(struct FixedEvent *ev /*$a0*/, struct _EVENT ***e /*$a1*/, int *cEvents /*$a2*/)
+// void /*$ra*/ InitDoor(FixedEvent *ev /*$a0*/, EVENT ***e /*$a1*/, int *cEvents /*$a2*/)
  // line 471, offset 0x0004beb8
 	/* begin block 1 */
 		// Start line: 8350
@@ -874,7 +875,7 @@ void InitTrain(_EVENT* ev, int count, int type)
 	// End Line: 8353
 
 // [D] [T]
-void InitDoor(FixedEvent* ev, _EVENT*** e, int* cEvents)
+void InitDoor(FixedEvent* ev, EVENT*** e, int* cEvents)
 {
 	ev->active = 0;
 	ev->rotation = ev->finalRotation;
@@ -951,7 +952,7 @@ void InitEvents(void)
 	// 		int count; // $s5
 	// 		int *p; // $s2
 	// 		int cEvents; // stack offset -52
-	// 		struct _EVENT **e; // stack offset -56
+	// 		EVENT **e; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 540
@@ -1039,7 +1040,7 @@ void InitEvents(void)
 					// Start line: 888
 					// Start offset: 0x00047094
 					// Variables:
-				// 		struct XYPAIR offset; // stack offset -64
+				// 		XYPAIR offset; // stack offset -64
 				/* end block 1.3.1.1 */
 				// End offset: 0x000471A0
 				// End Line: 896
@@ -1085,11 +1086,11 @@ void SetUpEvents(int full)
 	int iVar5;
 	FixedEvent* ev;
 	int* piVar6;
-	_EVENT* ev_00;
+	EVENT* ev_00;
 	int iVar7;
 	int loop;
 	int* piVar8;
-	_EVENT* p_Var9;
+	EVENT* p_Var9;
 	int i;
 	int detonatorModel;
 	uint __i;
@@ -1097,7 +1098,7 @@ void SetUpEvents(int full)
 	uint uVar10;
 	int trainModel;
 	XYPAIR offset;
-	_EVENT** e;
+	EVENT** e;
 	int cEvents;
 	int ElTrackModel;
 	int carModel;
@@ -1117,7 +1118,7 @@ void SetUpEvents(int full)
 		if (full)
 		{
 			EventCop = (CELL_OBJECT*)mallocptr;
-			event = (_EVENT*)(mallocptr + 256);
+			event = (EVENT*)(mallocptr + 256);
 			mallocptr = (char*)event;
 		}
 
@@ -1538,7 +1539,7 @@ void SetUpEvents(int full)
 				ev_00 = event;
 				HelicopterData.rotorrot = (ushort)lVar3 & 0xff;
 				HelicopterData.rotorvel = 1;
-				*(_TARGET**)&event[cEvents].node = MissionTargets + 4;
+				*(MS_TARGET**)&event[cEvents].node = MissionTargets + 4;
 				ev_00[cEvents].radius = 0;
 
 				if (full != 0)
@@ -1612,7 +1613,7 @@ LAB_000474bc:
 	*e = NULL;
 
 	if (full != 0)
-		mallocptr += cEvents * sizeof(_EVENT);
+		mallocptr += cEvents * sizeof(EVENT);
 
 	MALLOC_END();
 }
@@ -1681,7 +1682,7 @@ void ResetEventCamera(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetCamera(struct _EVENT *ev /*$s5*/)
+// void /*$ra*/ SetCamera(EVENT *ev /*$s5*/)
  // line 991, offset 0x00047538
 	/* begin block 1 */
 		// Start line: 992
@@ -1689,17 +1690,17 @@ void ResetEventCamera(void)
 		// Variables:
 	// 		int rotation; // $s4
 	// 		int axis; // $a3
-	// 		struct VECTOR pivot; // stack offset -96
+	// 		VECTOR pivot; // stack offset -96
 	// 		int iPivot; // $a2
 	// 		int height; // $a1
-	// 		struct SVECTOR offset; // stack offset -80
+	// 		SVECTOR offset; // stack offset -80
 
 		/* begin block 1.1 */
 			// Start line: 1037
 			// Start offset: 0x00047688
 			// Variables:
-		// 		struct MATRIX matrix; // stack offset -72
-		// 		struct SVECTOR temp; // stack offset -40
+		// 		MATRIX matrix; // stack offset -72
+		// 		SVECTOR temp; // stack offset -40
 
 			/* begin block 1.1.1 */
 				// Start line: 1045
@@ -1727,7 +1728,7 @@ void ResetEventCamera(void)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D]
-void SetCamera(_EVENT* ev)
+void SetCamera(EVENT* ev)
 {
 	ushort uVar1;
 	short ang;
@@ -1896,13 +1897,13 @@ void SetCamera(_EVENT* ev)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ EventCollisions(struct _CAR_DATA *cp /*$a2*/, int type /*$a1*/)
+// void /*$ra*/ EventCollisions(CAR_DATA *cp /*$a2*/, int type /*$a1*/)
  // line 1107, offset 0x0004bc50
 	/* begin block 1 */
 		// Start line: 1108
 		// Start offset: 0x0004BC50
 		// Variables:
-	// 		static struct SVECTOR offset; // offset 0x18
+	// 		static SVECTOR offset; // offset 0x18
 	/* end block 1 */
 	// End offset: 0x0004BD2C
 	// End Line: 1125
@@ -1918,7 +1919,7 @@ void SetCamera(_EVENT* ev)
 	// End Line: 6985
 
 // [D] [T]
-void EventCollisions(_CAR_DATA* cp, int type)
+void EventCollisions(CAR_DATA* cp, int type)
 {
 	if (carsOnBoat >> CAR_INDEX(cp) == 0)
 		return;
@@ -1946,7 +1947,7 @@ void EventCollisions(_CAR_DATA* cp, int type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ NextNode(struct _EVENT *ev /*$a0*/)
+// void /*$ra*/ NextNode(EVENT *ev /*$a0*/)
  // line 1127, offset 0x0004c0a4
 	/* begin block 1 */
 		// Start line: 9546
@@ -1964,7 +1965,7 @@ void EventCollisions(_CAR_DATA* cp, int type)
 	// End Line: 9688
 
 // [D] [T]
-void NextNode(_EVENT* ev)
+void NextNode(EVENT* ev)
 {
 	if (ev->node[2] == -0x7ffffffe)
 	{
@@ -1996,7 +1997,7 @@ void NextNode(_EVENT* ev)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StepFromToEvent(struct _EVENT *ev /*$a3*/)
+// void /*$ra*/ StepFromToEvent(EVENT *ev /*$a3*/)
  // line 1152, offset 0x000479dc
 	/* begin block 1 */
 		// Start line: 1153
@@ -2029,7 +2030,7 @@ void NextNode(_EVENT* ev)
 	// End Line: 3012
 
 // [D]
-void StepFromToEvent(_EVENT* ev)
+void StepFromToEvent(EVENT* ev)
 {
 	int uVar1;
 	int uVar2;
@@ -2138,7 +2139,7 @@ LAB_00047b78:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StepPathEvent(struct _EVENT *ev /*$s0*/)
+// void /*$ra*/ StepPathEvent(EVENT *ev /*$s0*/)
  // line 1214, offset 0x00047bd4
 	/* begin block 1 */
 		// Start line: 1215
@@ -2162,7 +2163,7 @@ LAB_00047b78:
 			// Start line: 1242
 			// Start offset: 0x00047C7C
 			// Variables:
-		// 		enum Station station; // $t2
+		// 		Station station; // $t2
 
 			/* begin block 1.2.1 */
 				// Start line: 1276
@@ -2172,8 +2173,8 @@ LAB_00047b78:
 			// 		int loop; // $a2
 			// 		int *i; // $a0
 			// 		int turn[4]; // stack offset -48
-			// 		struct XZPAIR centre; // stack offset -32
-			// 		struct XZPAIR offset; // stack offset -24
+			// 		XZPAIR centre; // stack offset -32
+			// 		XZPAIR offset; // stack offset -24
 			/* end block 1.2.1 */
 			// End offset: 0x00047F98
 			// End Line: 1348
@@ -2206,7 +2207,7 @@ LAB_00047b78:
 	// End Line: 3138
 
 // [D]
-void StepPathEvent(_EVENT* ev)
+void StepPathEvent(EVENT* ev)
 {
 	static int speed;
 
@@ -2554,7 +2555,7 @@ int GetBridgeRotation(int timer)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StepHelicopter(struct _EVENT *ev /*$s0*/)
+// void /*$ra*/ StepHelicopter(EVENT *ev /*$s0*/)
  // line 1478, offset 0x0004830c
 	/* begin block 1 */
 		// Start line: 1479
@@ -2583,7 +2584,7 @@ int GetBridgeRotation(int timer)
 				// Start line: 1522
 				// Start offset: 0x000484A0
 				// Variables:
-			// 		struct XZPAIR vel; // stack offset -56
+			// 		XZPAIR vel; // stack offset -56
 			// 		int direction; // $t1
 			// 		int temp; // $t1
 			// 		int dt; // $a0
@@ -2600,7 +2601,7 @@ int GetBridgeRotation(int timer)
 				// Start line: 1590
 				// Start offset: 0x00048854
 				// Variables:
-			// 		struct VECTOR pos; // stack offset -48
+			// 		VECTOR pos; // stack offset -48
 			/* end block 1.1.2 */
 			// End offset: 0x00048854
 			// End Line: 1591
@@ -2612,8 +2613,8 @@ int GetBridgeRotation(int timer)
 			// Start line: 1613
 			// Start offset: 0x00048948
 			// Variables:
-		// 		struct VECTOR pos; // stack offset -56
-		// 		struct VECTOR drift; // stack offset -32
+		// 		VECTOR pos; // stack offset -56
+		// 		VECTOR drift; // stack offset -32
 		/* end block 1.2 */
 		// End offset: 0x00048948
 		// End Line: 1613
@@ -2634,7 +2635,7 @@ int GetBridgeRotation(int timer)
 /* WARNING: Globals starting with '_' overlap smaller symbols at the same address */
 
 // [D]
-void StepHelicopter(_EVENT* ev)
+void StepHelicopter(EVENT* ev)
 {
 	static int rotating = 1;
 
@@ -2866,13 +2867,13 @@ LAB_00048934:
 		// Start line: 1645
 		// Start offset: 0x00048A60
 		// Variables:
-	// 		struct _EVENT *ev; // $s0
+	// 		EVENT *ev; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 1671
 			// Start offset: 0x00048AC4
 			// Variables:
-		// 		struct VECTOR old; // stack offset -72
+		// 		VECTOR old; // stack offset -72
 		// 		int onBoatLastFrame; // $s7
 
 			/* begin block 1.1.1 */
@@ -2881,7 +2882,7 @@ LAB_00048934:
 				// Variables:
 			// 		int dist; // stack offset -48
 			// 		int loop; // $s2
-			// 		struct _CAR_DATA *cp; // $s1
+			// 		CAR_DATA *cp; // $s1
 			/* end block 1.1.1 */
 			// End offset: 0x00048B98
 			// End Line: 1699
@@ -2906,7 +2907,7 @@ LAB_00048934:
 				// Start line: 1729
 				// Start offset: 0x00048D10
 				// Variables:
-			// 		struct XZPAIR speed; // stack offset -56
+			// 		XZPAIR speed; // stack offset -56
 
 				/* begin block 1.1.4.1 */
 					// Start line: 1733
@@ -2919,8 +2920,8 @@ LAB_00048934:
 						// Start line: 1740
 						// Start offset: 0x00048D60
 						// Variables:
-					// 		struct VECTOR *pos; // $a0
-					// 		struct VECTOR *vel; // $a1
+					// 		VECTOR *pos; // $a0
+					// 		VECTOR *vel; // $a1
 					/* end block 1.1.4.1.1 */
 					// End offset: 0x00048E4C
 					// End Line: 1775
@@ -2965,7 +2966,7 @@ LAB_00048934:
 				// Start line: 1889
 				// Start offset: 0x00049240
 				// Variables:
-			// 		struct CELL_OBJECT *cop; // $a2
+			// 		CELL_OBJECT *cop; // $a2
 			/* end block 1.3.1 */
 			// End offset: 0x000492C4
 			// End Line: 1936
@@ -3003,7 +3004,7 @@ void StepEvents(void)
 {
 	bool bVar1;
 	ushort uVar2;
-	_EVENT* ev;
+	EVENT* ev;
 	uint uVar3;
 	int i;
 	int iVar4;
@@ -3012,14 +3013,14 @@ void StepEvents(void)
 	int iVar7;
 	uint uVar8;
 	VECTOR* pos;
-	_EVENT* evt;
+	EVENT* evt;
 	VECTOR* vel;
 	CELL_OBJECT* cop;
 	int** ppiVar9;
 	ushort* puVar10;
 	ushort* puVar11;
-	_EVENT* _ev;
-	_CAR_DATA* cp;
+	EVENT* _ev;
+	CAR_DATA* cp;
 	uint uVar12;
 	int iVar13;
 	long* local_s4_736;
@@ -3078,7 +3079,7 @@ void StepEvents(void)
 							if ((uVar2 & 0x80) == 0)
 								evt = &event[uVar3 & 0x7f];
 							else
-								evt = (_EVENT*)&fixedEvent[uVar3 & 0x7f];
+								evt = (EVENT*)&fixedEvent[uVar3 & 0x7f];
 
 							if ((*(uint*)&evt->flags & 0x204) == 0x200)
 							{
@@ -3348,7 +3349,7 @@ void StepEvents(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawFerrisWheel(struct MATRIX *matrix /*$s0*/, struct VECTOR *pos /*$s1*/)
+// void /*$ra*/ DrawFerrisWheel(MATRIX *matrix /*$s0*/, VECTOR *pos /*$s1*/)
  // line 2110, offset 0x00049364
 	/* begin block 1 */
 		// Start line: 2111
@@ -3359,15 +3360,15 @@ void StepEvents(void)
 			// Start offset: 0x00049460
 			// Variables:
 		// 		int loop; // $s3
-		// 		struct MODEL *model; // $s2
-		// 		struct VECTOR spoke[2]; // stack offset -104
+		// 		MODEL *model; // $s2
+		// 		VECTOR spoke[2]; // stack offset -104
 
 			/* begin block 1.1.1 */
 				// Start line: 2138
 				// Start offset: 0x000494E4
 				// Variables:
-			// 		struct VECTOR offset; // stack offset -72
-			// 		struct VECTOR carPos; // stack offset -56
+			// 		VECTOR offset; // stack offset -72
+			// 		VECTOR carPos; // stack offset -56
 			// 		int rotation; // $v0
 			/* end block 1.1.1 */
 			// End offset: 0x000494E4
@@ -3465,16 +3466,16 @@ void DrawFerrisWheel(MATRIX* matrix, VECTOR* pos)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawRotor(struct VECTOR pos /*stack 0*/, struct MATRIX *matrix /*stack 16*/)
+// void /*$ra*/ DrawRotor(VECTOR pos /*stack 0*/, MATRIX *matrix /*stack 16*/)
  // line 2159, offset 0x00049684
 	/* begin block 1 */
 		// Start line: 2160
 		// Start offset: 0x00049684
 		// Variables:
-	// 		struct SVECTOR v[5]; // stack offset -120
-	// 		struct MATRIX local; // stack offset -80
-	// 		struct POLY_FT4 *poly; // $t0
-	// 		struct TEXTURE_DETAILS *tex; // $t3
+	// 		SVECTOR v[5]; // stack offset -120
+	// 		MATRIX local; // stack offset -80
+	// 		POLY_FT4 *poly; // $t0
+	// 		TEXTURE_DETAILS *tex; // $t3
 	// 		int z; // stack offset -48
 	// 		char *firstPoly; // $a1
 	/* end block 1 */
@@ -3631,14 +3632,14 @@ void DrawRotor(VECTOR pos, MATRIX* matrix)
 	// 		unsigned short *z; // $a0
 	// 		int thisCamera; // stack offset -56
 	// 		int otherCamera; // stack offset -52
-	// 		static struct _EVENT *nearestTrain; // offset 0x28
+	// 		static EVENT *nearestTrain; // offset 0x28
 	// 		static int distanceFromNearestTrain; // offset 0x2c
 
 		/* begin block 1.1 */
 			// Start line: 2276
 			// Start offset: 0x00049D14
 			// Variables:
-		// 		struct _EVENT *ev; // $s1
+		// 		EVENT *ev; // $s1
 
 			/* begin block 1.1.1 */
 				// Start line: 2289
@@ -3657,9 +3658,9 @@ void DrawRotor(VECTOR pos, MATRIX* matrix)
 					// Start line: 2316
 					// Start offset: 0x00049ED4
 					// Variables:
-				// 		struct MATRIX matrix; // stack offset -208
-				// 		struct MATRIX ext; // stack offset -176
-				// 		struct VECTOR pos; // stack offset -144
+				// 		MATRIX matrix; // stack offset -208
+				// 		MATRIX ext; // stack offset -176
+				// 		VECTOR pos; // stack offset -144
 				// 		int reflection; // $s5
 				// 		int temp; // stack offset -48
 
@@ -3678,14 +3679,14 @@ void DrawRotor(VECTOR pos, MATRIX* matrix)
 							// Start line: 2346
 							// Start offset: 0x0004A038
 							// Variables:
-						// 		struct VECTOR shadow[4]; // stack offset -128
+						// 		VECTOR shadow[4]; // stack offset -128
 						// 		int loop; // $t0
 
 							/* begin block 1.1.2.1.2.1.1 */
 								// Start line: 2351
 								// Start offset: 0x0004A05C
 								// Variables:
-							// 		struct XZPAIR offset; // stack offset -64
+							// 		XZPAIR offset; // stack offset -64
 							// 		int rotate; // $a1
 							/* end block 1.1.2.1.2.1.1 */
 							// End offset: 0x0004A0E8
@@ -3764,7 +3765,7 @@ void DrawRotor(VECTOR pos, MATRIX* matrix)
 // [D]
 void DrawEvents(int camera)
 {
-	static struct _EVENT* nearestTrain; // offset 0x28
+	static EVENT* nearestTrain; // offset 0x28
 	static int distanceFromNearestTrain; // offset 0x2c
 
 	bool bVar1;
@@ -3779,7 +3780,7 @@ void DrawEvents(int camera)
 	ushort* _xv;
 	int* piVar11;
 	VECTOR* pVVar12;
-	_EVENT* ev;
+	EVENT* ev;
 	MATRIX matrix;
 	MATRIX ext;
 	VECTOR pos;
@@ -3853,7 +3854,7 @@ void DrawEvents(int camera)
 			if ((*_xv & 0x80) == 0)
 				ev = &event[(*_xv & 0x7f)];
 			else
-				ev = (_EVENT*)&fixedEvent[(*_xv & 0x7f)];
+				ev = (EVENT*)&fixedEvent[(*_xv & 0x7f)];
 
 			uVar3 = ev->flags;
 
@@ -4149,7 +4150,7 @@ void DrawEvents(int camera)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ BoatOffset(SVECTOR *offset /*$a0*/, _EVENT *ev /*$a1*/)
+// void /*$ra*/ BoatOffset(SVECTOR *offset /*$a0*/, EVENT *ev /*$a1*/)
  // line 2520, offset 0x0004be24
 	/* begin block 1 */
 		// Start line: 10327
@@ -4167,7 +4168,7 @@ void DrawEvents(int camera)
 	// End Line: 10329
 
 // [D] [T]
-void BoatOffset(SVECTOR* offset, _EVENT* ev)
+void BoatOffset(SVECTOR* offset, EVENT* ev)
 {
 	offset->vx = 0;
 	offset->vy = -ev->data[2];
@@ -4178,7 +4179,7 @@ void BoatOffset(SVECTOR* offset, _EVENT* ev)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ OnBoat(struct VECTOR *pos /*$t1*/, struct _EVENT *ev /*$a1*/, int *dist /*$a2*/)
+// int /*$ra*/ OnBoat(VECTOR *pos /*$t1*/, EVENT *ev /*$a1*/, int *dist /*$a2*/)
  // line 2527, offset 0x0004bda0
 	/* begin block 1 */
 		// Start line: 2528
@@ -4206,7 +4207,7 @@ void BoatOffset(SVECTOR* offset, _EVENT* ev)
 	// End Line: 10309
 
 // [D] [T]
-int OnBoat(VECTOR* pos, _EVENT* ev, int* dist)
+int OnBoat(VECTOR* pos, EVENT* ev, int* dist)
 {
 	int halfBoatLength;
 	int halfBoatWidth;
@@ -4242,13 +4243,13 @@ int OnBoat(VECTOR* pos, _EVENT* ev, int* dist)
 
 // decompiled code
 // original method signature: 
-// struct _sdPlane * /*$ra*/ EventSurface(struct VECTOR *pos /*$a0*/, struct _sdPlane *plane /*$s1*/)
+// sdPlane * /*$ra*/ EventSurface(VECTOR *pos /*$a0*/, sdPlane *plane /*$s1*/)
  // line 2560, offset 0x0004a688
 	/* begin block 1 */
 		// Start line: 2561
 		// Start offset: 0x0004A688
 		// Variables:
-	// 		struct _EVENT *ev; // $s0
+	// 		EVENT *ev; // $s0
 	// 		int i; // $a2
 
 		/* begin block 1.1 */
@@ -4294,7 +4295,7 @@ int OnBoat(VECTOR* pos, _EVENT* ev, int* dist)
 int debugOffset = 0;
 
 // [D]
-_sdPlane* EventSurface(VECTOR* pos, _sdPlane* plane)
+sdPlane* EventSurface(VECTOR* pos, sdPlane* plane)
 {
 	short uVar1;
 	int* piVar2;
@@ -4304,7 +4305,7 @@ _sdPlane* EventSurface(VECTOR* pos, _sdPlane* plane)
 	int uVar6;
 	int iVar7;
 	int iVar8;
-	_EVENT* ev;
+	EVENT* ev;
 	int iVar9;
 	int dist;
 
@@ -4447,13 +4448,13 @@ LAB_0004aa50:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MakeEventTrackable(struct _EVENT *ev /*$a0*/)
+// void /*$ra*/ MakeEventTrackable(EVENT *ev /*$a0*/)
  // line 2684, offset 0x0004bd6c
 	/* begin block 1 */
 		// Start line: 2685
 		// Start offset: 0x0004BD6C
 		// Variables:
-	// 		struct _EVENT **p; // $v1
+	// 		EVENT **p; // $v1
 	/* end block 1 */
 	// End offset: 0x0004BDA0
 	// End Line: 2694
@@ -4469,9 +4470,9 @@ LAB_0004aa50:
 	// End Line: 10455
 
 // [D] [T]
-void MakeEventTrackable(_EVENT* ev)
+void MakeEventTrackable(EVENT* ev)
 {
-	_EVENT** p;
+	EVENT** p;
 
 	p = trackingEvent;
 	while (*p)
@@ -4485,7 +4486,7 @@ void MakeEventTrackable(_EVENT* ev)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TriggerDoor(struct FixedEvent *door /*$a3*/, int *stage /*$a1*/, int sound /*$a2*/)
+// void /*$ra*/ TriggerDoor(FixedEvent *door /*$a3*/, int *stage /*$a1*/, int sound /*$a2*/)
  // line 2696, offset 0x0004c208
 	/* begin block 1 */
 		// Start line: 11604
@@ -4523,14 +4524,14 @@ void TriggerDoor(FixedEvent* door, int* stage, int sound)
 
 // decompiled code
 // original method signature: 
-// struct VECTOR * /*$ra*/ TriggerEvent(int i /*$s4*/)
+// VECTOR * /*$ra*/ TriggerEvent(int i /*$s4*/)
  // line 2718, offset 0x0004aa78
 	/* begin block 1 */
 		// Start line: 2719
 		// Start offset: 0x0004AA78
 		// Variables:
 	// 		static int stage[10]; // offset 0x200
-	// 		struct VECTOR *pos; // $s7
+	// 		VECTOR *pos; // $s7
 
 		/* begin block 1.1 */
 			// Start line: 2726
@@ -4545,7 +4546,7 @@ void TriggerDoor(FixedEvent* door, int* stage, int sound)
 			// Start line: 2739
 			// Start offset: 0x0004AB20
 			// Variables:
-		// 		struct _EVENT *ev; // $a2
+		// 		EVENT *ev; // $a2
 		/* end block 1.2 */
 		// End offset: 0x0004AB20
 		// End Line: 2740
@@ -4558,7 +4559,7 @@ void TriggerDoor(FixedEvent* door, int* stage, int sound)
 				// Start line: 2757
 				// Start offset: 0x0004AC08
 				// Variables:
-			// 		struct MissionTrain *train; // $s1
+			// 		MissionTrain *train; // $s1
 
 				/* begin block 1.3.1.1 */
 					// Start line: 2763
@@ -4571,7 +4572,7 @@ void TriggerDoor(FixedEvent* door, int* stage, int sound)
 					// Start line: 2774
 					// Start offset: 0x0004AC5C
 					// Variables:
-				// 		struct _EVENT *ev; // $s0
+				// 		EVENT *ev; // $s0
 				// 		int count; // $s2
 				// 		int offset; // $s6
 
@@ -4594,7 +4595,7 @@ void TriggerDoor(FixedEvent* door, int* stage, int sound)
 				// Start line: 2831
 				// Start offset: 0x0004ADB8
 				// Variables:
-			// 		struct _EVENT *ev; // $v1
+			// 		EVENT *ev; // $v1
 			// 		int count; // $a0
 			/* end block 1.3.2 */
 			// End offset: 0x0004AE04
@@ -4650,16 +4651,16 @@ VECTOR* TriggerEvent(int i)
 	static int stage[10];
 
 	short uVar1;
-	_EVENT* p_Var2;
+	EVENT* p_Var2;
 	int count;
 	int* piVar3;
 	int iVar4;
-	_EVENT* _ev;
+	EVENT* _ev;
 	int iVar5;
-	_EVENT* p_Var6;
-	_EVENT* ev;
+	EVENT* p_Var6;
+	EVENT* ev;
 	int iVar7;
-	_EVENT* ev_00;
+	EVENT* ev_00;
 
 	p_Var2 = firstEvent;
 	p_Var6 = firstMissionEvent;
@@ -4794,7 +4795,7 @@ VECTOR* TriggerEvent(int i)
 				break;
 			case 5:
 				PrepareSecretCar();
-				events.cameraEvent = (_EVENT*)chicagoDoor;
+				events.cameraEvent = (EVENT*)chicagoDoor;
 			case 6:
 				TriggerDoor(chicagoDoor + i - 5, stage + i, 1); // might be incorrect
 		}
@@ -4819,7 +4820,7 @@ VECTOR* TriggerEvent(int i)
 				break;
 			case 3:
 				PrepareSecretCar();
-				events.cameraEvent = (_EVENT*)(havanaFixed + 2);
+				events.cameraEvent = (EVENT*)(havanaFixed + 2);
 				TriggerDoor(havanaFixed + 2, stage + i, 0);
 				break;
 			case 4:
@@ -4864,7 +4865,7 @@ VECTOR* TriggerEvent(int i)
 				TriggerDoor(vegasDoor + i - 4, stage + i, 0);
 				break;
 			case 8:
-				events.cameraEvent = (_EVENT*)(vegasDoor + 4);
+				events.cameraEvent = (EVENT*)(vegasDoor + 4);
 				PrepareSecretCar();
 			case 5:
 			case 6:
@@ -4886,7 +4887,7 @@ VECTOR* TriggerEvent(int i)
 				TriggerDoor(rioDoor + 2, stage + i, 0);
 				TriggerDoor(rioDoor + 3, stage + i, 0);
 
-				events.cameraEvent = (_EVENT*)(rioDoor + 2);
+				events.cameraEvent = (EVENT*)(rioDoor + 2);
 				break;
 			case 5:
 			case 6:
@@ -4911,7 +4912,7 @@ VECTOR* TriggerEvent(int i)
 				PingOutAllSpecialCivCars();
 				TriggerDoor(rioDoor + 4, stage + i, 0);
 				TriggerDoor(rioDoor + 5, stage + i, 0);
-				events.cameraEvent = (_EVENT*)(rioDoor + 4);
+				events.cameraEvent = (EVENT*)(rioDoor + 4);
 		}
 	}
 
@@ -4927,7 +4928,7 @@ switchD_0004afa0_caseD_1:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ OffsetTarget(struct VECTOR *target /*$a0*/)
+// void /*$ra*/ OffsetTarget(VECTOR *target /*$a0*/)
  // line 2994, offset 0x0004bd2c
 	/* begin block 1 */
 		// Start line: 8890
@@ -5048,7 +5049,7 @@ void SpecialCamera(enum SpecialCamera type, int change)
 		{
 			boat = boatCamera;
 		LAB_0004b418:
-			events.cameraEvent = (_EVENT*)0x1;
+			events.cameraEvent = (EVENT*)0x1;
 		}
 		else
 		{
@@ -5092,7 +5093,7 @@ void SpecialCamera(enum SpecialCamera type, int change)
 			else if (gCurrentMissionNumber == 0x16)
 			{
 				hackCamera = VegasCameraHack + 0xd;
-				events.cameraEvent = (_EVENT*)0x1;
+				events.cameraEvent = (EVENT*)0x1;
 				camera_position.vy = -1800;
 			}
 			else if (gCurrentMissionNumber == 0x1e)
@@ -5150,7 +5151,7 @@ LAB_0004b5b8:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ScreenShake(int count /*$a0*/, struct SVECTOR *ang /*$s0*/)
+// void /*$ra*/ ScreenShake(int count /*$a0*/, SVECTOR *ang /*$s0*/)
  // line 3144, offset 0x0004c280
 	/* begin block 1 */
 		// Start line: 3145
@@ -5190,7 +5191,7 @@ void ScreenShake(int count, SVECTOR* ang)
 		// Start line: 3154
 		// Start offset: 0x0004B5FC
 		// Variables:
-	// 		static struct SVECTOR rememberCameraAngle; // offset 0x30
+	// 		static SVECTOR rememberCameraAngle; // offset 0x30
 
 		/* begin block 1.1 */
 			// Start line: 3168
@@ -5206,7 +5207,7 @@ void ScreenShake(int count, SVECTOR* ang)
 					// Start line: 3179
 					// Start offset: 0x0004B6CC
 					// Variables:
-				// 		struct VECTOR pos; // stack offset -32
+				// 		VECTOR pos; // stack offset -32
 				/* end block 1.1.1.1 */
 				// End offset: 0x0004B700
 				// End Line: 3184
@@ -5215,7 +5216,7 @@ void ScreenShake(int count, SVECTOR* ang)
 					// Start line: 3188
 					// Start offset: 0x0004B720
 					// Variables:
-				// 		struct VECTOR pos; // stack offset -32
+				// 		VECTOR pos; // stack offset -32
 				/* end block 1.1.1.2 */
 				// End offset: 0x0004B720
 				// End Line: 3189
@@ -5230,14 +5231,14 @@ void ScreenShake(int count, SVECTOR* ang)
 			// Start line: 3218
 			// Start offset: 0x0004B864
 			// Variables:
-		// 		struct _EVENT *ev; // $s0
-		// 		struct VECTOR pos; // stack offset -32
+		// 		EVENT *ev; // $s0
+		// 		VECTOR pos; // stack offset -32
 
 			/* begin block 1.2.1 */
 				// Start line: 3247
 				// Start offset: 0x0004B9B0
 				// Variables:
-			// 		struct VECTOR *epicentre; // $v1
+			// 		VECTOR *epicentre; // $v1
 			/* end block 1.2.1 */
 			// End offset: 0x0004BA08
 			// End Line: 3260
@@ -5273,13 +5274,13 @@ void ScreenShake(int count, SVECTOR* ang)
 // [D]
 int DetonatorTimer(void)
 {
-	static struct SVECTOR rememberCameraAngle; // offset 0x30
+	static SVECTOR rememberCameraAngle; // offset 0x30
 	static int count = 0; // offset 0x38
 
 	long* plVar1;
-	_EVENT* _ev;
+	EVENT* _ev;
 	int cnt;
-	_EVENT* ev;
+	EVENT* ev;
 	VECTOR pos;
 
 	_ev = firstMissionEvent;
@@ -5385,7 +5386,7 @@ int DetonatorTimer(void)
 
 				detonator.timer = 200;
 				SpecialCamera(SPECIAL_CAMERA_SET, 0);
-				events.cameraEvent = (_EVENT*)0x1;
+				events.cameraEvent = (EVENT*)0x1;
 
 				rememberCameraAngle = camera_angle;
 			}
@@ -5433,15 +5434,15 @@ LAB_0004ba8c:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MultiCarEvent(struct _TARGET *target /*$a0*/)
+// void /*$ra*/ MultiCarEvent(MS_TARGET *target /*$a0*/)
  // line 3288, offset 0x0004bab0
 	/* begin block 1 */
 		// Start line: 3289
 		// Start offset: 0x0004BAB0
 		// Variables:
-	// 		struct MULTICAR_DATA *data; // $s0
+	// 		MULTICAR_DATA *data; // $s0
 	// 		int i; // $s1
-	// 		struct _EVENT *ev; // $s2
+	// 		EVENT *ev; // $s2
 
 		/* begin block 1.1 */
 			// Start line: 3301
@@ -5471,11 +5472,11 @@ LAB_0004ba8c:
 	// End Line: 8399
 
 // [D] [T]
-void MultiCarEvent(_TARGET* target)
+void MultiCarEvent(MS_TARGET* target)
 {
-	_EVENT* first;
+	EVENT* first;
 	int n;
-	_EVENT* ev;
+	EVENT* ev;
 	MULTICAR_DATA* data;
 	int i;
 

--- a/src_rebuild/GAME/C/EVENT.H
+++ b/src_rebuild/GAME/C/EVENT.H
@@ -10,11 +10,11 @@ extern int GetVisValue(int index, int zDir); // 0x00045AB8
 
 extern void VisibilityLists(VisType type, int i); // 0x00045C68
 
-extern void SetElTrainRotation(_EVENT *ev); // 0x0004BE5C
+extern void SetElTrainRotation(EVENT *ev); // 0x0004BE5C
 
-extern void InitTrain(_EVENT *ev, int count, int type); // 0x000460EC
+extern void InitTrain(EVENT *ev, int count, int type); // 0x000460EC
 
-extern void InitDoor(FixedEvent *ev, _EVENT ***e, int *cEvents); // 0x0004BEB8
+extern void InitDoor(FixedEvent *ev, EVENT ***e, int *cEvents); // 0x0004BEB8
 
 extern void InitEvents(); // 0x0004BBD4
 
@@ -24,19 +24,19 @@ extern void InitEventCamera(); // 0x0004BF54
 
 extern void ResetEventCamera(); // 0x0004C014
 
-extern void SetCamera(_EVENT *ev); // 0x00047538
+extern void SetCamera(EVENT *ev); // 0x00047538
 
-extern void EventCollisions(_CAR_DATA *cp, int type); // 0x0004BC50
+extern void EventCollisions(CAR_DATA *cp, int type); // 0x0004BC50
 
-extern void NextNode(_EVENT *ev); // 0x0004C0A4
+extern void NextNode(EVENT *ev); // 0x0004C0A4
 
-extern void StepFromToEvent(_EVENT *ev); // 0x000479DC
+extern void StepFromToEvent(EVENT *ev); // 0x000479DC
 
-extern void StepPathEvent(_EVENT *ev); // 0x00047BD4
+extern void StepPathEvent(EVENT *ev); // 0x00047BD4
 
 extern int GetBridgeRotation(int timer); // 0x0004C158
 
-extern void StepHelicopter(_EVENT *ev); // 0x0004830C
+extern void StepHelicopter(EVENT *ev); // 0x0004830C
 
 extern void StepEvents(); // 0x00048A60
 
@@ -46,13 +46,13 @@ extern void DrawRotor(VECTOR pos, MATRIX *matrix); // 0x00049684
 
 extern void DrawEvents(int camera); // 0x00049C38
 
-extern void BoatOffset(SVECTOR *offset, _EVENT *ev); // 0x0004BE24
+extern void BoatOffset(SVECTOR *offset, EVENT *ev); // 0x0004BE24
 
-extern int OnBoat(VECTOR *pos, _EVENT *ev, int *dist); // 0x0004BDA0
+extern int OnBoat(VECTOR *pos, EVENT *ev, int *dist); // 0x0004BDA0
 
-extern _sdPlane * EventSurface(VECTOR *pos, _sdPlane *plane); // 0x0004A688
+extern sdPlane * EventSurface(VECTOR *pos, sdPlane *plane); // 0x0004A688
 
-extern void MakeEventTrackable(_EVENT *ev); // 0x0004BD6C
+extern void MakeEventTrackable(EVENT *ev); // 0x0004BD6C
 
 extern void TriggerDoor(FixedEvent *door, int *stage, int sound); // 0x0004C208
 
@@ -66,7 +66,7 @@ extern void ScreenShake(int count, SVECTOR *ang); // 0x0004C280
 
 extern int DetonatorTimer(); // 0x0004B5FC
 
-extern void MultiCarEvent(_TARGET *target); // 0x0004BAB0
+extern void MultiCarEvent(MS_TARGET *target); // 0x0004BAB0
 
 
 #endif

--- a/src_rebuild/GAME/C/FELONY.C
+++ b/src_rebuild/GAME/C/FELONY.C
@@ -45,13 +45,13 @@ int FelonyDecreaseTimer = 0;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitFelonyDelayArray(struct FELONY_DELAY *pFelonyDelay /*$a0*/, short *pMaximum /*$a1*/, int count /*$a2*/)
+// void /*$ra*/ InitFelonyDelayArray(FELONY_DELAY *pFelonyDelay /*$a0*/, short *pMaximum /*$a1*/, int count /*$a2*/)
  // line 413, offset 0x0004d364
 	/* begin block 1 */
 		// Start line: 414
 		// Start offset: 0x0004D364
 		// Variables:
-	// 		struct FELONY_DELAY *pCurrent; // $a0
+	// 		FELONY_DELAY *pCurrent; // $a0
 	/* end block 1 */
 	// End offset: 0x0004D3A0
 	// End Line: 422
@@ -86,7 +86,7 @@ void InitFelonyDelayArray(FELONY_DELAY *pFelonyDelay, short *pMaximum, int count
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitFelonyData(struct FELONY_DATA *pFelonyData /*$s0*/)
+// void /*$ra*/ InitFelonyData(FELONY_DATA *pFelonyData /*$s0*/)
  // line 431, offset 0x0004d3a0
 	/* begin block 1 */
 		// Start line: 432
@@ -96,9 +96,9 @@ void InitFelonyDelayArray(FELONY_DELAY *pFelonyDelay, short *pMaximum, int count
 			// Start line: 432
 			// Start offset: 0x0004D3A0
 			// Variables:
-		// 		struct FELONY_VALUE *pSrc; // $v1
-		// 		struct FELONY_VALUE *pDest; // $s0
-		// 		struct FELONY_VALUE *pEnd; // $a0
+		// 		FELONY_VALUE *pSrc; // $v1
+		// 		FELONY_VALUE *pDest; // $s0
+		// 		FELONY_VALUE *pEnd; // $a0
 		/* end block 1.1 */
 		// End offset: 0x0004D420
 		// End Line: 445
@@ -161,7 +161,7 @@ int GetCarHeading(int direction)
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ GetCarDirectionOfTravel(struct _CAR_DATA *cp /*$s0*/)
+// char /*$ra*/ GetCarDirectionOfTravel(CAR_DATA *cp /*$s0*/)
  // line 454, offset 0x0004d430
 	/* begin block 1 */
 		// Start line: 455
@@ -178,7 +178,7 @@ int GetCarHeading(int direction)
 	// End Line: 1423
 
 // [D] [T]
-char GetCarDirectionOfTravel(_CAR_DATA *cp)
+char GetCarDirectionOfTravel(CAR_DATA *cp)
 {
 	int direction;
 
@@ -194,7 +194,7 @@ char GetCarDirectionOfTravel(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ NoteFelony(struct FELONY_DATA *pFelonyData /*$a3*/, char type /*$s3*/, short scale /*$t0*/)
+// void /*$ra*/ NoteFelony(FELONY_DATA *pFelonyData /*$a3*/, char type /*$s3*/, short scale /*$t0*/)
  // line 476, offset 0x0004c330
 	/* begin block 1 */
 		// Start line: 477
@@ -206,7 +206,7 @@ char GetCarDirectionOfTravel(_CAR_DATA *cp)
 			// Start line: 478
 			// Start offset: 0x0004C3A8
 			// Variables:
-		// 		struct FELONY_DELAY *pFelonyDelay; // $v1
+		// 		FELONY_DELAY *pFelonyDelay; // $v1
 		/* end block 1.1 */
 		// End offset: 0x0004C3CC
 		// End Line: 495
@@ -381,7 +381,7 @@ void NoteFelony(FELONY_DATA *pFelonyData, char type, short scale)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AdjustFelony(struct FELONY_DATA *pFelonyData /*$a0*/)
+// void /*$ra*/ AdjustFelony(FELONY_DATA *pFelonyData /*$a0*/)
  // line 597, offset 0x0004c8b4
 	/* begin block 1 */
 		// Start line: 598
@@ -391,7 +391,7 @@ void NoteFelony(FELONY_DATA *pFelonyData, char type, short scale)
 			// Start line: 649
 			// Start offset: 0x0004CBE8
 			// Variables:
-		// 		struct FELONY_DELAY *pFelonyDelay; // $v1
+		// 		FELONY_DELAY *pFelonyDelay; // $v1
 		/* end block 1.1 */
 		// End offset: 0x0004CC28
 		// End Line: 658
@@ -463,11 +463,11 @@ void AdjustFelony(FELONY_DATA *pFelonyData)
 		// Start line: 670
 		// Start offset: 0x0004CC28
 		// Variables:
-	// 		struct FELONY_DATA *pFelonyData; // $s4
-	// 		struct DRIVER2_CURVE *cv; // $s5
-	// 		struct DRIVER2_STRAIGHT *st; // $s6
-	// 		struct _CAR_DATA *cp; // $s3
-	// 		struct VECTOR *carPos; // $s2
+	// 		FELONY_DATA *pFelonyData; // $s4
+	// 		DRIVER2_CURVE *cv; // $s5
+	// 		DRIVER2_STRAIGHT *st; // $s6
+	// 		CAR_DATA *cp; // $s3
+	// 		VECTOR *carPos; // $s2
 	// 		int surfInd; // $s0
 
 		/* begin block 1.1 */
@@ -480,7 +480,7 @@ void AdjustFelony(FELONY_DATA *pFelonyData)
 				// Start line: 699
 				// Start offset: 0x0004CD64
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *jn; // $a2
+			// 		DRIVER2_JUNCTION *jn; // $a2
 			// 		short exitId; // $s1
 			/* end block 1.1.1 */
 			// End offset: 0x0004CE0C
@@ -564,7 +564,7 @@ void CheckPlayerMiscFelonies(void)
 	VECTOR *carPos;
 	DRIVER2_ROAD_INFO roadInfo;
 	DRIVER2_JUNCTION *jn;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 
 	// Do not register felony if player does not have a car
 	if (player[0].playerType == 2 || 
@@ -753,7 +753,7 @@ void InitFelonySystem(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CarHitByPlayer(struct _CAR_DATA *victim /*$a0*/, int howHard /*$a2*/)
+// void /*$ra*/ CarHitByPlayer(CAR_DATA *victim /*$a0*/, int howHard /*$a2*/)
  // line 824, offset 0x0004d2b8
 	/* begin block 1 */
 		// Start line: 1714
@@ -761,7 +761,7 @@ void InitFelonySystem(void)
 	// End Line: 1715
 
 // [D] [T]
-void CarHitByPlayer(_CAR_DATA *victim, int howHard)
+void CarHitByPlayer(CAR_DATA *victim, int howHard)
 {
 	char type;
 

--- a/src_rebuild/GAME/C/FELONY.H
+++ b/src_rebuild/GAME/C/FELONY.H
@@ -6,23 +6,23 @@
 
 extern FELONY_DATA felonyData;
 
-extern void InitFelonyDelayArray(struct FELONY_DELAY *pFelonyDelay, short *pMaximum, int count); // 0x0004D364
+extern void InitFelonyDelayArray(FELONY_DELAY *pFelonyDelay, short *pMaximum, int count); // 0x0004D364
 
-extern void InitFelonyData(struct FELONY_DATA *pFelonyData); // 0x0004D3A0
+extern void InitFelonyData(FELONY_DATA *pFelonyData); // 0x0004D3A0
 
 extern int GetCarHeading(int direction); // 0x0004D420
 
-extern char GetCarDirectionOfTravel(struct _CAR_DATA *cp); // 0x0004D430
+extern char GetCarDirectionOfTravel(CAR_DATA *cp); // 0x0004D430
 
-extern void NoteFelony(struct FELONY_DATA *pFelonyData, char type, short scale); // 0x0004C330
+extern void NoteFelony(FELONY_DATA *pFelonyData, char type, short scale); // 0x0004C330
 
-extern void AdjustFelony(struct FELONY_DATA *pFelonyData); // 0x0004C8B4
+extern void AdjustFelony(FELONY_DATA *pFelonyData); // 0x0004C8B4
 
 extern void CheckPlayerMiscFelonies(); // 0x0004CC28
 
 extern void InitFelonySystem(); // 0x0004D280
 
-extern void CarHitByPlayer(struct _CAR_DATA *victim, int howHard); // 0x0004D2B8
+extern void CarHitByPlayer(CAR_DATA *victim, int howHard); // 0x0004D2B8
 
 
 #endif

--- a/src_rebuild/GAME/C/FMVPLAY.C
+++ b/src_rebuild/GAME/C/FMVPLAY.C
@@ -71,7 +71,7 @@ void ReInitSystem(void)
 		// Start line: 69
 		// Start offset: 0x0004D518
 		// Variables:
-	// 		struct RENDER_ARGS args; // stack offset -40
+	// 		RENDER_ARGS args; // stack offset -40
 
 		/* begin block 1.1 */
 			// Start line: 75
@@ -129,7 +129,7 @@ void PlayFMV(unsigned char render)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlayRender(struct RENDER_ARGS *args /*$s0*/)
+// void /*$ra*/ PlayRender(RENDER_ARGS *args /*$s0*/)
  // line 107, offset 0x0004d5d0
 	/* begin block 1 */
 		// Start line: 108

--- a/src_rebuild/GAME/C/FMVPLAY.H
+++ b/src_rebuild/GAME/C/FMVPLAY.H
@@ -8,7 +8,7 @@ extern void ReInitSystem(); // 0x0004D478
 
 extern void PlayFMV(unsigned char render); // 0x0004D518
 
-extern void PlayRender(struct RENDER_ARGS *args); // 0x0004D5D0
+extern void PlayRender(RENDER_ARGS *args); // 0x0004D5D0
 
 
 #endif

--- a/src_rebuild/GAME/C/GAMESND.C
+++ b/src_rebuild/GAME/C/GAMESND.C
@@ -29,12 +29,12 @@
 
 #include "FELONY.H"
 
-typedef void(*envsoundfunc)(struct __envsound* ep /*$s1*/, struct __envsoundinfo* E /*$a1*/, int pl /*$a2*/);
+typedef void(*envsoundfunc)(__envsound* ep /*$s1*/, __envsoundinfo* E /*$a1*/, int pl /*$a2*/);
 
-void IdentifyZone(struct __envsound* ep, struct __envsoundinfo* E, int pl);
-void CalcEffPos(struct __envsound* ep, struct __envsoundinfo* E, int pl);
-void CalcEffPos2(struct __envsound* ep, struct __envsoundinfo* E, int pl);
-void UpdateEnvSnd(struct __envsound* ep, struct __envsoundinfo* E, int pl);
+void IdentifyZone(envsound* ep, envsoundinfo* E, int pl);
+void CalcEffPos(envsound* ep, envsoundinfo* E, int pl);
+void CalcEffPos2(envsound* ep, envsoundinfo* E, int pl);
+void UpdateEnvSnd(envsound* ep, envsoundinfo* E, int pl);
 
 static envsoundfunc UpdateEnvSounds[] = {
 	IdentifyZone,
@@ -75,8 +75,8 @@ SPEECH_QUEUE gSpeechQueue;
 static char cop_bank = 0;
 char phrase_top = 0;
 
-static struct __othercarsound siren_noise[MAX_SIREN_NOISES];
-static struct __othercarsound car_noise[MAX_CAR_NOISES];
+static othercarsound siren_noise[MAX_SIREN_NOISES];
+static othercarsound car_noise[MAX_CAR_NOISES];
 static int loudhail_time = 0;
 
 static int copmusic = 0;
@@ -85,9 +85,9 @@ int current_music_id;
 static char header_pt[sizeof(XMHEADER)];
 static char song_pt[sizeof(XMSONG)];
 
-static __envsound envsnd[MAX_LEVEL_ENVSOUNDS];
-static __envsoundinfo ESdata[2];
-__tunnelinfo tunnels;
+static envsound envsnd[MAX_LEVEL_ENVSOUNDS];
+static envsoundinfo ESdata[2];
+tunnelinfo tunnels;
 
 char _sbank_buffer[0x80000];		// 0x180000
 
@@ -632,7 +632,7 @@ void LoadLevelSFX(int missionNum)
 		// Start line: 307
 		// Start offset: 0x0004DE30
 		// Variables:
-	// 		struct VECTOR *cp; // $s2
+	// 		VECTOR *cp; // $s2
 	// 		int i; // $s1
 
 		/* begin block 1.1 */
@@ -677,8 +677,8 @@ void StartGameSounds(void)
 {
 	int channel;
 	int i;
-	_PLAYER* lcp;
-	_CAR_DATA* cp;
+	PLAYER* lcp;
+	CAR_DATA* cp;
 	int sample;
 	int pitch;
 	int car_model;
@@ -806,7 +806,7 @@ void StartGameSounds(void)
 
 // decompiled code
 // original method signature: 
-// unsigned short /*$ra*/ GetEngineRevs(struct _CAR_DATA *cp /*$t2*/)
+// unsigned short /*$ra*/ GetEngineRevs(CAR_DATA *cp /*$t2*/)
  // line 404, offset 0x0004e188
 	/* begin block 1 */
 		// Start line: 405
@@ -834,7 +834,7 @@ void StartGameSounds(void)
 /* WARNING: Removing unreachable block (ram,0x0004e1b0) */
 
 // [D] [T]
-ushort GetEngineRevs(_CAR_DATA* cp)
+ushort GetEngineRevs(CAR_DATA* cp)
 {
 	int acc;
 	GEAR_DESC* gd;
@@ -904,7 +904,7 @@ ushort GetEngineRevs(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ControlCarRevs(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ ControlCarRevs(CAR_DATA *cp /*$s0*/)
  // line 458, offset 0x0004e2e8
 	/* begin block 1 */
 		// Start line: 459
@@ -943,7 +943,7 @@ const int maxrevdrop = 1440;
 const int maxrevrise = 1600;
 
 // [D] [T]
-void ControlCarRevs(_CAR_DATA* cp)
+void ControlCarRevs(CAR_DATA* cp)
 {
 	char spin;
 	int player_id, acc, oldvol;
@@ -1068,7 +1068,7 @@ void DoSpeech(int chan, int sound)
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ PlaySpeech(struct SPEECH_QUEUE *pSpeechQueue /*$a0*/, int sound /*$a1*/)
+// char /*$ra*/ PlaySpeech(SPEECH_QUEUE *pSpeechQueue /*$a0*/, int sound /*$a1*/)
  // line 562, offset 0x0005228c
 	/* begin block 1 */
 		// Start line: 563
@@ -1116,7 +1116,7 @@ char PlaySpeech(SPEECH_QUEUE* pSpeechQueue, int sound)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitSpeechQueue(struct SPEECH_QUEUE *pSpeechQueue /*$s0*/)
+// void /*$ra*/ InitSpeechQueue(SPEECH_QUEUE *pSpeechQueue /*$s0*/)
  // line 587, offset 0x00052654
 	/* begin block 1 */
 		// Start line: 5265
@@ -1136,7 +1136,7 @@ void InitSpeechQueue(SPEECH_QUEUE* pSpeechQueue)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ControlSpeech(struct SPEECH_QUEUE *pSpeechQueue /*$s0*/)
+// void /*$ra*/ ControlSpeech(SPEECH_QUEUE *pSpeechQueue /*$s0*/)
  // line 595, offset 0x0004e560
 	/* begin block 1 */
 		// Start line: 596
@@ -1434,8 +1434,8 @@ void InitDopplerSFX(void)
 	// 		int num_noisy_cars; // $s5
 	// 		unsigned long car_dist[20]; // stack offset -176
 	// 		unsigned short indexlist[20]; // stack offset -96
-	// 		struct _CAR_DATA *car_ptr; // $s2
-	// 		struct VECTOR *pp; // $a1
+	// 		CAR_DATA *car_ptr; // $s2
+	// 		VECTOR *pp; // $a1
 	// 		unsigned long car_flags; // $s4
 	// 		char sirens; // stack offset -56
 
@@ -1507,7 +1507,7 @@ void DoDopplerSFX(void)
 	ulong car_dist[MAX_CARS];
 	ushort indexlist[MAX_CARS];
 
-	_CAR_DATA* car_ptr;
+	CAR_DATA* car_ptr;
 	int dx, dz;
 	ulong dist;
 
@@ -1885,7 +1885,7 @@ void DoDopplerSFX(void)
 			// Start line: 951
 			// Start offset: 0x0004F560
 			// Variables:
-		// 		struct _CAR_DATA *car_ptr; // $a3
+		// 		CAR_DATA *car_ptr; // $a3
 		/* end block 1.1 */
 		// End offset: 0x0004F624
 		// End Line: 959
@@ -1925,7 +1925,7 @@ void DoPoliceLoudhailer(int cars, ushort* indexlist, ulong* dist)
 
 	while (i < cars)
 	{
-		_CAR_DATA* car_ptr;
+		CAR_DATA* car_ptr;
 
 		carId = indexlist[i];
 
@@ -1953,7 +1953,7 @@ void DoPoliceLoudhailer(int cars, ushort* indexlist, ulong* dist)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CollisionSound(char player_id /*$s0*/, struct _CAR_DATA *cp /*$s5*/, int impact /*$s2*/, int car_car /*$s7*/)
+// void /*$ra*/ CollisionSound(char player_id /*$s0*/, CAR_DATA *cp /*$s5*/, int impact /*$s2*/, int car_car /*$s7*/)
  // line 975, offset 0x0004f668
 	/* begin block 1 */
 		// Start line: 976
@@ -1997,7 +1997,7 @@ void DoPoliceLoudhailer(int cars, ushort* indexlist, ulong* dist)
 	// End Line: 2286
 
 // [D] [T]
-void CollisionSound(char player_id, _CAR_DATA* cp, int impact, int car_car)
+void CollisionSound(char player_id, CAR_DATA* cp, int impact, int car_car)
 {
 	int chan;
 	long rnd;
@@ -2112,7 +2112,7 @@ void CollisionSound(char player_id, _CAR_DATA* cp, int impact, int car_car)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ExplosionSound(struct VECTOR *pos /*$s4*/, int type /*$s0*/)
+// void /*$ra*/ ExplosionSound(VECTOR *pos /*$s4*/, int type /*$s0*/)
  // line 1019, offset 0x0004f984
 	/* begin block 1 */
 		// Start line: 1020
@@ -2121,7 +2121,7 @@ void CollisionSound(char player_id, _CAR_DATA* cp, int impact, int car_car)
 	// 		int bang; // $s5
 	// 		int pitch; // $t0
 	// 		int rnd; // $s3
-	// 		struct VECTOR P; // stack offset -48
+	// 		VECTOR P; // stack offset -48
 	// 		int sc1; // $s2
 	// 		int sc2; // $s1
 	/* end block 1 */
@@ -2292,7 +2292,7 @@ void FunkUpDaBGMTunez(int funk)
 		// Start offset: 0x0004FC90
 		// Variables:
 	// 		int i; // $s2
-	// 		struct _CAR_DATA *cp; // $s1
+	// 		CAR_DATA *cp; // $s1
 	/* end block 1 */
 	// End offset: 0x000500E4
 	// End Line: 1183
@@ -2317,15 +2317,15 @@ void FunkUpDaBGMTunez(int funk)
 // [D] [T]
 void SoundTasks(void)
 {
-	static struct __envsoundtags EStags;
+	static __envsoundtags EStags;
 
 	int chan;
 	int vol;
 	VECTOR* position;
 	long* velocity;
 
-	_PLAYER* lcp;
-	_CAR_DATA* cp;
+	PLAYER* lcp;
+	CAR_DATA* cp;
 	int i;
 
 	UpdateEnvSounds[EStags.func_cnt++](envsnd, ESdata, 0);
@@ -2579,7 +2579,7 @@ void InitMusic(int musicnum)
 		// Start line: 1318
 		// Start offset: 0x0005243C
 		// Variables:
-	// 		struct __tunnelinfo *T; // $a1
+	// 		tunnelinfo *T; // $a1
 	/* end block 1 */
 	// End offset: 0x00052460
 	// End Line: 1325
@@ -2614,7 +2614,7 @@ void InitTunnels(char n)
 		// Start line: 1332
 		// Start offset: 0x00052848
 		// Variables:
-	// 		struct __tunnelinfo *T; // $t0
+	// 		tunnelinfo *T; // $t0
 	/* end block 1 */
 	// End offset: 0x000528FC
 	// End Line: 1344
@@ -2645,7 +2645,7 @@ int AddTunnel(long x1, long y1, long z1, long x2, long y2, long z2)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Tunnels(struct __tunnelinfo *T /*$a0*/)
+// void /*$ra*/ Tunnels(tunnelinfo *T /*$a0*/)
  // line 1350, offset 0x0005027c
 	/* begin block 1 */
 		// Start line: 1351
@@ -2673,7 +2673,7 @@ int AddTunnel(long x1, long y1, long z1, long x2, long y2, long z2)
 	// End Line: 3120
 
 // [D] [T]
-void Tunnels(__tunnelinfo* T)
+void Tunnels(tunnelinfo* T)
 {
 	int i;
 	int verb;
@@ -2802,7 +2802,7 @@ void AddTunnels(int level)
 		// Variables:
 	// 		int i; // $v1
 	// 		int p; // $a1
-	// 		struct __envsoundtags *T; // $t1
+	// 		__envsoundtags *T; // $t1
 	/* end block 1 */
 	// End offset: 0x0005243C
 	// End Line: 1538
@@ -2817,7 +2817,7 @@ void AddTunnels(int level)
 	/* end block 3 */
 	// End Line: 5623
 
-static struct __envsoundtags EStags;
+static __envsoundtags EStags;
 
 // [D] [T]
 void InitEnvSnd(int num_envsnds)
@@ -2933,8 +2933,8 @@ void SetEnvSndPos(int snd, long px, long pz)
 		// Start offset: 0x00050C08
 		// Variables:
 	// 		void *data; // $a1
-	// 		struct __envsound *ep; // $t1
-	// 		struct __envsoundtags *T; // $t0
+	// 		envsound *ep; // $t1
+	// 		__envsoundtags *T; // $t0
 	// 		long s; // $a1
 	/* end block 1 */
 	// End offset: 0x00050E08
@@ -2948,7 +2948,7 @@ void SetEnvSndPos(int snd, long px, long pz)
 // [D] [T]
 int AddEnvSnd(int type, char flags, int bank, int sample, int vol, long px, long pz, long px2, long pz2)
 {
-	__envsound* ep;
+	envsound* ep;
 
 	if (EStags.envsnd_cnt >= EStags.num_envsnds)
 		return -1;
@@ -3001,7 +3001,7 @@ int AddEnvSnd(int type, char flags, int bank, int sample, int vol, long px, long
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ IdentifyZone(struct __envsound *ep /*$a3*/, struct __envsoundinfo *E /*stack 4*/, int pl /*$a2*/)
+// void /*$ra*/ IdentifyZone(envsound *ep /*$a3*/, envsoundinfo *E /*stack 4*/, int pl /*$a2*/)
  // line 1646, offset 0x00050e08
 	/* begin block 1 */
 		// Start line: 1647
@@ -3012,7 +3012,7 @@ int AddEnvSnd(int type, char flags, int bank, int sample, int vol, long px, long
 	// 		int tmp[4]; // stack offset -96
 	// 		float d; // $s0
 	// 		float _g[4]; // stack offset -80
-	// 		struct __bitfield64 zones; // stack offset -64
+	// 		__bitfield64 zones; // stack offset -64
 	/* end block 1 */
 	// End offset: 0x000514BC
 	// End Line: 1704
@@ -3028,7 +3028,7 @@ int AddEnvSnd(int type, char flags, int bank, int sample, int vol, long px, long
 	// End Line: 3740
 
 // [D] [T]
-void IdentifyZone(__envsound* ep, __envsoundinfo* E, int pl)
+void IdentifyZone(envsound* ep, envsoundinfo* E, int pl)
 {
 	int i, j;
 	int vol;
@@ -3189,7 +3189,7 @@ void IdentifyZone(__envsound* ep, __envsoundinfo* E, int pl)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CalcEffPos(struct __envsound *ep /*$s1*/, struct __envsoundinfo *E /*$a1*/, int pl /*$a2*/)
+// void /*$ra*/ CalcEffPos(envsound *ep /*$s1*/, envsoundinfo *E /*$a1*/, int pl /*$a2*/)
  // line 1706, offset 0x000514bc
 	/* begin block 1 */
 		// Start line: 1707
@@ -3212,7 +3212,7 @@ void IdentifyZone(__envsound* ep, __envsoundinfo* E, int pl)
 	// End Line: 3907
 
 // [D] [A] unprocessed arrays
-void CalcEffPos(__envsound* ep, __envsoundinfo* E, int pl)
+void CalcEffPos(envsound* ep, envsoundinfo* E, int pl)
 {
 	int minX, maxX;
 	int minZ, maxZ;
@@ -3303,7 +3303,7 @@ void CalcEffPos(__envsound* ep, __envsoundinfo* E, int pl)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CalcEffPos2(struct __envsound *ep /*stack 0*/, struct __envsoundinfo *E /*$s7*/, int pl /*$a2*/)
+// void /*$ra*/ CalcEffPos2(envsound *ep /*stack 0*/, envsoundinfo *E /*$s7*/, int pl /*$a2*/)
  // line 1744, offset 0x000517d0
 	/* begin block 1 */
 		// Start line: 1745
@@ -3333,7 +3333,7 @@ void CalcEffPos(__envsound* ep, __envsoundinfo* E, int pl)
 	// End Line: 4014
 
 // [D] [A] unprocessed arrays
-void CalcEffPos2(__envsound* ep, __envsoundinfo* E, int pl)
+void CalcEffPos2(envsound* ep, envsoundinfo* E, int pl)
 {
 	int snd;
 	int i;
@@ -3513,7 +3513,7 @@ void CalcEffPos2(__envsound* ep, __envsoundinfo* E, int pl)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ UpdateEnvSnd(struct __envsound *ep /*stack 0*/, struct __envsoundinfo *E /*$s4*/, int pl /*stack 8*/)
+// void /*$ra*/ UpdateEnvSnd(envsound *ep /*stack 0*/, envsoundinfo *E /*$s4*/, int pl /*stack 8*/)
  // line 1812, offset 0x00051f0c
 	/* begin block 1 */
 		// Start line: 1813
@@ -3535,7 +3535,7 @@ void CalcEffPos2(__envsound* ep, __envsoundinfo* E, int pl)
 	// End Line: 4446
 
 // [D] [T]
-void UpdateEnvSnd(__envsound* ep, __envsoundinfo* E, int pl)
+void UpdateEnvSnd(envsound* ep, envsoundinfo* E, int pl)
 {
 	int channel;
 	long* velocity;
@@ -3608,7 +3608,7 @@ void InitLeadHorn(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ LeadHorn(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ LeadHorn(CAR_DATA *cp /*$s0*/)
  // line 1855, offset 0x00052954
 	/* begin block 1 */
 		// Start line: 1856
@@ -3630,7 +3630,7 @@ void InitLeadHorn(void)
 	// End Line: 7806
 
 // [D] [T]
-void LeadHorn(_CAR_DATA* cp)
+void LeadHorn(CAR_DATA* cp)
 {
 	static unsigned int rnd = 0;
 

--- a/src_rebuild/GAME/C/GAMESND.H
+++ b/src_rebuild/GAME/C/GAMESND.H
@@ -26,17 +26,17 @@ extern void LoadLevelSFX(int missionNum); // 0x0004D784
 
 extern void StartGameSounds(); // 0x0004DE30
 
-extern ushort GetEngineRevs(struct _CAR_DATA *cp); // 0x0004E188
+extern ushort GetEngineRevs(CAR_DATA *cp); // 0x0004E188
 
-extern void ControlCarRevs(struct _CAR_DATA *cp); // 0x0004E2E8
+extern void ControlCarRevs(CAR_DATA *cp); // 0x0004E2E8
 
 extern void DoSpeech(int chan, int sound); // 0x000525F8
 
-extern char PlaySpeech(struct SPEECH_QUEUE *pSpeechQueue, int sound); // 0x0005228C
+extern char PlaySpeech(SPEECH_QUEUE *pSpeechQueue, int sound); // 0x0005228C
 
-extern void InitSpeechQueue(struct SPEECH_QUEUE *pSpeechQueue); // 0x00052654
+extern void InitSpeechQueue(SPEECH_QUEUE *pSpeechQueue); // 0x00052654
 
-extern void ControlSpeech(struct SPEECH_QUEUE *pSpeechQueue); // 0x0004E560
+extern void ControlSpeech(SPEECH_QUEUE *pSpeechQueue); // 0x0004E560
 
 extern void CopSay(int phrase, int direction); // 0x00052190
 
@@ -52,7 +52,7 @@ extern void DoDopplerSFX(); // 0x0004E790
 
 extern void DoPoliceLoudhailer(int cars, unsigned short *indexlist, unsigned long *dist); // 0x0004F4A0
 
-extern void CollisionSound(char player_id, struct _CAR_DATA *cp, int impact, int car_car); // 0x0004F668
+extern void CollisionSound(char player_id, CAR_DATA *cp, int impact, int car_car); // 0x0004F668
 
 extern void ExplosionSound(VECTOR *pos, int type); // 0x0004F984
 
@@ -68,7 +68,7 @@ extern void InitTunnels(char n); // 0x0005243C
 
 extern int AddTunnel(long x1, long y1, long z1, long x2, long y2, long z2); // 0x00052848
 
-extern void Tunnels(struct __tunnelinfo *T); // 0x0005027C
+extern void Tunnels(tunnelinfo *T); // 0x0005027C
 
 extern void AddTunnels(int level); // 0x00050400
 
@@ -80,17 +80,17 @@ extern void SetEnvSndPos(int snd, long px, long pz); // 0x00052904
 
 extern int AddEnvSnd(int type, char flags, int bank, int sample, int vol, long px, long pz, long px2, long pz2); // 0x00050C08
 
-extern void IdentifyZone(struct __envsound *ep, struct __envsoundinfo *E, int pl); // 0x00050E08
+extern void IdentifyZone(envsound *ep, envsoundinfo *E, int pl); // 0x00050E08
 
-extern void CalcEffPos(struct __envsound *ep, struct __envsoundinfo *E, int pl); // 0x000514BC
+extern void CalcEffPos(envsound *ep, envsoundinfo *E, int pl); // 0x000514BC
 
-extern void CalcEffPos2(struct __envsound *ep, struct __envsoundinfo *E, int pl); // 0x000517D0
+extern void CalcEffPos2(envsound *ep, envsoundinfo *E, int pl); // 0x000517D0
 
-extern void UpdateEnvSnd(struct __envsound *ep, struct __envsoundinfo *E, int pl); // 0x00051F0C
+extern void UpdateEnvSnd(envsound *ep, envsoundinfo *E, int pl); // 0x00051F0C
 
 extern void InitLeadHorn(); // 0x00052948
 
-extern void LeadHorn(struct _CAR_DATA *cp); // 0x00052954
+extern void LeadHorn(CAR_DATA *cp); // 0x00052954
 
 
 #endif

--- a/src_rebuild/GAME/C/GLAUNCH.C
+++ b/src_rebuild/GAME/C/GLAUNCH.C
@@ -109,7 +109,7 @@ int AttractMode = 0;
 		// Start line: 836
 		// Start offset: 0x00052A28
 		// Variables:
-	// 		struct RECT rect; // stack offset -16
+	// 		RECT rect; // stack offset -16
 	// 		int oldVMode; // $s0
 	// 		int SurvivalCopSettingsBackup; // $s0
 	/* end block 1 */
@@ -322,7 +322,7 @@ void StartRender(int renderNum)
 		// Start line: 1032
 		// Start offset: 0x00052E98
 		// Variables:
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00052FE8
 	// End Line: 1103
@@ -404,8 +404,8 @@ void ReInitFrontend(void)
 		// Start line: 1106
 		// Start offset: 0x00052FE8
 		// Variables:
-	// 		struct MISSION_STEP *CurrentStep; // $s0
-	// 		struct RENDER_ARGS RenderArgs; // stack offset -48
+	// 		MISSION_STEP *CurrentStep; // $s0
+	// 		RENDER_ARGS RenderArgs; // stack offset -48
 	// 		int quit; // $s3
 
 		/* begin block 1.1 */
@@ -679,7 +679,7 @@ int FindPrevMissionFromLadderPos(int pos)
 		// Start line: 1281
 		// Start offset: 0x000532B8
 		// Variables:
-	// 		struct RECT rect; // stack offset -16
+	// 		RECT rect; // stack offset -16
 	// 		int quit; // $s0
 	/* end block 1 */
 	// End offset: 0x000535D8
@@ -839,7 +839,7 @@ void LaunchGame(void)
 		// Start line: 1418
 		// Start offset: 0x00053740
 		// Variables:
-	// 		struct MISSION_STEP *step; // $a1
+	// 		MISSION_STEP *step; // $a1
 	// 		int pos; // $a2
 	/* end block 1 */
 	// End offset: 0x00053814

--- a/src_rebuild/GAME/C/HANDLING.C
+++ b/src_rebuild/GAME/C/HANDLING.C
@@ -29,7 +29,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitCarPhysics(struct _CAR_DATA *cp /*$s0*/, long (*startpos)[4] /*$t0*/, int direction /*$a2*/)
+// void /*$ra*/ InitCarPhysics(CAR_DATA *cp /*$s0*/, long (*startpos)[4] /*$t0*/, int direction /*$a2*/)
  // line 998, offset 0x0005381c
 	/* begin block 1 */
 		// Start line: 999
@@ -63,7 +63,7 @@
 
 
 // [D] [T]
-void InitCarPhysics(_CAR_DATA* cp, long(*startpos)[4], int direction)
+void InitCarPhysics(CAR_DATA* cp, long(*startpos)[4], int direction)
 {
 	int ty;
 	int odz;
@@ -126,7 +126,7 @@ void InitCarPhysics(_CAR_DATA* cp, long(*startpos)[4], int direction)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TempBuildHandlingMatrix(struct _CAR_DATA *cp /*$s0*/, int init /*$a1*/)
+// void /*$ra*/ TempBuildHandlingMatrix(CAR_DATA *cp /*$s0*/, int init /*$a1*/)
  // line 1055, offset 0x000539e8
 	/* begin block 1 */
 		// Start line: 1056
@@ -154,7 +154,7 @@ void InitCarPhysics(_CAR_DATA* cp, long(*startpos)[4], int direction)
 	// End Line: 2179
 
 // [D] [T]
-void TempBuildHandlingMatrix(_CAR_DATA* cp, int init)
+void TempBuildHandlingMatrix(CAR_DATA* cp, int init)
 {
 	int dz;
 	int ang;
@@ -182,14 +182,14 @@ void TempBuildHandlingMatrix(_CAR_DATA* cp, int init)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ UpdateCarPoints(struct CAR_COSMETICS *carCos /*$a0*/)
+// void /*$ra*/ UpdateCarPoints(CAR_COSMETICS *carCos /*$a0*/)
  // line 1079, offset 0x00053b08
 	/* begin block 1 */
 		// Start line: 1080
 		// Start offset: 0x00053B08
 		// Variables:
-	// 		struct SVECTOR *groundCollPoints; // $a1
-	// 		struct SVECTOR *wheelPoints; // $a3
+	// 		SVECTOR *groundCollPoints; // $a1
+	// 		SVECTOR *wheelPoints; // $a3
 	// 		int i; // $a2
 	/* end block 1 */
 	// End offset: 0x00053C00
@@ -259,7 +259,7 @@ void UpdateCarPoints(CAR_COSMETICS* carCos)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ FixCarCos(struct CAR_COSMETICS *carCos /*$s0*/, int externalModelNumber /*$a1*/)
+// void /*$ra*/ FixCarCos(CAR_COSMETICS *carCos /*$s0*/, int externalModelNumber /*$a1*/)
  // line 1106, offset 0x00056c24
 	/* begin block 1 */
 		// Start line: 1107
@@ -398,17 +398,17 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 	// 		int i; // $fp
 	// 		int RKstep; // stack offset -84
 	// 		int subframe; // stack offset -80
-	// 		struct _CAR_DATA *c0; // $s0
-	// 		static union RigidBodyState _tp[20]; // offset 0x0
-	// 		static union RigidBodyState _d0[20]; // offset 0x410
-	// 		static union RigidBodyState _d1[20]; // offset 0x820
+	// 		CAR_DATA *c0; // $s0
+	// 		static RigidBodyState _tp[20]; // offset 0x0
+	// 		static RigidBodyState _d0[20]; // offset 0x410
+	// 		static RigidBodyState _d1[20]; // offset 0x820
 
 		/* begin block 1.1 */
 			// Start line: 1268
 			// Start offset: 0x00053C6C
 			// Variables:
-		// 		struct _CAR_DATA *c0; // $t2
-		// 		union RigidBodyState *st; // $t1
+		// 		CAR_DATA *c0; // $t2
+		// 		RigidBodyState *st; // $t1
 
 			/* begin block 1.1.1 */
 				// Start line: 1283
@@ -436,28 +436,28 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 			// Start line: 1334
 			// Start offset: 0x00054024
 			// Variables:
-		// 		union RigidBodyState *thisDelta; // stack offset -76
+		// 		RigidBodyState *thisDelta; // stack offset -76
 
 			/* begin block 1.2.1 */
 				// Start line: 1340
 				// Start offset: 0x00054038
 				// Variables:
-			// 		struct _CAR_DATA *c0; // $s4
+			// 		CAR_DATA *c0; // $s4
 
 				/* begin block 1.2.1.1 */
 					// Start line: 1348
 					// Start offset: 0x00054094
 					// Variables:
-				// 		union RigidBodyState *thisState_i; // $s6
+				// 		RigidBodyState *thisState_i; // $s6
 				// 		int j; // stack offset -72
 
 					/* begin block 1.2.1.1.1 */
 						// Start line: 1193
 						// Start offset: 0x000540EC
 						// Variables:
-					// 		union RigidBodyState *state; // $s6
-					// 		union RigidBodyState *delta; // $a3
-					// 		struct _CAR_DATA *cp; // $s4
+					// 		RigidBodyState *state; // $s6
+					// 		RigidBodyState *delta; // $a3
+					// 		CAR_DATA *cp; // $s4
 
 						/* begin block 1.2.1.1.1.1 */
 							// Start line: 1193
@@ -475,8 +475,8 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 						// Start line: 1367
 						// Start offset: 0x000542D8
 						// Variables:
-					// 		struct _CAR_DATA *c1; // $s3
-					// 		union RigidBodyState *thisState_j; // $s0
+					// 		CAR_DATA *c1; // $s3
+					// 		RigidBodyState *thisState_j; // $s0
 
 						/* begin block 1.2.1.1.2.1 */
 							// Start line: 1375
@@ -492,8 +492,8 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 								// Start line: 1378
 								// Start offset: 0x00054340
 								// Variables:
-							// 		struct BOUND_BOX *bb1; // $a2
-							// 		struct BOUND_BOX *bb2; // $a0
+							// 		BOUND_BOX *bb1; // $a2
+							// 		BOUND_BOX *bb2; // $a0
 							/* end block 1.2.1.1.2.1.1 */
 							// End offset: 0x00054440
 							// End Line: 1409
@@ -532,7 +532,7 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 									// Start line: 1487
 									// Start offset: 0x00054870
 									// Variables:
-								// 		struct VECTOR velocity; // stack offset -104
+								// 		VECTOR velocity; // stack offset -104
 
 									/* begin block 1.2.1.1.2.1.3.2.1 */
 										// Start line: 1506
@@ -600,16 +600,16 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 				// Start line: 1626
 				// Start offset: 0x00054FA4
 				// Variables:
-			// 		struct _CAR_DATA *c0; // $a1
+			// 		CAR_DATA *c0; // $a1
 
 				/* begin block 1.2.2.1 */
 					// Start line: 1630
 					// Start offset: 0x00054FC4
 					// Variables:
-				// 		union RigidBodyState *st; // $t2
-				// 		union RigidBodyState *tp; // $a0
-				// 		union RigidBodyState *d0; // $a2
-				// 		union RigidBodyState *d1; // $v1
+				// 		RigidBodyState *st; // $t2
+				// 		RigidBodyState *tp; // $a0
+				// 		RigidBodyState *d0; // $a2
+				// 		RigidBodyState *d1; // $v1
 				// 		int j; // $t1
 				/* end block 1.2.2.1 */
 				// End offset: 0x000550B0
@@ -685,9 +685,9 @@ int playerhitcopsanyway = 0;
 // [D] [T]
 void GlobalTimeStep(void)
 {
-	static union RigidBodyState _tp[MAX_CARS]; // offset 0x0
-	static union RigidBodyState _d0[MAX_CARS]; // offset 0x410
-	static union RigidBodyState _d1[MAX_CARS]; // offset 0x820
+	static RigidBodyState _tp[MAX_CARS]; // offset 0x0
+	static RigidBodyState _d0[MAX_CARS]; // offset 0x410
+	static RigidBodyState _d1[MAX_CARS]; // offset 0x820
 
 	int howHard;
 	long tmp;
@@ -696,8 +696,8 @@ void GlobalTimeStep(void)
 	RigidBodyState* thisDelta;
 	BOUND_BOX* bb1;
 	BOUND_BOX* bb2;
-	_CAR_DATA* cp;
-	_CAR_DATA* c1;
+	CAR_DATA* cp;
+	CAR_DATA* c1;
 	RigidBodyState* st;
 	RigidBodyState* tp;
 	RigidBodyState* d0;
@@ -1200,24 +1200,24 @@ void GlobalTimeStep(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetShadowPoints(struct _CAR_DATA *c0 /*$s4*/)
+// void /*$ra*/ SetShadowPoints(CAR_DATA *c0 /*$s4*/)
  // line 1704, offset 0x000551ec
 	/* begin block 1 */
 		// Start line: 1705
 		// Start offset: 0x000551EC
 		// Variables:
 	// 		int j; // $s2
-	// 		struct CAR_COSMETICS *car_cos; // $v1
-	// 		struct _sdPlane *surfacePtr; // stack offset -48
+	// 		CAR_COSMETICS *car_cos; // $v1
+	// 		sdPlane *surfacePtr; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 1718
 			// Start offset: 0x000552A8
 			// Variables:
-		// 		struct SVECTOR disp; // stack offset -104
-		// 		struct VECTOR pointPos; // stack offset -96
-		// 		struct VECTOR surfaceNormal; // stack offset -80
-		// 		struct VECTOR surfacePoint; // stack offset -64
+		// 		SVECTOR disp; // stack offset -104
+		// 		VECTOR pointPos; // stack offset -96
+		// 		VECTOR surfaceNormal; // stack offset -80
+		// 		VECTOR surfacePoint; // stack offset -64
 		/* end block 1.1 */
 		// End offset: 0x00055388
 		// End Line: 1739
@@ -1243,7 +1243,7 @@ void GlobalTimeStep(void)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-void SetShadowPoints(_CAR_DATA* c0, VECTOR* outpoints)
+void SetShadowPoints(CAR_DATA* c0, VECTOR* outpoints)
 {
 	int i;
 	SVECTOR disp;
@@ -1251,7 +1251,7 @@ void SetShadowPoints(_CAR_DATA* c0, VECTOR* outpoints)
 	VECTOR surfaceNormal;
 	CAR_COSMETICS* car_cos;
 
-	_sdPlane* surfacePtr;
+	sdPlane* surfacePtr;
 	surfacePtr = NULL;
 
 	gte_SetRotMatrix(&c0->hd.where);
@@ -1279,7 +1279,7 @@ void SetShadowPoints(_CAR_DATA* c0, VECTOR* outpoints)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ LongQuaternion2Matrix(long (*qua)[4] /*$a0*/, struct MATRIX *m /*$a1*/)
+// void /*$ra*/ LongQuaternion2Matrix(long (*qua)[4] /*$a0*/, MATRIX *m /*$a1*/)
  // line 1753, offset 0x000553cc
 	/* begin block 1 */
 		// Start line: 1754
@@ -1361,13 +1361,13 @@ void LongQuaternion2Matrix(long(*qua)[4], MATRIX* m)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ initOBox(struct _CAR_DATA *cp /*$a2*/)
+// void /*$ra*/ initOBox(CAR_DATA *cp /*$a2*/)
  // line 1802, offset 0x000554f0
 	/* begin block 1 */
 		// Start line: 1803
 		// Start offset: 0x000554F0
 		// Variables:
-	// 		struct SVECTOR *boxDisp; // $a0
+	// 		SVECTOR *boxDisp; // $a0
 
 		/* begin block 1.1 */
 			// Start line: 1803
@@ -1392,7 +1392,7 @@ void LongQuaternion2Matrix(long(*qua)[4], MATRIX* m)
 	// End Line: 5020
 
 // [D] [T]
-void initOBox(_CAR_DATA* cp)
+void initOBox(CAR_DATA* cp)
 {
 	SVECTOR boxDisp;
 	CAR_COSMETICS* car_cos;
@@ -1448,7 +1448,7 @@ void initOBox(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RebuildCarMatrix(union RigidBodyState *st /*$a2*/, struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ RebuildCarMatrix(RigidBodyState *st /*$a2*/, CAR_DATA *cp /*$s0*/)
  // line 1854, offset 0x00056ae4
 	/* begin block 1 */
 		// Start line: 1855
@@ -1481,7 +1481,7 @@ void initOBox(_CAR_DATA* cp)
 	// End Line: 3709
 
 // [D] [T]
-void RebuildCarMatrix(RigidBodyState* st, _CAR_DATA* cp)
+void RebuildCarMatrix(RigidBodyState* st, CAR_DATA* cp)
 {
 	int sm;
 	int osm;
@@ -1529,13 +1529,13 @@ void RebuildCarMatrix(RigidBodyState* st, _CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StepCarPhysics(struct _CAR_DATA *cp /*$a2*/)
+// void /*$ra*/ StepCarPhysics(CAR_DATA *cp /*$a2*/)
  // line 1875, offset 0x00056a0c
 	/* begin block 1 */
 		// Start line: 1876
 		// Start offset: 0x00056A0C
 		// Variables:
-	// 		struct _HANDLING_TYPE *hp; // $v0
+	// 		_HANDLING_TYPE *hp; // $v0
 	/* end block 1 */
 	// End offset: 0x00056A64
 	// End Line: 1899
@@ -1546,7 +1546,7 @@ void RebuildCarMatrix(RigidBodyState* st, _CAR_DATA* cp)
 	// End Line: 3751
 
 // [D] [T]
-void StepCarPhysics(_CAR_DATA* cp)
+void StepCarPhysics(CAR_DATA* cp)
 {
 	_HANDLING_TYPE* hp;
 	int car_id;
@@ -1633,14 +1633,14 @@ void InitialiseCarHandling(void)
 		// Start line: 1932
 		// Start offset: 0x000556E0
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $t2
-	// 		struct BOUND_BOX *bp; // $t1
-	// 		struct BOUND_BOX *bb1; // $t0
-	// 		struct BOUND_BOX *bb2; // $a1
+	// 		CAR_DATA *cp; // $t2
+	// 		BOUND_BOX *bp; // $t1
+	// 		BOUND_BOX *bb1; // $t0
+	// 		BOUND_BOX *bb2; // $a1
 	// 		int lbod; // $v1
 	// 		int wbod; // $a0
 	// 		int hbod; // $t0
-	// 		struct SVECTOR *colBox; // $a1
+	// 		SVECTOR *colBox; // $a1
 	// 		int loop1; // $t4
 	// 		int loop2; // $a3
 
@@ -1697,7 +1697,7 @@ void CheckCarToCarCollisions(void)
 	BOUND_BOX* bb;
 	BOUND_BOX* bb2;
 	BOUND_BOX* bb1;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	SVECTOR* colBox;
 
 	cp = car_data;
@@ -1835,7 +1835,7 @@ void CheckCarToCarCollisions(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ProcessCarPad(struct _CAR_DATA *cp /*$s0*/, unsigned long pad /*$s3*/, char PadSteer /*$s4*/, char use_analogue /*$s5*/)
+// void /*$ra*/ ProcessCarPad(CAR_DATA *cp /*$s0*/, unsigned long pad /*$s3*/, char PadSteer /*$s4*/, char use_analogue /*$s5*/)
 // line 2027, offset 0x00055a9c
 /* begin block 1 */
 // Start line: 2028
@@ -1884,7 +1884,7 @@ void CheckCarToCarCollisions(void)
 // Start line: 2320
 // Start offset: 0x000560D4
 // Variables:
-// 		struct _CAR_DATA *tp; // $a1
+// 		CAR_DATA *tp; // $a1
 // 		int cx; // $v1
 // 		int cz; // $v0
 // 		int chase_square_dist; // $v0
@@ -1913,7 +1913,7 @@ void CheckCarToCarCollisions(void)
 // End Line: 5532
 
 // [D] [T]
-void ProcessCarPad(_CAR_DATA* cp, ulong pad, char PadSteer, char use_analogue)
+void ProcessCarPad(CAR_DATA* cp, ulong pad, char PadSteer, char use_analogue)
 {
 	int player_id;
 	int int_steer;
@@ -2124,7 +2124,7 @@ void ProcessCarPad(_CAR_DATA* cp, ulong pad, char PadSteer, char use_analogue)
 
 			if (cp->controlType == CONTROL_TYPE_PLAYER)
 			{
-				_CAR_DATA* tp;
+				CAR_DATA* tp;
 				int targetCarId, cx, cz, chase_square_dist;
 
 				if (player[0].playerCarId == cp->id)
@@ -2263,7 +2263,7 @@ void TerminateSkidding(int player_id)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CheckCarEffects(struct _CAR_DATA *cp /*$s2*/, int player_id /*$s3*/)
+// void /*$ra*/ CheckCarEffects(CAR_DATA *cp /*$s2*/, int player_id /*$s3*/)
 // line 2414, offset 0x00056350
 /* begin block 1 */
 // Start line: 2415
@@ -2328,7 +2328,7 @@ char continuous_track = 0;
 int last_track_state = -1;
 
 // [D] [T]
-void CheckCarEffects(_CAR_DATA* cp, int player_id)
+void CheckCarEffects(CAR_DATA* cp, int player_id)
 {
 	int channel;
 	int sample;
@@ -2530,7 +2530,7 @@ void CheckCarEffects(_CAR_DATA* cp, int player_id)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ jump_debris(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ jump_debris(CAR_DATA *cp /*$s1*/)
 // line 2575, offset 0x000568d8
 /* begin block 1 */
 // Start line: 2576
@@ -2542,8 +2542,8 @@ void CheckCarEffects(_CAR_DATA* cp, int player_id)
 // Start line: 2599
 // Start offset: 0x00056964
 // Variables:
-// 		struct VECTOR position; // stack offset -48
-// 		struct VECTOR velocity; // stack offset -32
+// 		VECTOR position; // stack offset -48
+// 		VECTOR velocity; // stack offset -32
 /* end block 1.1 */
 // End offset: 0x000569F8
 // End Line: 2603
@@ -2564,7 +2564,7 @@ void CheckCarEffects(_CAR_DATA* cp, int player_id)
 char DebrisTimer = 0;
 
 // [D] [T]
-void jump_debris(_CAR_DATA* cp)
+void jump_debris(CAR_DATA* cp)
 {
 	WHEEL* wheel;
 	int count;
@@ -2619,7 +2619,7 @@ void jump_debris(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ nose_down(struct _CAR_DATA *cp /*$a0*/)
+// void /*$ra*/ nose_down(CAR_DATA *cp /*$a0*/)
 // line 2607, offset 0x00056a74
 /* begin block 1 */
 // Start line: 7459
@@ -2632,7 +2632,7 @@ void jump_debris(_CAR_DATA* cp)
 // End Line: 7462
 
 // [D] [T]
-void nose_down(_CAR_DATA* cp)
+void nose_down(CAR_DATA* cp)
 {
 	cp->st.n.angularVelocity[0] += cp->hd.where.m[0][0] * 50;
 	cp->st.n.angularVelocity[1] += cp->hd.where.m[1][0] * 50;
@@ -2643,7 +2643,7 @@ void nose_down(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GetPlayerId(struct _CAR_DATA *cp /*$a0*/)
+// int /*$ra*/ GetPlayerId(CAR_DATA *cp /*$a0*/)
 // line 2664, offset 0x00056cec
 /* begin block 1 */
 // Start line: 2665
@@ -2666,7 +2666,7 @@ void nose_down(_CAR_DATA* cp)
 // End Line: 9346
 
 // [D] [T]
-int GetPlayerId(_CAR_DATA* cp)
+int GetPlayerId(CAR_DATA* cp)
 {
 	int i;
 	int p_id;

--- a/src_rebuild/GAME/C/HANDLING.C
+++ b/src_rebuild/GAME/C/HANDLING.C
@@ -29,7 +29,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitCarPhysics(CAR_DATA *cp /*$s0*/, long (*startpos)[4] /*$t0*/, int direction /*$a2*/)
+// void /*$ra*/ InitCarPhysics(CAR_DATA *cp /*$s0*/, LONGVECTOR* startpos /*$t0*/, int direction /*$a2*/)
  // line 998, offset 0x0005381c
 	/* begin block 1 */
 		// Start line: 999
@@ -423,8 +423,8 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 				// Start line: 1301
 				// Start offset: 0x00053E18
 				// Variables:
-			// 		long AV[4]; // stack offset -248
-			// 		long delta_orientation[4]; // stack offset -232
+			// 		LONGVECTOR AV; // stack offset -248
+			// 		LONGQUATERNION delta_orientation; // stack offset -232
 			/* end block 1.1.2 */
 			// End offset: 0x00053FF8
 			// End Line: 1321
@@ -463,7 +463,7 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 							// Start line: 1193
 							// Start offset: 0x000540EC
 							// Variables:
-						// 		long AV[4]; // stack offset -248
+						// 		LONGVECTOR AV; // stack offset -248
 						/* end block 1.2.1.1.1.1 */
 						// End offset: 0x000540EC
 						// End Line: 1193
@@ -483,10 +483,10 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 							// Start offset: 0x00054340
 							// Variables:
 						// 		int strength; // $s5
-						// 		long centre0[4]; // stack offset -248
-						// 		long centre1[4]; // stack offset -232
-						// 		long normal[4]; // stack offset -216
-						// 		long collisionpoint[4]; // stack offset -200
+						// 		LONGVECTOR centre0; // stack offset -248
+						// 		LONGVECTOR centre1; // stack offset -232
+						// 		LONGVECTOR normal; // stack offset -216
+						// 		LONGVECTOR collisionpoint; // stack offset -200
 
 							/* begin block 1.2.1.1.2.1.1 */
 								// Start line: 1378
@@ -511,11 +511,11 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 								// Start line: 1419
 								// Start offset: 0x00054460
 								// Variables:
-							// 		long lever0[4]; // stack offset -184
-							// 		long lever1[4]; // stack offset -168
-							// 		long torque[4]; // stack offset -152
-							// 		long pointVel0[4]; // stack offset -136
-							// 		long pointVel1[4]; // stack offset -120
+							// 		LONGVECTOR lever0; // stack offset -184
+							// 		LONGVECTOR lever1; // stack offset -168
+							// 		LONGVECTOR torque; // stack offset -152
+							// 		LONGVECTOR pointVel0; // stack offset -136
+							// 		LONGVECTOR pointVel1; // stack offset -120
 							// 		int strikeVel; // stack offset -68
 
 								/* begin block 1.2.1.1.2.1.3.1 */
@@ -560,7 +560,7 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 										// Start line: 1548
 										// Start offset: 0x00054A50
 										// Variables:
-									// 		long force[4]; // stack offset -104
+									// 		LONGVECTOR force; // stack offset -104
 									// 		int strength1; // $a0
 									// 		int twistY; // $t4
 									/* end block 1.2.1.1.2.1.3.3.1 */
@@ -571,7 +571,7 @@ void FixCarCos(CAR_COSMETICS* carCos, int externalModelNumber)
 										// Start line: 1581
 										// Start offset: 0x00054CA8
 										// Variables:
-									// 		long force[4]; // stack offset -104
+									// 		LONGVECTOR force; // stack offset -104
 									// 		int strength2; // $a1
 									// 		int twistY; // $t2
 									/* end block 1.2.1.1.2.1.3.3.2 */
@@ -702,14 +702,14 @@ void GlobalTimeStep(void)
 	RigidBodyState* tp;
 	RigidBodyState* d0;
 	RigidBodyState* d1;
-	long AV[4];
-	long delta_orientation[4];
-	long normal[4];
-	long collisionpoint[4];
-	long lever0[4];
-	long lever1[4];
-	long torque[4];
-	long pointVel0[4];
+	LONGVECTOR AV;
+	LONGQUATERNION delta_orientation;
+	LONGVECTOR normal;
+	LONGVECTOR collisionpoint;
+	LONGVECTOR lever0;
+	LONGVECTOR lever1;
+	LONGVECTOR torque;
+	LONGVECTOR pointVel0;
 	VECTOR velocity;
 	int depth;
 	int RKstep;
@@ -928,10 +928,10 @@ void GlobalTimeStep(void)
 
 								if (howHard > 0 && RKstep > -1)
 								{
-									if (DamageCar3D(c1, (long(*)[4])lever1, howHard >> 1, cp))
+									if (DamageCar3D(c1, &lever1, howHard >> 1, cp))
 										c1->ap.needsDenting = 1;
 
-									if (DamageCar3D(cp, (long(*)[4])lever0, howHard >> 1, c1))
+									if (DamageCar3D(cp, &lever0, howHard >> 1, c1))
 										cp->ap.needsDenting = 1;
 
 									if (howHard > 0x32000)
@@ -1279,7 +1279,7 @@ void SetShadowPoints(CAR_DATA* c0, VECTOR* outpoints)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ LongQuaternion2Matrix(long (*qua)[4] /*$a0*/, MATRIX *m /*$a1*/)
+// void /*$ra*/ LongQuaternion2Matrix(LONGQUATERNION* qua /*$a0*/, MATRIX *m /*$a1*/)
  // line 1753, offset 0x000553cc
 	/* begin block 1 */
 		// Start line: 1754
@@ -1314,41 +1314,26 @@ void SetShadowPoints(CAR_DATA* c0, VECTOR* outpoints)
 	// End Line: 4834
 
 // [D] [T]
-void LongQuaternion2Matrix(long(*qua)[4], MATRIX* m)
+void LongQuaternion2Matrix(LONGQUATERNION *qua, MATRIX* m)
 {
-	int xx;
-	int xy;
-	int xz;
-	int xw;
-	int yy;
-	int yz;
-	int yw;
-	int zz;
-	int zw;
+	int qx = (*qua)[0];
+	int qy = (*qua)[1];
+	int qz = (*qua)[2];
+	int qw = (*qua)[3];
 
-	int qy;
-	int qx;
-	int qw;
-	int qz;
+	int yy = FixHalfRound(qy * qy, 11);
+	int zz = FixHalfRound(qz * qz, 11);
+	int xx = FixHalfRound(qx * qx, 11);
+	int zw = FixHalfRound(qz * qw, 11);
+	int xy = FixHalfRound(qx * qy, 11);
+	int xz = FixHalfRound(qx * qz, 11);
+	int yw = FixHalfRound(qy * qw, 11);
+	int xw = FixHalfRound(qx * qw, 11);
+	int yz = FixHalfRound(qy * qz, 11);
 
-	qx = (*qua)[0];
-	qy = (*qua)[1];
-	qz = (*qua)[2];
-	qw = (*qua)[3];
-
-	yy = FixHalfRound(qy * qy, 11);
-	zz = FixHalfRound(qz * qz, 11);
-	xx = FixHalfRound(qx * qx, 11);
-	zw = FixHalfRound(qz * qw, 11);
-	xy = FixHalfRound(qx * qy, 11);
-	xz = FixHalfRound(qx * qz, 11);
-	yw = FixHalfRound(qy * qw, 11);
-	xw = FixHalfRound(qx * qw, 11);
-	yz = FixHalfRound(qy * qz, 11);
-
-	m->m[0][0] = 4096 - (yy + zz);
-	m->m[1][1] = 4096 - (xx + zz);
-	m->m[2][2] = 4096 - (xx + yy);
+	m->m[0][0] = ONE - (yy + zz);
+	m->m[1][1] = ONE - (xx + zz);
+	m->m[2][2] = ONE - (xx + yy);
 	m->m[0][1] = xy - zw;
 	m->m[0][2] = xz + yw;
 	m->m[1][0] = xy + zw;
@@ -1520,7 +1505,7 @@ void RebuildCarMatrix(RigidBodyState* st, CAR_DATA* cp)
 	}
 	st->n.orientation[3] = sm;
 
-	LongQuaternion2Matrix((long(*)[4])st->n.orientation, &cp->hd.where);
+	LongQuaternion2Matrix(&st->n.orientation, &cp->hd.where);
 
 	initOBox(cp);
 }

--- a/src_rebuild/GAME/C/HANDLING.H
+++ b/src_rebuild/GAME/C/HANDLING.H
@@ -6,9 +6,9 @@ extern int playerghost;
 extern int playerhitcopsanyway;
 extern char continuous_track;
 
-extern void InitCarPhysics(_CAR_DATA *cp, long (*startpos)[4], int direction); // 0x0005381C
+extern void InitCarPhysics(CAR_DATA *cp, long (*startpos)[4], int direction); // 0x0005381C
 
-extern void TempBuildHandlingMatrix(_CAR_DATA *cp, int init); // 0x000539E8
+extern void TempBuildHandlingMatrix(CAR_DATA *cp, int init); // 0x000539E8
 
 extern void UpdateCarPoints(CAR_COSMETICS *carCos); // 0x00053B08
 
@@ -16,33 +16,33 @@ extern void FixCarCos(CAR_COSMETICS *carCos, int externalModelNumber); // 0x0005
 
 extern void GlobalTimeStep(); // 0x00053C00
 
-extern void SetShadowPoints(_CAR_DATA *c0, VECTOR* outpoints); // 0x000551EC
+extern void SetShadowPoints(CAR_DATA *c0, VECTOR* outpoints); // 0x000551EC
 
 extern void LongQuaternion2Matrix(long (*qua)[4], MATRIX *m); // 0x000553CC
 
-extern void initOBox(_CAR_DATA *cp); // 0x000554F0
+extern void initOBox(CAR_DATA *cp); // 0x000554F0
 
-extern void RebuildCarMatrix(union RigidBodyState *st, _CAR_DATA *cp); // 0x00056AE4
+extern void RebuildCarMatrix(RigidBodyState *st, CAR_DATA *cp); // 0x00056AE4
 
-extern void StepCarPhysics(_CAR_DATA *cp); // 0x00056A0C
+extern void StepCarPhysics(CAR_DATA *cp); // 0x00056A0C
 
 extern void InitialiseCarHandling(); // 0x00056A6C
 
 extern void CheckCarToCarCollisions(); // 0x000556E0
 
-extern void ProcessCarPad(_CAR_DATA *cp, unsigned long pad, char PadSteer, char use_analogue); // 0x00055A9C
+extern void ProcessCarPad(CAR_DATA *cp, unsigned long pad, char PadSteer, char use_analogue); // 0x00055A9C
 
 extern void InitSkidding(); // 0x00056CB8
 
 extern void TerminateSkidding(int player_id); // 0x000562AC
 
-extern void CheckCarEffects(_CAR_DATA *cp, int player_id); // 0x00056350
+extern void CheckCarEffects(CAR_DATA *cp, int player_id); // 0x00056350
 
-extern void jump_debris(_CAR_DATA *cp); // 0x000568D8
+extern void jump_debris(CAR_DATA *cp); // 0x000568D8
 
-extern void nose_down(_CAR_DATA *cp); // 0x00056A74
+extern void nose_down(CAR_DATA *cp); // 0x00056A74
 
-extern int GetPlayerId(_CAR_DATA *cp); // 0x00056CEC
+extern int GetPlayerId(CAR_DATA *cp); // 0x00056CEC
 
 
 #endif

--- a/src_rebuild/GAME/C/HANDLING.H
+++ b/src_rebuild/GAME/C/HANDLING.H
@@ -6,7 +6,7 @@ extern int playerghost;
 extern int playerhitcopsanyway;
 extern char continuous_track;
 
-extern void InitCarPhysics(CAR_DATA *cp, long (*startpos)[4], int direction); // 0x0005381C
+extern void InitCarPhysics(CAR_DATA *cp, LONGVECTOR* startpos, int direction); // 0x0005381C
 
 extern void TempBuildHandlingMatrix(CAR_DATA *cp, int init); // 0x000539E8
 
@@ -18,7 +18,7 @@ extern void GlobalTimeStep(); // 0x00053C00
 
 extern void SetShadowPoints(CAR_DATA *c0, VECTOR* outpoints); // 0x000551EC
 
-extern void LongQuaternion2Matrix(long (*qua)[4], MATRIX *m); // 0x000553CC
+extern void LongQuaternion2Matrix(LONGQUATERNION* qua, MATRIX *m); // 0x000553CC
 
 extern void initOBox(CAR_DATA *cp); // 0x000554F0
 

--- a/src_rebuild/GAME/C/JOB_FX.C
+++ b/src_rebuild/GAME/C/JOB_FX.C
@@ -12,7 +12,7 @@
 
 #include "INLINE_C.H"
 
-_ExOBJECT explosion[MAX_EXPLOSION_OBJECTS];
+EXOBJECT explosion[MAX_EXPLOSION_OBJECTS];
 
 MATRIX SS = { 0 };
 
@@ -66,7 +66,7 @@ void InitExObjects(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddExplosion(struct VECTOR pos /*stack 0*/, int type /*stack 16*/)
+// void /*$ra*/ AddExplosion(VECTOR pos /*stack 0*/, int type /*stack 16*/)
  // line 129, offset 0x00056d54
 	/* begin block 1 */
 		// Start line: 130
@@ -90,7 +90,7 @@ void InitExObjects(void)
 // [D]
 void AddExplosion(VECTOR pos, int type)
 {
-	_ExOBJECT *newExplosion;
+	EXOBJECT *newExplosion;
 	int i;
 
 	i = 0;
@@ -141,7 +141,7 @@ void AddExplosion(VECTOR pos, int type)
 		// Start offset: 0x00056E44
 		// Variables:
 	// 		int i; // $s5
-	// 		struct _CAR_DATA *cp; // $s0
+	// 		CAR_DATA *cp; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 212
@@ -178,8 +178,8 @@ void AddExplosion(VECTOR pos, int type)
 // [D]
 void HandleExplosion(void)
 {
-	_CAR_DATA *cp;
-	_ExOBJECT *exp;
+	CAR_DATA *cp;
+	EXOBJECT *exp;
 	int i;
 
 	if (pauseflag != 0)
@@ -412,7 +412,7 @@ void initExplosion(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawExplosion(int time /*stack 0*/, struct VECTOR position /*stack 4*/, int hscale /*stack 20*/, int rscale /*stack 24*/)
+// void /*$ra*/ DrawExplosion(int time /*stack 0*/, VECTOR position /*stack 4*/, int hscale /*stack 20*/, int rscale /*stack 24*/)
  // line 588, offset 0x000572a8
 	/* begin block 1 */
 		// Start line: 589
@@ -420,9 +420,9 @@ void initExplosion(void)
 		// Variables:
 	// 		int i; // $t1
 	// 		int j; // $s3
-	// 		struct POLY_FT4 *poly; // $a2
-	// 		struct SVECTOR *src; // $t0
-	// 		struct VECTOR v; // stack offset -136
+	// 		POLY_FT4 *poly; // $a2
+	// 		SVECTOR *src; // $t0
+	// 		VECTOR v; // stack offset -136
 	// 		int rgb; // $s0
 	// 		int z; // stack offset -56
 	// 		int sf1; // $t0
@@ -447,7 +447,7 @@ void initExplosion(void)
 			// Start line: 631
 			// Start offset: 0x000573F0
 			// Variables:
-		// 		struct MATRIX workmatrix; // stack offset -120
+		// 		MATRIX workmatrix; // stack offset -120
 		// 		int sf; // $v0
 		// 		int s; // $v1
 		// 		int c; // $a3
@@ -471,7 +471,7 @@ void initExplosion(void)
 			// Start line: 698
 			// Start offset: 0x000577A4
 			// Variables:
-		// 		struct MATRIX workmatrix; // stack offset -88
+		// 		MATRIX workmatrix; // stack offset -88
 		// 		int sf; // $v0
 		// 		int s; // $v1
 		// 		int c; // $a3

--- a/src_rebuild/GAME/C/JOB_FX.H
+++ b/src_rebuild/GAME/C/JOB_FX.H
@@ -1,7 +1,7 @@
 #ifndef JOB_FX_H
 #define JOB_FX_H
 
-extern _ExOBJECT explosion[MAX_EXPLOSION_OBJECTS];
+extern EXOBJECT explosion[MAX_EXPLOSION_OBJECTS];
 
 extern void InitExObjects(); // 0x00057B0C
 

--- a/src_rebuild/GAME/C/LEADAI.C
+++ b/src_rebuild/GAME/C/LEADAI.C
@@ -298,7 +298,7 @@ void LeadUpdateState(CAR_DATA *cp)
 		tmpStart.vy = MapHeight(&tmpStart);
 		tmpStart.vy = tmpStart.vy - ((cp->ap).carCos)->wheelDisp[0].vy;
 
-		InitCarPhysics(cp, (long(*)[4]) & tmpStart, (int)cp->ai.l.targetDir);
+		InitCarPhysics(cp, (LONGVECTOR *)&tmpStart, (int)cp->ai.l.targetDir);
 
 		cp->ai.l.dstate = 3;
 	}

--- a/src_rebuild/GAME/C/LEADAI.C
+++ b/src_rebuild/GAME/C/LEADAI.C
@@ -53,7 +53,7 @@ int leadRand(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitLead(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ InitLead(CAR_DATA *cp /*$s0*/)
  // line 278, offset 0x000e7128
 	/* begin block 1 */
 		// Start line: 279
@@ -63,8 +63,8 @@ int leadRand(void)
 			// Start line: 319
 			// Start offset: 0x000E71A0
 			// Variables:
-		// 		struct DRIVER2_STRAIGHT *straight; // $a3
-		// 		struct DRIVER2_CURVE *curve; // $t0
+		// 		DRIVER2_STRAIGHT *straight; // $a3
+		// 		DRIVER2_CURVE *curve; // $t0
 		// 		int i; // $a2
 		// 		int dx; // $a0
 		// 		int dz; // $a1
@@ -83,7 +83,7 @@ int leadRand(void)
 	// End Line: 560
 
 // [D]
-void InitLead(_CAR_DATA *cp)
+void InitLead(CAR_DATA *cp)
 {
 	int iVar1;
 	int iVar2;
@@ -198,7 +198,7 @@ void InitLead(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ LeadUpdateState(struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ LeadUpdateState(CAR_DATA *cp /*$s0*/)
  // line 382, offset 0x000e73e8
 	/* begin block 1 */
 		// Start line: 383
@@ -211,7 +211,7 @@ void InitLead(_CAR_DATA *cp)
 			// Start line: 399
 			// Start offset: 0x000E7498
 			// Variables:
-		// 		struct VECTOR tmpStart; // stack offset -48
+		// 		VECTOR tmpStart; // stack offset -48
 		/* end block 1.1 */
 		// End offset: 0x000E74EC
 		// End Line: 412
@@ -229,7 +229,7 @@ void InitLead(_CAR_DATA *cp)
 			// Start line: 542
 			// Start offset: 0x000E7938
 			// Variables:
-		// 		struct VECTOR pos; // stack offset -32
+		// 		VECTOR pos; // stack offset -32
 		/* end block 1.3 */
 		// End offset: 0x000E7980
 		// End Line: 557
@@ -248,7 +248,7 @@ void InitLead(_CAR_DATA *cp)
 	// End Line: 871
 
 // [D]
-void LeadUpdateState(_CAR_DATA *cp)
+void LeadUpdateState(CAR_DATA *cp)
 {
 	bool bVar1;
 	int iVar2;
@@ -502,7 +502,7 @@ void LeadUpdateState(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// unsigned long /*$ra*/ LeadPadResponse(struct _CAR_DATA *cp /*$t0*/)
+// unsigned long /*$ra*/ LeadPadResponse(CAR_DATA *cp /*$t0*/)
  // line 566, offset 0x000e7994
 	/* begin block 1 */
 		// Start line: 567
@@ -550,7 +550,7 @@ void LeadUpdateState(_CAR_DATA *cp)
 	// End Line: 1283
 
 // [D]
-ulong LeadPadResponse(_CAR_DATA *cp)
+ulong LeadPadResponse(CAR_DATA *cp)
 {
 	int iVar1;
 	int iVar2;
@@ -767,7 +767,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ FakeMotion(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ FakeMotion(CAR_DATA *cp /*$s1*/)
  // line 718, offset 0x000e7de8
 	/* begin block 1 */
 		// Start line: 719
@@ -777,7 +777,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 			// Start line: 724
 			// Start offset: 0x000E7E40
 			// Variables:
-		// 		struct DRIVER2_STRAIGHT *straight; // $t1
+		// 		DRIVER2_STRAIGHT *straight; // $t1
 		// 		static int d; // offset 0x0
 		// 		static int toGo; // offset 0x4
 		// 		static int angle; // offset 0x8
@@ -791,7 +791,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 				// Start line: 757
 				// Start offset: 0x000E7FA4
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *junction; // $s0
+			// 		DRIVER2_JUNCTION *junction; // $s0
 			/* end block 1.1.1 */
 			// End offset: 0x000E7FA4
 			// End Line: 757
@@ -803,7 +803,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 			// Start line: 781
 			// Start offset: 0x000E8010
 			// Variables:
-		// 		struct DRIVER2_CURVE *curve; // $s0
+		// 		DRIVER2_CURVE *curve; // $s0
 		// 		int angle; // $a3
 		// 		int toGo; // $v0
 		// 		int radius; // $a2
@@ -815,7 +815,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 				// Start line: 813
 				// Start offset: 0x000E8104
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *junction; // $s0
+			// 		DRIVER2_JUNCTION *junction; // $s0
 			/* end block 1.2.1 */
 			// End offset: 0x000E8104
 			// End Line: 813
@@ -824,7 +824,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 				// Start line: 848
 				// Start offset: 0x000E81F0
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *junction; // $s0
+			// 		DRIVER2_JUNCTION *junction; // $s0
 			/* end block 1.2.2 */
 			// End offset: 0x000E81F0
 			// End Line: 848
@@ -836,7 +836,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 			// Start line: 877
 			// Start offset: 0x000E82E0
 			// Variables:
-		// 		struct DRIVER2_JUNCTION *junction; // $s0
+		// 		DRIVER2_JUNCTION *junction; // $s0
 		/* end block 1.3 */
 		// End offset: 0x000E8338
 		// End Line: 885
@@ -855,7 +855,7 @@ ulong LeadPadResponse(_CAR_DATA *cp)
 	// End Line: 1645
 
 // [D]
-void FakeMotion(_CAR_DATA *cp)
+void FakeMotion(CAR_DATA *cp)
 {
 	static int d; // offset 0x0
 	static int toGo; // offset 0x4
@@ -1047,7 +1047,7 @@ LAB_LEAD__000e824c:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PosToIndex(int *normal /*$t1*/, int *tangent /*$t4*/, int intention /*$a2*/, struct _CAR_DATA *cp /*$a3*/)
+// void /*$ra*/ PosToIndex(int *normal /*$t1*/, int *tangent /*$t4*/, int intention /*$a2*/, CAR_DATA *cp /*$a3*/)
  // line 932, offset 0x000e834c
 	/* begin block 1 */
 		// Start line: 933
@@ -1108,7 +1108,7 @@ LAB_LEAD__000e824c:
 	// End Line: 2159
 
 // [D]
-void PosToIndex(int *normal, int *tangent, int intention, _CAR_DATA *cp)
+void PosToIndex(int *normal, int *tangent, int intention, CAR_DATA *cp)
 {
 	int uVar1;
 	int iVar2;
@@ -1241,7 +1241,7 @@ void PosToIndex(int *normal, int *tangent, int intention, _CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ BlockToMap(struct MAP_DATA *data /*$s3*/)
+// void /*$ra*/ BlockToMap(MAP_DATA *data /*$s3*/)
  // line 1053, offset 0x000e86bc
 	/* begin block 1 */
 		// Start line: 1054
@@ -1255,7 +1255,7 @@ void PosToIndex(int *normal, int *tangent, int intention, _CAR_DATA *cp)
 	// 		static int right; // offset 0x20
 	// 		static int ldist; // offset 0x24
 	// 		static int rdist; // offset 0x28
-	// 		static struct MAP_DATA newdata; // offset 0x30
+	// 		static MAP_DATA newdata; // offset 0x30
 
 		/* begin block 1.1 */
 			// Start line: 1074
@@ -1274,7 +1274,7 @@ void PosToIndex(int *normal, int *tangent, int intention, _CAR_DATA *cp)
 			// Start line: 1166
 			// Start offset: 0x000E8AB0
 			// Variables:
-		// 		struct DRIVER2_CURVE *curve; // $s1
+		// 		DRIVER2_CURVE *curve; // $s1
 		// 		int dx; // $s6
 		// 		int dz; // $s5
 		// 		int v; // $a0
@@ -1439,7 +1439,7 @@ void BlockToMap(MAP_DATA *data)
 	static int right; // offset 0x20
 	static int ldist; // offset 0x24
 	static int rdist; // offset 0x28
-	static struct MAP_DATA newdata; // offset 0x30
+	static MAP_DATA newdata; // offset 0x30
 
 	static int offx;
 
@@ -1452,7 +1452,7 @@ void BlockToMap(MAP_DATA *data)
 	VECTOR* pVVar5;
 	CAR_COSMETICS* pCVar6;
 	VECTOR* pVVar7;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	int x;
 	int iVar8;
 	int iVar9;
@@ -1982,7 +1982,7 @@ LAB_LEAD__000e97b4:
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ IsOnMap(int x /*$t0*/, int z /*$a1*/, struct VECTOR *basePos /*$a2*/, int intention /*$s4*/, struct _CAR_DATA *cp /*stack 16*/)
+// int /*$ra*/ IsOnMap(int x /*$t0*/, int z /*$a1*/, VECTOR *basePos /*$a2*/, int intention /*$s4*/, CAR_DATA *cp /*stack 16*/)
  // line 1563, offset 0x000e98a4
 	/* begin block 1 */
 		// Start line: 1564
@@ -2005,7 +2005,7 @@ LAB_LEAD__000e97b4:
 			// Start line: 1596
 			// Start offset: 0x000E99F4
 			// Variables:
-		// 		struct DRIVER2_CURVE *curve; // $s0
+		// 		DRIVER2_CURVE *curve; // $s0
 		// 		int tangent; // stack offset -36
 		// 		int normal; // stack offset -40
 		/* end block 1.2 */
@@ -2038,7 +2038,7 @@ LAB_LEAD__000e97b4:
 /* WARNING: Type propagation algorithm not settling */
 
 // [D]
-int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
+int IsOnMap(int x, int z, VECTOR *basePos, int intention, CAR_DATA *cp)
 {
 	DRIVER2_CURVE* curve;
 	int dx;
@@ -2115,7 +2115,7 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ UpdateRoadPosition(struct _CAR_DATA *cp /*$s3*/, struct VECTOR *basePos /*stack 4*/, int intention /*stack 8*/)
+// void /*$ra*/ UpdateRoadPosition(CAR_DATA *cp /*$s3*/, VECTOR *basePos /*stack 4*/, int intention /*stack 8*/)
  // line 1657, offset 0x000e9bb8
 	/* begin block 1 */
 		// Start line: 1658
@@ -2124,7 +2124,7 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 	// 		int sindex; // $t0
 	// 		int i; // $s0
 	// 		int di; // $a2
-	// 		struct _CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *lcp; // $s0
 	// 		int laneAvoid; // stack offset -56
 
 		/* begin block 1.1 */
@@ -2153,15 +2153,15 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 						// Start line: 1714
 						// Start offset: 0x000E9D94
 						// Variables:
-					// 		struct CELL_OBJECT *cop; // $s1
-					// 		struct CELL_ITERATOR ci; // stack offset -344
+					// 		CELL_OBJECT *cop; // $s1
+					// 		CELL_ITERATOR ci; // stack offset -344
 
 						/* begin block 1.1.1.1.1.1 */
 							// Start line: 1721
 							// Start offset: 0x000E9DB0
 							// Variables:
-						// 		struct COLLISION_PACKET *collide; // $s0
-						// 		struct MODEL *model; // $a0
+						// 		COLLISION_PACKET *collide; // $s0
+						// 		MODEL *model; // $a0
 						// 		int num_cb; // $a0
 						// 		int box_loop; // $s2
 
@@ -2169,11 +2169,11 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 								// Start line: 1739
 								// Start offset: 0x000E9E4C
 								// Variables:
-							// 		struct MATRIX *mat; // $a1
-							// 		struct VECTOR offset; // stack offset -320
-							// 		struct VECTOR vel; // stack offset -304
-							// 		struct VECTOR size; // stack offset -288
-							// 		struct MAP_DATA data; // stack offset -272
+							// 		MATRIX *mat; // $a1
+							// 		VECTOR offset; // stack offset -320
+							// 		VECTOR vel; // stack offset -304
+							// 		VECTOR size; // stack offset -288
+							// 		MAP_DATA data; // stack offset -272
 
 								/* begin block 1.1.1.1.1.1.1.1 */
 									// Start line: 1753
@@ -2210,11 +2210,11 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 			// Start line: 1814
 			// Start offset: 0x000EA0CC
 			// Variables:
-		// 		struct SVECTOR *colBox; // $a3
-		// 		struct VECTOR pos; // stack offset -344
-		// 		struct VECTOR vel; // stack offset -328
-		// 		struct VECTOR size; // stack offset -312
-		// 		struct MAP_DATA data; // stack offset -296
+		// 		SVECTOR *colBox; // $a3
+		// 		VECTOR pos; // stack offset -344
+		// 		VECTOR vel; // stack offset -328
+		// 		VECTOR size; // stack offset -312
+		// 		MAP_DATA data; // stack offset -296
 		/* end block 1.2 */
 		// End offset: 0x000EA260
 		// End Line: 1845
@@ -2309,7 +2309,7 @@ int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp)
 			// Start line: 2226
 			// Start offset: 0x000EB0C4
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s3
+		// 		CAR_DATA *cp; // $s3
 		// 		int sindex; // $a0
 		// 		int intention; // stack offset 8
 		/* end block 1.10 */
@@ -2333,7 +2333,7 @@ int roadAhead[41]; // offset 0x000ecde8
 int localMap[41]; // offset 0x000ecd40
 
 // [D] [A] overlapping stack variables - might be incorrect (i've tried to resolve them so far)
-void UpdateRoadPosition(_CAR_DATA *cp, VECTOR *basePos, int intention)
+void UpdateRoadPosition(CAR_DATA *cp, VECTOR *basePos, int intention)
 {
 	short* psVar1;
 	short* psVar2;
@@ -2359,7 +2359,7 @@ void UpdateRoadPosition(_CAR_DATA *cp, VECTOR *basePos, int intention)
 	int iVar15;
 	int iVar16;
 	COLLISION_PACKET* collide;
-	_CAR_DATA* lcp;
+	CAR_DATA* lcp;
 	int uVar17;
 	VECTOR offset;
 	VECTOR pos;
@@ -3167,7 +3167,7 @@ LAB_LEAD__000eb0c8:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CheckCurrentRoad(struct _CAR_DATA *cp /*$s3*/)
+// void /*$ra*/ CheckCurrentRoad(CAR_DATA *cp /*$s3*/)
  // line 2242, offset 0x000eb1fc
 	/* begin block 1 */
 		// Start line: 2243
@@ -3177,14 +3177,14 @@ LAB_LEAD__000eb0c8:
 	// 		int cr; // $s5
 	// 		static int jdist; // offset 0x20
 	// 		static int nextJunction; // offset 0x50
-	// 		static struct VECTOR basePosition; // offset 0x60
+	// 		static VECTOR basePosition; // offset 0x60
 	// 		int checkNext; // $s6
 
 		/* begin block 1.1 */
 			// Start line: 2278
 			// Start offset: 0x000EB300
 			// Variables:
-		// 		struct DRIVER2_STRAIGHT *straight; // $t3
+		// 		DRIVER2_STRAIGHT *straight; // $t3
 		// 		static int d; // offset 0x70
 		// 		static int toGo; // offset 0x74
 		// 		static int angle; // offset 0x78
@@ -3200,7 +3200,7 @@ LAB_LEAD__000eb0c8:
 			// Start line: 2328
 			// Start offset: 0x000EB5C4
 			// Variables:
-		// 		struct DRIVER2_CURVE *curve; // $s2
+		// 		DRIVER2_CURVE *curve; // $s2
 		// 		static int angle; // offset 0x84
 		// 		static int radius; // offset 0x88
 		// 		static int dx; // offset 0x8c
@@ -3220,7 +3220,7 @@ LAB_LEAD__000eb0c8:
 				// Start line: 2420
 				// Start offset: 0x000EB98C
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *junction; // $s0
+			// 		DRIVER2_JUNCTION *junction; // $s0
 			/* end block 1.3.1 */
 			// End offset: 0x000EB9D4
 			// End Line: 2428
@@ -3229,7 +3229,7 @@ LAB_LEAD__000eb0c8:
 				// Start line: 2440
 				// Start offset: 0x000EBA14
 				// Variables:
-			// 		struct DRIVER2_STRAIGHT *straight; // $v1
+			// 		DRIVER2_STRAIGHT *straight; // $v1
 			/* end block 1.3.2 */
 			// End offset: 0x000EBA5C
 			// End Line: 2446
@@ -3238,7 +3238,7 @@ LAB_LEAD__000eb0c8:
 				// Start line: 2449
 				// Start offset: 0x000EBA5C
 				// Variables:
-			// 		struct DRIVER2_CURVE *curve; // $v1
+			// 		DRIVER2_CURVE *curve; // $v1
 			// 		static int dx; // offset 0x9c
 			// 		static int dz; // offset 0xa0
 			/* end block 1.3.3 */
@@ -3249,7 +3249,7 @@ LAB_LEAD__000eb0c8:
 				// Start line: 2475
 				// Start offset: 0x000EBB2C
 				// Variables:
-			// 		struct DRIVER2_STRAIGHT *straight; // $t1
+			// 		DRIVER2_STRAIGHT *straight; // $t1
 			// 		static int dx; // offset 0xa4
 			// 		static int dz; // offset 0xa8
 			// 		static int dist; // offset 0xac
@@ -3263,7 +3263,7 @@ LAB_LEAD__000eb0c8:
 				// Start line: 2504
 				// Start offset: 0x000EBC5C
 				// Variables:
-			// 		struct DRIVER2_CURVE *curve; // $s4
+			// 		DRIVER2_CURVE *curve; // $s4
 			// 		static int angle; // offset 0xb8
 			// 		int radius; // $s2
 			// 		static int dx; // offset 0xbc
@@ -3296,7 +3296,7 @@ LAB_LEAD__000eb0c8:
 	// End Line: 5779
 
 // [D]
-void CheckCurrentRoad(_CAR_DATA *cp)
+void CheckCurrentRoad(CAR_DATA *cp)
 {
 	static int heading; // offset 0x1c
 	static int nextJunction; // offset 0x50
@@ -3739,7 +3739,7 @@ LAB_LEAD__000eb96c:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetTarget(struct _CAR_DATA *cp /*$s1*/, int cr /*$a0*/, int heading /*$s4*/, int *nextJunction /*$s3*/)
+// void /*$ra*/ SetTarget(CAR_DATA *cp /*$s1*/, int cr /*$a0*/, int heading /*$s4*/, int *nextJunction /*$s3*/)
  // line 2644, offset 0x000ec1c4
 	/* begin block 1 */
 		// Start line: 2645
@@ -3759,7 +3759,7 @@ LAB_LEAD__000eb96c:
 			// Start line: 2675
 			// Start offset: 0x000EC298
 			// Variables:
-		// 		struct DRIVER2_STRAIGHT *straight; // $t5
+		// 		DRIVER2_STRAIGHT *straight; // $t5
 		// 		int dx; // $a1
 		// 		int dz; // $a0
 		// 		int rx; // $v1
@@ -3777,7 +3777,7 @@ LAB_LEAD__000eb96c:
 			// Start line: 2720
 			// Start offset: 0x000EC444
 			// Variables:
-		// 		struct DRIVER2_CURVE *curve; // $s0
+		// 		DRIVER2_CURVE *curve; // $s0
 		// 		int angle; // $a1
 		// 		int radius; // $a2
 		/* end block 1.3 */
@@ -3793,7 +3793,7 @@ LAB_LEAD__000eb96c:
 	// End Line: 6938
 
 // [D]
-void SetTarget(_CAR_DATA *cp, int cr, int heading, int *nextJunction)
+void SetTarget(CAR_DATA *cp, int cr, int heading, int *nextJunction)
 {
 	static int dx = 0; // offset 0xd8
 	static int dz = 0; // offset 0xdc
@@ -3916,7 +3916,7 @@ void SetTarget(_CAR_DATA *cp, int cr, int heading, int *nextJunction)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SelectExit(struct _CAR_DATA *cp /*$s3*/, struct DRIVER2_JUNCTION *junction /*$a3*/)
+// void /*$ra*/ SelectExit(CAR_DATA *cp /*$s3*/, DRIVER2_JUNCTION *junction /*$a3*/)
  // line 2763, offset 0x000ec5e4
 	/* begin block 1 */
 		// Start line: 2764
@@ -3964,7 +3964,7 @@ void SetTarget(_CAR_DATA *cp, int cr, int heading, int *nextJunction)
 	// End Line: 7242
 
 // [D]
-void SelectExit(_CAR_DATA *cp, DRIVER2_JUNCTION *junction)
+void SelectExit(CAR_DATA *cp, DRIVER2_JUNCTION *junction)
 {
 	int uVar1;
 	int uVar2;
@@ -4106,7 +4106,7 @@ LAB_LEAD__000ec924:
 
 // decompiled code
 // original method signature: 
-// unsigned long /*$ra*/ FreeRoamer(struct _CAR_DATA *cp /*$s1*/)
+// unsigned long /*$ra*/ FreeRoamer(CAR_DATA *cp /*$s1*/)
  // line 2848, offset 0x000ec99c
 	/* begin block 1 */
 		// Start line: 2849
@@ -4116,7 +4116,7 @@ LAB_LEAD__000ec924:
 			// Start line: 2965
 			// Start offset: 0x000ECA4C
 			// Variables:
-		// 		struct _CAR_DATA *pCar; // $v0
+		// 		CAR_DATA *pCar; // $v0
 
 			/* begin block 1.1.1 */
 				// Start line: 2965
@@ -4153,7 +4153,7 @@ LAB_LEAD__000ec924:
 	// End Line: 7436
 
 // [D]
-ulong FreeRoamer(_CAR_DATA *cp)
+ulong FreeRoamer(CAR_DATA *cp)
 {	
 	int i;
 	int playerCarId;

--- a/src_rebuild/GAME/C/LEADAI.H
+++ b/src_rebuild/GAME/C/LEADAI.H
@@ -4,21 +4,21 @@
 
 extern int leadRand(); // 0x000E70A0
 
-extern void InitLead(_CAR_DATA *cp); // 0x000E7128
+extern void InitLead(CAR_DATA *cp); // 0x000E7128
 
-extern void LeadUpdateState(_CAR_DATA *cp); // 0x000E73E8
+extern void LeadUpdateState(CAR_DATA *cp); // 0x000E73E8
 
-extern unsigned long LeadPadResponse(_CAR_DATA *cp); // 0x000E7994
+extern unsigned long LeadPadResponse(CAR_DATA *cp); // 0x000E7994
 
-extern void FakeMotion(_CAR_DATA *cp); // 0x000E7DE8
+extern void FakeMotion(CAR_DATA *cp); // 0x000E7DE8
 
-extern void PosToIndex(int *normal, int *tangent, int intention, _CAR_DATA *cp); // 0x000E834C
+extern void PosToIndex(int *normal, int *tangent, int intention, CAR_DATA *cp); // 0x000E834C
 
 extern void BlockToMap(MAP_DATA *data); // 0x000E86BC
 
-extern int IsOnMap(int x, int z, VECTOR *basePos, int intention, _CAR_DATA *cp); // 0x000E98A4
+extern int IsOnMap(int x, int z, VECTOR *basePos, int intention, CAR_DATA *cp); // 0x000E98A4
 
-extern void UpdateRoadPosition(_CAR_DATA *cp, VECTOR *basePos, int intention); // 0x000E9BB8
+extern void UpdateRoadPosition(CAR_DATA *cp, VECTOR *basePos, int intention); // 0x000E9BB8
 
 extern void slowWallTests() ; // 0x000E913C
 
@@ -28,13 +28,13 @@ extern void DoExtraWorkForNFrames() ; // 0x000E99AC
 
 extern void searchTarget() ; // 0x000E9AB8
 
-extern void CheckCurrentRoad(_CAR_DATA *cp); // 0x000EB1FC
+extern void CheckCurrentRoad(CAR_DATA *cp); // 0x000EB1FC
 
-extern void SetTarget(_CAR_DATA *cp, int cr, int heading, int *nextJunction); // 0x000EC1C4
+extern void SetTarget(CAR_DATA *cp, int cr, int heading, int *nextJunction); // 0x000EC1C4
 
-extern void SelectExit(_CAR_DATA *cp, DRIVER2_JUNCTION *junction); // 0x000EC5E4
+extern void SelectExit(CAR_DATA *cp, DRIVER2_JUNCTION *junction); // 0x000EC5E4
 
-extern unsigned long FreeRoamer(_CAR_DATA *cp); // 0x000EC99C
+extern unsigned long FreeRoamer(CAR_DATA *cp); // 0x000EC99C
 
 extern unsigned long hypot(long x, long y); // 0x000ECB28
 

--- a/src_rebuild/GAME/C/LOADSAVE.C
+++ b/src_rebuild/GAME/C/LOADSAVE.C
@@ -464,7 +464,7 @@ int SaveGameData(char* buffer)
 		// Start line: 86
 		// Start offset: 0x000580CC
 		// Variables:
-	// 		struct GAME_SAVE_HEADER *header; // $a0
+	// 		GAME_SAVE_HEADER *header; // $a0
 	/* end block 1 */
 	// End offset: 0x00058164
 	// End Line: 99
@@ -543,7 +543,7 @@ int CalcConfigDataSize(void)
 		// Start line: 110
 		// Start offset: 0x00057BF0
 		// Variables:
-	// 		struct CONFIG_SAVE_HEADER *header; // $s0
+	// 		CONFIG_SAVE_HEADER *header; // $s0
 	// 		int i; // $t0
 	/* end block 1 */
 	// End offset: 0x00057DF0
@@ -597,7 +597,7 @@ int SaveConfigData(char* buffer)
 		// Start line: 141
 		// Start offset: 0x00057DF0
 		// Variables:
-	// 		struct CONFIG_SAVE_HEADER *header; // $t3
+	// 		CONFIG_SAVE_HEADER *header; // $t3
 	// 		int i; // $t4
 	/* end block 1 */
 	// End offset: 0x00057FD4

--- a/src_rebuild/GAME/C/LOADVIEW.C
+++ b/src_rebuild/GAME/C/LOADVIEW.C
@@ -28,7 +28,7 @@ int loading_bar_pos = 0;
 		// Start line: 202
 		// Start offset: 0x0005816C
 		// Variables:
-	// 		struct POLY_G4 poly; // stack offset -56
+	// 		POLY_G4 poly; // stack offset -56
 	// 		int col; // $s0
 	/* end block 1 */
 	// End offset: 0x00058298
@@ -140,8 +140,8 @@ void SetupScreenFade(int start, int end, int speed)
 		// Start line: 269
 		// Start offset: 0x000582AC
 		// Variables:
-	// 		static struct POLY_F4 poly; // offset 0x0
-	// 		static struct POLY_FT4 p; // offset 0x20
+	// 		static POLY_F4 poly; // offset 0x0
+	// 		static POLY_FT4 p; // offset 0x20
 	// 		int do_fade; // $v0
 
 		/* begin block 1.1 */
@@ -233,9 +233,9 @@ void FadeGameScreen(int flag, int speed)
 	// 		int fcount; // $s0
 	// 		int j; // $s2
 	// 		int done; // $fp
-	// 		struct RECT dest; // stack offset -264
-	// 		struct SPRT prims[4]; // stack offset -256
-	// 		struct POLY_FT3 nulls[4]; // stack offset -176
+	// 		RECT dest; // stack offset -264
+	// 		SPRT prims[4]; // stack offset -256
+	// 		POLY_FT3 nulls[4]; // stack offset -176
 	// 		int fade; // $s5
 	// 		int fade_step; // stack offset -48
 	/* end block 1 */
@@ -436,7 +436,7 @@ void ShowLoadingScreen(char *screen_name, int effect, int loading_steps)
 		// Start line: 483
 		// Start offset: 0x000589D0
 		// Variables:
-	// 		struct POLY_F4 poly[2]; // stack offset -80
+	// 		POLY_F4 poly[2]; // stack offset -80
 	// 		int h; // $s0
 	// 		int done; // $s2
 	/* end block 1 */
@@ -561,7 +561,7 @@ void SetupFadePolys(void)
 		// Start line: 558
 		// Start offset: 0x00058824
 		// Variables:
-	// 		struct POLY_G4 *fl_g4; // $a2
+	// 		POLY_G4 *fl_g4; // $a2
 	/* end block 1 */
 	// End offset: 0x000589B0
 	// End Line: 577

--- a/src_rebuild/GAME/C/MAIN.C
+++ b/src_rebuild/GAME/C/MAIN.C
@@ -183,7 +183,7 @@ int gDemoLevel = 0;
 				// Start line: 2845
 				// Start offset: 0x00058F7C
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *dst; // $a0
+			// 		DRIVER2_JUNCTION *dst; // $a0
 			// 		unsigned long *src; // $a2
 			// 		int i; // $v1
 			/* end block 1.1.1 */
@@ -194,7 +194,7 @@ int gDemoLevel = 0;
 				// Start line: 2865
 				// Start offset: 0x00058FCC
 				// Variables:
-			// 		struct DRIVER2_JUNCTION *dst; // $a0
+			// 		DRIVER2_JUNCTION *dst; // $a0
 			// 		unsigned long *src; // $a2
 			// 		int i; // $v1
 			/* end block 1.1.2 */
@@ -612,7 +612,7 @@ void InitModelNames(void)
 			// Start line: 3305
 			// Start offset: 0x000596B0
 			// Variables:
-		// 		struct STREAM_SOURCE *pinfo; // $s0
+		// 		STREAM_SOURCE *pinfo; // $s0
 		// 		char padid; // stack offset -48
 		// 		int i; // $s2
 		/* end block 1.4 */
@@ -682,7 +682,7 @@ void InitModelNames(void)
 void GameInit(void)
 {
 	long lVar1;
-	_PLAYER* p_Var2;
+	PLAYER* p_Var2;
 	STREAM_SOURCE* pSVar3;
 	int i;
 	int iVar5;
@@ -995,7 +995,7 @@ void GameInit(void)
 	// 		static char t1; // offset 0x4
 	// 		static char t2; // offset 0x5
 	// 		static int oldsp; // offset 0x8
-	// 		struct _CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *lcp; // $s0
 	// 		int i; // $s2
 
 		/* begin block 1.1 */
@@ -1142,8 +1142,8 @@ void StepSim(void)
 	char padSteer;
 	short* playerFelony;
 	int stream;
-	_CAR_DATA* cp;
-	_PLAYER* pl;
+	CAR_DATA* cp;
+	PLAYER* pl;
 	int i, j;
 	int car;
 
@@ -1598,14 +1598,14 @@ void StepSim(void)
 		// Start offset: 0x0005A8DC
 		// Variables:
 	// 		int i; // $s0
-	// 		struct RECT dest; // stack offset -24
+	// 		RECT dest; // stack offset -24
 
 		/* begin block 1.1 */
 			// Start line: 4125
 			// Start offset: 0x0005AA2C
 			// Variables:
-		// 		static struct POLY_FT3 buffer[2]; // offset 0x10
-		// 		static struct POLY_FT3 *null; // offset 0xc
+		// 		static POLY_FT3 buffer[2]; // offset 0x10
+		// 		static POLY_FT3 *null; // offset 0xc
 		/* end block 1.1 */
 		// End offset: 0x0005AA98
 		// End Line: 4140
@@ -1809,7 +1809,7 @@ void StepGame(void)
 	int iVar2;
 	int i;
 	unsigned char* puVar4;
-	_PLAYER* pl;
+	PLAYER* pl;
 
 	if (CameraCnt == 3)
 	{
@@ -2161,7 +2161,7 @@ void DrawGame(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ EndGame(enum GAMEMODE mode /*$a0*/)
+// void /*$ra*/ EndGame(GAMEMODE mode /*$a0*/)
  // line 4586, offset 0x0005c574
 	/* begin block 1 */
 		// Start line: 10823
@@ -2193,7 +2193,7 @@ void EndGame(GAMEMODE mode)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ EnablePause(enum PAUSEMODE mode /*$a0*/)
+// void /*$ra*/ EnablePause(PAUSEMODE mode /*$a0*/)
  // line 4593, offset 0x0005c590
 	/* begin block 1 */
 		// Start line: 10842
@@ -2697,7 +2697,7 @@ void FadeScreen(int end_value)
 		// Start line: 4895
 		// Start offset: 0x0005B54C
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $s1
+	// 		CAR_DATA *cp; // $s1
 	// 		int count; // $s0
 	// 		int scale; // $v1
 	// 		int wheel; // $t1
@@ -2731,7 +2731,7 @@ void UpdatePlayerInformation(void)
 	int i, j;
 	int wheelsInWater;
 	int wheelsAboveWaterToDieWithFade;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 
 	cp = NULL;
 
@@ -2855,7 +2855,7 @@ void UpdatePlayerInformation(void)
 			// Start line: 5090
 			// Start offset: 0x0005BAE4
 			// Variables:
-		// 		struct POLY_F4 *poly; // $v1
+		// 		POLY_F4 *poly; // $v1
 		// 		int col; // $a1
 		/* end block 1.3 */
 		// End offset: 0x0005BC20
@@ -2892,7 +2892,7 @@ void RenderGame2(int view)
 	int notInDreaAndStevesEvilLair;
 
 	CurrentPlayerView = view;
-	InitCamera((_PLAYER*)(player + view));
+	InitCamera((PLAYER*)(player + view));
 
 #ifndef PSX
 	int screenW, screenH;
@@ -3262,7 +3262,7 @@ void InitGameVariables(void)
 		// Start line: 5346
 		// Start offset: 0x0005BF74
 		// Variables:
-	// 		struct _CAR_DATA *car; // $s0
+	// 		CAR_DATA *car; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 5348
@@ -3289,7 +3289,7 @@ void DealWithHorn(char* hr, int i)
 {
 	int channel;
 	int modelId;
-	_CAR_DATA* car;
+	CAR_DATA* car;
 
 	car = &car_data[player[i].playerCarId];
 

--- a/src_rebuild/GAME/C/MAIN.C
+++ b/src_rebuild/GAME/C/MAIN.C
@@ -857,7 +857,7 @@ void GameInit(void)
 
 		gStartOnFoot = (pSVar3->type == 2);
 
-		InitPlayer(&player[i], &car_data[i], pSVar3->controlType, pSVar3->rotation, (long(*)[4]) & pSVar3->position, pSVar3->model, pSVar3->palette, &padid);
+		InitPlayer(&player[i], &car_data[i], pSVar3->controlType, pSVar3->rotation, (LONGVECTOR *)&pSVar3->position, pSVar3->model, pSVar3->palette, &padid);
 
 		if (gStartOnFoot == 0)
 		{

--- a/src_rebuild/GAME/C/MAIN.H
+++ b/src_rebuild/GAME/C/MAIN.H
@@ -49,9 +49,9 @@ extern void StepGame(); // 0x0005AB28
 
 extern void DrawGame(); // 0x0005C458
 
-extern void EndGame(enum GAMEMODE mode); // 0x0005C574
+extern void EndGame(GAMEMODE mode); // 0x0005C574
 
-extern void EnablePause(enum PAUSEMODE mode); // 0x0005C590
+extern void EnablePause(PAUSEMODE mode); // 0x0005C590
 
 extern void CheckForPause(); // 0x0005C5D0
 

--- a/src_rebuild/GAME/C/MAP.C
+++ b/src_rebuild/GAME/C/MAP.C
@@ -40,7 +40,7 @@ CELL_OBJECT** coplist;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ NewProcessRoadMapLump(struct ROAD_MAP_LUMP_DATA *pRoadMapLumpData /*$s0*/, char *pLumpFile /*$s1*/)
+// void /*$ra*/ NewProcessRoadMapLump(ROAD_MAP_LUMP_DATA *pRoadMapLumpData /*$s0*/, char *pLumpFile /*$s1*/)
  // line 237, offset 0x0005d7bc
 	/* begin block 1 */
 		// Start line: 238
@@ -150,7 +150,7 @@ void ProcessJuncBoundsLump(char *lump_file, int lump_size)
 
 // decompiled code
 // original method signature: 
-// struct MODEL * /*$ra*/ FindModelPtrWithName(char *name /*$s4*/)
+// MODEL * /*$ra*/ FindModelPtrWithName(char *name /*$s4*/)
  // line 289, offset 0x0005d40c
 	/* begin block 1 */
 		// Start line: 290
@@ -353,7 +353,7 @@ void InitCellData(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ newPositionVisible(struct VECTOR *pos /*$a0*/, char *pvs /*$a1*/, int ccx /*$a2*/, int ccz /*$a3*/)
+// int /*$ra*/ newPositionVisible(VECTOR *pos /*$a0*/, char *pvs /*$a1*/, int ccx /*$a2*/, int ccz /*$a3*/)
  // line 378, offset 0x0005d61c
 	/* begin block 1 */
 		// Start line: 379
@@ -410,7 +410,7 @@ int newPositionVisible(VECTOR *pos, char *pvs, int ccx, int ccz)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ PositionVisible(struct VECTOR *pos /*$a0*/)
+// int /*$ra*/ PositionVisible(VECTOR *pos /*$a0*/)
  // line 400, offset 0x0005d560
 	/* begin block 1 */
 		// Start line: 401
@@ -484,7 +484,7 @@ int PositionVisible(VECTOR *pos)
 		// Start line: 440
 		// Start offset: 0x0005C824
 		// Variables:
-	// 		struct AREA_LOAD_INFO regions_to_unpack[3]; // stack offset -104
+	// 		AREA_LOAD_INFO regions_to_unpack[3]; // stack offset -104
 	// 		int leftright_unpack; // $a1
 	// 		int topbottom_unpack; // $a2
 	// 		int num_regions_to_unpack; // $s5
@@ -495,7 +495,7 @@ int PositionVisible(VECTOR *pos)
 	// 		int sortcount; // $s4
 	// 		int i; // $v1
 	// 		int j; // $a2
-	// 		struct SVECTOR sortregions[4]; // stack offset -80
+	// 		SVECTOR sortregions[4]; // stack offset -80
 	// 		unsigned short sortorder[4]; // stack offset -48
 	// 		int force_load_boundary; // $a0
 
@@ -504,7 +504,7 @@ int PositionVisible(VECTOR *pos)
 			// Start offset: 0x0005C9F4
 			// Variables:
 		// 		int region_to_unpack; // $s0
-		// 		struct Spool *spoolptr; // $a1
+		// 		Spool *spoolptr; // $a1
 
 			/* begin block 1.1.1 */
 				// Start line: 559
@@ -831,7 +831,7 @@ void ControlMap(void)
 				// Variables:
 			// 		int region; // $a3
 			// 		int barrel_region; // $a1
-			// 		struct Spool *spoolptr; // $v1
+			// 		Spool *spoolptr; // $v1
 
 				/* begin block 1.1.1.1 */
 					// Start line: 726
@@ -956,7 +956,7 @@ void InitMap(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetVisSetAtPosition(struct VECTOR *pos /*$a0*/, char *tgt /*$t3*/, int *ccx /*$a1*/, int *ccz /*$a3*/)
+// void /*$ra*/ GetVisSetAtPosition(VECTOR *pos /*$a0*/, char *tgt /*$t3*/, int *ccx /*$a1*/, int *ccz /*$a3*/)
  // line 756, offset 0x0005d6e4
 	/* begin block 1 */
 		// Start line: 757

--- a/src_rebuild/GAME/C/MAP.H
+++ b/src_rebuild/GAME/C/MAP.H
@@ -73,7 +73,7 @@ extern void ProcessRoadBoundsLump(char *lump_file, int lump_size); // 0x0005D6D4
 
 extern void ProcessJuncBoundsLump(char *lump_file, int lump_size); // 0x0005D6DC
 
-extern struct MODEL * FindModelPtrWithName(char *name); // 0x0005D40C
+extern MODEL * FindModelPtrWithName(char *name); // 0x0005D40C
 
 extern int FindModelIdxWithName(char *name); // 0x0005D4C4
 

--- a/src_rebuild/GAME/C/MC_SND.C
+++ b/src_rebuild/GAME/C/MC_SND.C
@@ -342,7 +342,7 @@ void InitializeCutsceneSound(int cutscene)
 					// Start line: 245
 					// Start offset: 0x0005DBAC
 					// Variables:
-				// 		struct _CAR_DATA *you; // $s0
+				// 		CAR_DATA *you; // $s0
 				/* end block 1.1.2.1 */
 				// End offset: 0x0005DBF0
 				// End Line: 248
@@ -658,8 +658,8 @@ void InitializeMissionSound(void)
 			// Start line: 475
 			// Start offset: 0x0005E348
 			// Variables:
-		// 		struct VECTOR Q[3]; // stack offset -96
-		// 		struct VECTOR P; // stack offset -48
+		// 		VECTOR Q[3]; // stack offset -96
+		// 		VECTOR P; // stack offset -48
 		/* end block 1.2 */
 		// End offset: 0x0005E410
 		// End Line: 478
@@ -677,8 +677,8 @@ void InitializeMissionSound(void)
 			// Start line: 523
 			// Start offset: 0x0005E6F0
 			// Variables:
-		// 		struct VECTOR Q[3]; // stack offset -96
-		// 		struct VECTOR P; // stack offset -48
+		// 		VECTOR Q[3]; // stack offset -96
+		// 		VECTOR P; // stack offset -48
 		/* end block 1.4 */
 		// End offset: 0x0005E7B8
 		// End Line: 526
@@ -728,7 +728,7 @@ void DoMissionSound(void)
 	char cVar1;
 	int y;
 	int z;
-	_TARGET* p_Var4;
+	MS_TARGET* p_Var4;
 	int x;
 	int y_00;
 	int z_00;
@@ -1076,7 +1076,7 @@ void DoMissionSound(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetMSoundVar(int var /*$a0*/, struct VECTOR *V /*$a1*/)
+// void /*$ra*/ SetMSoundVar(int var /*$a0*/, VECTOR *V /*$a1*/)
  // line 636, offset 0x0005f25c
 	/* begin block 1 */
 		// Start line: 1453

--- a/src_rebuild/GAME/C/MC_SND.C
+++ b/src_rebuild/GAME/C/MC_SND.C
@@ -976,7 +976,7 @@ void DoMissionSound(void)
 			}
 			else 
 			{
-				long V[4];
+				LONGVECTOR V;
 				long* C = (long*)bodgevar; // Ahhh, Reflections...
 
 				x = car_data[player[0].playerCarId].hd.where.t[0];

--- a/src_rebuild/GAME/C/MDRAW.C
+++ b/src_rebuild/GAME/C/MDRAW.C
@@ -120,7 +120,7 @@ void DrawMission(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawTimer(struct MR_TIMER *timer /*$s1*/)
+// void /*$ra*/ DrawTimer(MR_TIMER *timer /*$s1*/)
  // line 126, offset 0x0005fa88
 	/* begin block 1 */
 		// Start line: 127
@@ -394,7 +394,7 @@ void DrawFullscreenTargets(void)
 		iVar1 = 0;
 		do {
 			iVar2 = iVar2 + 1;
-			DrawFullscreenTarget((_TARGET *)((int)MissionTargets->data + iVar1));
+			DrawFullscreenTarget((MS_TARGET *)((int)MissionTargets->data + iVar1));
 			iVar1 = iVar2 * 0x40;
 		} while (iVar2 < 0x10);
 	}
@@ -451,13 +451,13 @@ void DrawMultiplayerTargets(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawOverheadTarget(struct _TARGET *target /*$s0*/)
+// void /*$ra*/ DrawOverheadTarget(MS_TARGET *target /*$s0*/)
  // line 230, offset 0x0005fd7c
 	/* begin block 1 */
 		// Start line: 231
 		// Start offset: 0x0005FD7C
 		// Variables:
-	// 		struct VECTOR tv; // stack offset -24
+	// 		VECTOR tv; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x0005FE84
 	// End Line: 269
@@ -468,7 +468,7 @@ void DrawMultiplayerTargets(void)
 	// End Line: 894
 
 // [D]
-void DrawOverheadTarget(_TARGET *target)
+void DrawOverheadTarget(MS_TARGET *target)
 {
 	int iVar1;
 	int *piVar2;
@@ -519,13 +519,13 @@ LAB_0005fe3c:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawFullscreenTarget(struct _TARGET *target /*$s0*/)
+// void /*$ra*/ DrawFullscreenTarget(MS_TARGET *target /*$s0*/)
  // line 271, offset 0x0005fe94
 	/* begin block 1 */
 		// Start line: 272
 		// Start offset: 0x0005FE94
 		// Variables:
-	// 		struct VECTOR tv; // stack offset -24
+	// 		VECTOR tv; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x0005FF9C
 	// End Line: 310
@@ -536,7 +536,7 @@ LAB_0005fe3c:
 	// End Line: 978
 
 // [D]
-void DrawFullscreenTarget(_TARGET *target)
+void DrawFullscreenTarget(MS_TARGET *target)
 {
 	int iVar1;
 	int *piVar2;
@@ -586,13 +586,13 @@ LAB_0005ff54:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawWorldTarget(struct _TARGET *target /*$s0*/)
+// void /*$ra*/ DrawWorldTarget(MS_TARGET *target /*$s0*/)
  // line 312, offset 0x0005f56c
 	/* begin block 1 */
 		// Start line: 313
 		// Start offset: 0x0005F56C
 		// Variables:
-	// 		struct VECTOR tv; // stack offset -32
+	// 		VECTOR tv; // stack offset -32
 	// 		int slot; // $v1
 	// 		int flags; // $s1
 	/* end block 1 */
@@ -610,7 +610,7 @@ LAB_0005ff54:
 	// End Line: 634
 
 // [D]
-void DrawWorldTarget(_TARGET *target)
+void DrawWorldTarget(MS_TARGET *target)
 {
 	int iVar1;
 	int iVar2;
@@ -744,13 +744,13 @@ LAB_0005f7dc:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawMultiplayerTarget(struct _TARGET *target /*$s0*/)
+// void /*$ra*/ DrawMultiplayerTarget(MS_TARGET *target /*$s0*/)
  // line 419, offset 0x0005f864
 	/* begin block 1 */
 		// Start line: 420
 		// Start offset: 0x0005F864
 		// Variables:
-	// 		struct VECTOR tv; // stack offset -40
+	// 		VECTOR tv; // stack offset -40
 	// 		unsigned char r; // $s3
 	// 		unsigned char g; // $s2
 	// 		unsigned char b; // $s1
@@ -764,7 +764,7 @@ LAB_0005f7dc:
 	// End Line: 860
 
 // [D] [A] - not drawn properly...
-void DrawMultiplayerTarget(_TARGET *target)
+void DrawMultiplayerTarget(MS_TARGET *target)
 {
 	int iVar1;
 	uint uVar2;

--- a/src_rebuild/GAME/C/MDRAW.H
+++ b/src_rebuild/GAME/C/MDRAW.H
@@ -4,7 +4,7 @@
 
 extern void DrawMission(); // 0x0005F2FC
 
-extern void DrawTimer(struct MR_TIMER *timer); // 0x0005FA88
+extern void DrawTimer(MR_TIMER *timer); // 0x0005FA88
 
 extern void DisplayPlayerPosition(); // 0x0005FB7C
 
@@ -18,13 +18,13 @@ extern void DrawFullscreenTargets(); // 0x0005FCDC
 
 extern void DrawMultiplayerTargets(); // 0x0005FD2C
 
-extern void DrawOverheadTarget(struct _TARGET *target); // 0x0005FD7C
+extern void DrawOverheadTarget(MS_TARGET *target); // 0x0005FD7C
 
-extern void DrawFullscreenTarget(struct _TARGET *target); // 0x0005FE94
+extern void DrawFullscreenTarget(MS_TARGET *target); // 0x0005FE94
 
-extern void DrawWorldTarget(struct _TARGET *target); // 0x0005F56C
+extern void DrawWorldTarget(MS_TARGET *target); // 0x0005F56C
 
-extern void DrawMultiplayerTarget(struct _TARGET *target); // 0x0005F864
+extern void DrawMultiplayerTarget(MS_TARGET *target); // 0x0005F864
 
 
 #endif

--- a/src_rebuild/GAME/C/MGENERIC.C
+++ b/src_rebuild/GAME/C/MGENERIC.C
@@ -17,8 +17,8 @@
 		// Start line: 64
 		// Start offset: 0x00060740
 		// Variables:
-	// 		struct _TARGET *target; // $s0
-	// 		struct SAVED_CAR_POS *carpos; // $s2
+	// 		MS_TARGET *target; // $s0
+	// 		SAVED_CAR_POS *carpos; // $s2
 	// 		int i; // $s1
 	/* end block 1 */
 	// End offset: 0x000607E4
@@ -44,7 +44,7 @@
 // [D]
 void StoreEndData(void)
 {
-	_TARGET *target;
+	MS_TARGET *target;
 	int i;
 	SAVED_CAR_POS *carpos;
 
@@ -79,7 +79,7 @@ void StoreEndData(void)
 		// Start line: 88
 		// Start offset: 0x000607E4
 		// Variables:
-	// 		struct SAVED_CAR_POS *carpos; // $s0
+	// 		SAVED_CAR_POS *carpos; // $s0
 	// 		int i; // $s1
 	/* end block 1 */
 	// End offset: 0x00060838
@@ -133,7 +133,7 @@ void RestoreStartData(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StorePlayerPosition(struct SAVED_PLAYER_POS *data /*$a2*/)
+// void /*$ra*/ StorePlayerPosition(SAVED_PLAYER_POS *data /*$a2*/)
  // line 109, offset 0x0005ffac
 	/* begin block 1 */
 		// Start line: 110
@@ -195,7 +195,7 @@ void StorePlayerPosition(SAVED_PLAYER_POS *data)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RestorePlayerPosition(struct SAVED_PLAYER_POS *data /*$a2*/)
+// void /*$ra*/ RestorePlayerPosition(SAVED_PLAYER_POS *data /*$a2*/)
  // line 150, offset 0x00060248
 	/* begin block 1 */
 		// Start line: 151
@@ -251,7 +251,7 @@ void RestorePlayerPosition(SAVED_PLAYER_POS *data)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StoreCarPosition(struct _TARGET *target /*$t1*/, struct SAVED_CAR_POS *data /*$t0*/)
+// void /*$ra*/ StoreCarPosition(MS_TARGET *target /*$t1*/, SAVED_CAR_POS *data /*$t0*/)
  // line 180, offset 0x000603b0
 	/* begin block 1 */
 		// Start line: 181
@@ -273,7 +273,7 @@ void RestorePlayerPosition(SAVED_PLAYER_POS *data)
 	// End Line: 369
 
 // [D]
-void StoreCarPosition(_TARGET *target, SAVED_CAR_POS *data)
+void StoreCarPosition(MS_TARGET *target, SAVED_CAR_POS *data)
 {
 	int slot;
 
@@ -312,7 +312,7 @@ void StoreCarPosition(_TARGET *target, SAVED_CAR_POS *data)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ RestoreCarPosition(struct SAVED_CAR_POS *data /*$a3*/)
+// void /*$ra*/ RestoreCarPosition(SAVED_CAR_POS *data /*$a3*/)
  // line 214, offset 0x000604e4
 	/* begin block 1 */
 		// Start line: 439

--- a/src_rebuild/GAME/C/MGENERIC.H
+++ b/src_rebuild/GAME/C/MGENERIC.H
@@ -6,13 +6,13 @@ extern void StoreEndData(); // 0x00060740
 
 extern void RestoreStartData(); // 0x000607E4
 
-extern void StorePlayerPosition(struct SAVED_PLAYER_POS *data); // 0x0005FFAC
+extern void StorePlayerPosition(SAVED_PLAYER_POS *data); // 0x0005FFAC
 
-extern void RestorePlayerPosition(struct SAVED_PLAYER_POS *data); // 0x00060248
+extern void RestorePlayerPosition(SAVED_PLAYER_POS *data); // 0x00060248
 
-extern void StoreCarPosition(struct _TARGET *target, struct SAVED_CAR_POS *data); // 0x000603B0
+extern void StoreCarPosition(MS_TARGET *target, SAVED_CAR_POS *data); // 0x000603B0
 
-extern void RestoreCarPosition(struct SAVED_CAR_POS *data); // 0x000604E4
+extern void RestoreCarPosition(SAVED_CAR_POS *data); // 0x000604E4
 
 
 #endif

--- a/src_rebuild/GAME/C/MISSION.C
+++ b/src_rebuild/GAME/C/MISSION.C
@@ -2557,7 +2557,7 @@ void MRSetVariable(MR_THREAD *thread, ulong var, long value)
 			// Start offset: 0x00062BFC
 			// Variables:
 		// 		int direction; // $s0
-		// 		long pos[4]; // stack offset -64
+		// 		LONGVECTOR pos; // stack offset -64
 		// 		int *inform; // $s4
 		// 		CAR_DATA *cp; // $v0
 		/* end block 1.2 */
@@ -2568,7 +2568,7 @@ void MRSetVariable(MR_THREAD *thread, ulong var, long value)
 			// Start line: 3069
 			// Start offset: 0x00063028
 			// Variables:
-		// 		long pos[4]; // stack offset -64
+		// 		LONGVECTOR pos; // stack offset -64
 		/* end block 1.3 */
 		// End offset: 0x00063090
 		// End Line: 3076
@@ -2625,7 +2625,7 @@ int MRProcessTarget(MR_THREAD *thread, MS_TARGET *target)
 	int ret;
 	VECTOR tv;
 	VECTOR pv;
-	long pos[4];
+	LONGVECTOR pos;
 	int slot;
 
 	ret = 0;
@@ -2880,7 +2880,7 @@ int MRProcessTarget(MR_THREAD *thread, MS_TARGET *target)
 						cp->inform = NULL;
 
 						PingOutCar(&car_data[slot]);
-						slot = CreateCivCarWotDrivesABitThenStops(direction, (long(*)[4])pos, NULL, model, palette);
+						slot = CreateCivCarWotDrivesABitThenStops(direction, &pos, NULL, model, palette);
 
 						cp->inform = inform;
 
@@ -3351,7 +3351,7 @@ void MRHandleCarRequests(void)
 		// Start line: 3312
 		// Start offset: 0x00063728
 		// Variables:
-	// 		long pos[4]; // stack offset -64
+	// 		LONGVECTOR pos; // stack offset -64
 	// 		int actAsCop; // $s2
 	// 		int damaged; // $s7
 	// 		int model; // $s4
@@ -3379,7 +3379,7 @@ int MRCreateCar(MS_TARGET *target)
 {
 	int curslot;
 	int newslot;
-	long pos[4];
+	LONGVECTOR pos;
 	char playerid;
 
 	pos[0] = target->data[3];
@@ -3393,7 +3393,7 @@ int MRCreateCar(MS_TARGET *target)
 	}
 	else
 	{
-		curslot = CreateStationaryCivCar(target->data[5], 0, ((target->data[10] & 0x40000) != 0) << 10, (long(*)[4])pos, target->data[7], target->data[8], (target->data[10] & 8) != 0);
+		curslot = CreateStationaryCivCar(target->data[5], 0, ((target->data[10] & 0x40000) != 0) << 10, &pos, target->data[7], target->data[8], (target->data[10] & 8) != 0);
 	}
 
 	if (curslot < 0)
@@ -3416,7 +3416,7 @@ int MRCreateCar(MS_TARGET *target)
 	{
 		playerid = 0xff;
 
-		InitPlayer((PLAYER *)(player + 1), &car_data[curslot], 4, target->data[5], (long(*)[4])pos, target->data[7], target->data[8], (char *)&playerid);
+		InitPlayer((PLAYER *)(player + 1), &car_data[curslot], 4, target->data[5], &pos, target->data[7], target->data[8], (char *)&playerid);
 
 		EnablePercentageBar(&DamageBar, target->data[13]);
 		NewLeadDelay = 0;

--- a/src_rebuild/GAME/C/MISSION.C
+++ b/src_rebuild/GAME/C/MISSION.C
@@ -189,7 +189,7 @@ int gBatterPlayer = 1;
 
 int wantedCar[2] = { -1, -1 };
 
-_TARGET* MissionTargets;
+MS_TARGET* MissionTargets;
 unsigned long* MissionScript;
 char* MissionStrings;
 char* gMissionTitle = NULL;
@@ -335,7 +335,7 @@ void InitialiseMissionDefaults(void)
 			// Start line: 1767
 			// Start offset: 0x00060F84
 			// Variables:
-		// 		struct _ROUTE_INFO *rinfo; // $s0
+		// 		_ROUTE_INFO *rinfo; // $s0
 		/* end block 1.2 */
 		// End offset: 0x00061024
 		// End Line: 1793
@@ -421,9 +421,9 @@ void LoadMission(int missionnum)
 	LoadfileSeg(filename, (char *)MissionLoadAddress, offset, sizeof(_MISSION));
 
 	MissionHeader = MissionLoadAddress;
-	MissionTargets = (_TARGET *)((int)&MissionLoadAddress->id + MissionLoadAddress->size);
+	MissionTargets = (MS_TARGET *)((int)&MissionLoadAddress->id + MissionLoadAddress->size);
 	MissionScript = (ulong *)(MissionTargets + 16);
-	MissionStrings = (char *)(((_TARGET *)MissionScript)->data + MissionLoadAddress->strings);
+	MissionStrings = (char *)(((MS_TARGET *)MissionScript)->data + MissionLoadAddress->strings);
 
 	if (MissionLoadAddress->route && !NewLevel)
 		loadsize = (int)MissionStrings + (MissionLoadAddress->route - (int)MissionLoadAddress);
@@ -1155,7 +1155,7 @@ void HandleMission(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ HandleTimer(struct MR_TIMER *timer /*$s0*/)
+// void /*$ra*/ HandleTimer(MR_TIMER *timer /*$s0*/)
  // line 1962, offset 0x000614a4
 	/* begin block 1 */
 		// Start line: 4347
@@ -1187,7 +1187,7 @@ void HandleTimer(MR_TIMER *timer)
 
 					if (timer->flags & 0x10) 
 					{
-						events.cameraEvent = (_EVENT *)0x1;
+						events.cameraEvent = (EVENT *)0x1;
 						
 						BombThePlayerToHellAndBack(gCarWithABerm);
 					}
@@ -1394,7 +1394,7 @@ void SetPlayerMessage(int player, char *message, int priority, int seconds)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ TargetComplete(struct _TARGET *target /*$a0*/, int player /*$a1*/)
+// int /*$ra*/ TargetComplete(MS_TARGET *target /*$a0*/, int player /*$a1*/)
  // line 2094, offset 0x000643c4
 	/* begin block 1 */
 		// Start line: 2095
@@ -1416,7 +1416,7 @@ void SetPlayerMessage(int player, char *message, int priority, int seconds)
 	// End Line: 6689
 
 // [D] [T]
-int TargetComplete(_TARGET *target, int player)
+int TargetComplete(MS_TARGET *target, int player)
 {
 	unsigned long complete;
 
@@ -1447,7 +1447,7 @@ int TargetComplete(_TARGET *target, int player)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ TargetActive(struct _TARGET *target /*$a0*/, int player /*$a1*/)
+// int /*$ra*/ TargetActive(MS_TARGET *target /*$a0*/, int player /*$a1*/)
  // line 2117, offset 0x00064408
 	/* begin block 1 */
 		// Start line: 2118
@@ -1474,7 +1474,7 @@ int TargetComplete(_TARGET *target, int player)
 	// End Line: 6735
 
 // [D] [T]
-int TargetActive(_TARGET *target, int player)
+int TargetActive(MS_TARGET *target, int player)
 {
 	unsigned long active;
 
@@ -1508,8 +1508,8 @@ int TargetActive(_TARGET *target, int player)
 		// Start line: 2141
 		// Start offset: 0x00061784
 		// Variables:
-	// 		struct _CAR_DATA cd; // stack offset -704
-	// 		struct _CAR_DATA *cp; // $s0
+	// 		CAR_DATA cd; // stack offset -704
+	// 		CAR_DATA *cp; // $s0
 	// 		int ctrlNodeCurId; // $s4
 	// 		int pnodeCurId; // $s5
 	// 		int ctrlNodeNewId; // $t2
@@ -1528,14 +1528,14 @@ int TargetActive(_TARGET *target, int player)
 // [D] [T]
 int Swap2Cars(int curslot, int newslot)
 {
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 
 	int ctrlNodeNewId;
 	int pnodeNewId;
 	int ctrlNodeCurId;
 	int pnodeCurId;
 
-	_CAR_DATA cd;
+	CAR_DATA cd;
 
 	if (curslot == newslot)
 		return newslot;
@@ -1588,9 +1588,9 @@ int Swap2Cars(int curslot, int newslot)
 	cp = &car_data[newslot];
 
 	// do data swap
-	memcpy(&cd, &car_data[newslot], sizeof(_CAR_DATA));
-	memcpy(&car_data[newslot], &car_data[curslot], sizeof(_CAR_DATA));
-	memcpy(&car_data[curslot], &cd, sizeof(_CAR_DATA));
+	memcpy(&cd, &car_data[newslot], sizeof(CAR_DATA));
+	memcpy(&car_data[newslot], &car_data[curslot], sizeof(CAR_DATA));
+	memcpy(&car_data[curslot], &cd, sizeof(CAR_DATA));
 
 	// swap ids
 	car_data[newslot].id = newslot;
@@ -1707,7 +1707,7 @@ void SetConfusedCar(int slot)
 		// Start line: 2236
 		// Start offset: 0x00061C5C
 		// Variables:
-	// 		struct MR_THREAD *thread; // $s0
+	// 		MR_THREAD *thread; // $s0
 	// 		int running; // $s1
 	// 		unsigned long value; // $a1
 	// 		int i; // $a0
@@ -1787,7 +1787,7 @@ void HandleMissionThreads(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRCommand(struct MR_THREAD *thread /*$s1*/, unsigned long cmd /*$a1*/)
+// int /*$ra*/ MRCommand(MR_THREAD *thread /*$s1*/, unsigned long cmd /*$a1*/)
  // line 2279, offset 0x00061e3c
 	/* begin block 1 */
 		// Start line: 2280
@@ -2043,7 +2043,7 @@ int MRCommand(MR_THREAD *thread, ulong cmd)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MROperator(struct MR_THREAD *thread /*$s3*/, unsigned long op /*$s0*/)
+// int /*$ra*/ MROperator(MR_THREAD *thread /*$s3*/, unsigned long op /*$s0*/)
  // line 2441, offset 0x00064498
 	/* begin block 1 */
 		// Start line: 2442
@@ -2119,7 +2119,7 @@ int MROperator(MR_THREAD *thread, ulong op)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRFunction(struct MR_THREAD *thread /*$s0*/, unsigned long fnc /*$a1*/)
+// int /*$ra*/ MRFunction(MR_THREAD *thread /*$s0*/, unsigned long fnc /*$a1*/)
  // line 2494, offset 0x000645ac
 	/* begin block 1 */
 		// Start line: 2495
@@ -2165,7 +2165,7 @@ int MRFunction(MR_THREAD *thread, ulong fnc)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MRInitialiseThread(struct MR_THREAD *thread /*$a0*/, unsigned long *pc /*$a1*/, unsigned char player /*$a2*/)
+// void /*$ra*/ MRInitialiseThread(MR_THREAD *thread /*$a0*/, unsigned long *pc /*$a1*/, unsigned char player /*$a2*/)
  // line 2514, offset 0x00064614
 	/* begin block 1 */
 		// Start line: 7538
@@ -2195,7 +2195,7 @@ void MRInitialiseThread(MR_THREAD *thread, ulong *pc, unsigned char player)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MRStartThread(struct MR_THREAD *callingthread /*$t0*/, unsigned long addr /*$a1*/, unsigned char player /*$a2*/)
+// void /*$ra*/ MRStartThread(MR_THREAD *callingthread /*$t0*/, unsigned long addr /*$a1*/, unsigned char player /*$a2*/)
  // line 2526, offset 0x00064630
 	/* begin block 1 */
 		// Start line: 2527
@@ -2234,7 +2234,7 @@ void MRStartThread(MR_THREAD *callingthread, ulong addr, unsigned char player)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRStopThread(struct MR_THREAD *thread /*$a0*/)
+// int /*$ra*/ MRStopThread(MR_THREAD *thread /*$a0*/)
  // line 2545, offset 0x00064690
 	/* begin block 1 */
 		// Start line: 7613
@@ -2297,7 +2297,7 @@ void MRCommitThreadGenocide(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRJump(struct MR_THREAD *thread /*$a2*/, long jump /*$a1*/)
+// int /*$ra*/ MRJump(MR_THREAD *thread /*$a2*/, long jump /*$a1*/)
  // line 2560, offset 0x000646e0
 	/* begin block 1 */
 		// Start line: 7640
@@ -2323,7 +2323,7 @@ int MRJump(MR_THREAD *thread, long jump)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MRPush(struct MR_THREAD *thread /*$a0*/, long value /*$a1*/)
+// void /*$ra*/ MRPush(MR_THREAD *thread /*$a0*/, long value /*$a1*/)
  // line 2575, offset 0x0006472c
 	/* begin block 1 */
 		// Start line: 7678
@@ -2351,7 +2351,7 @@ void MRPush(MR_THREAD *thread, long value)
 
 // decompiled code
 // original method signature: 
-// long /*$ra*/ MRPop(struct MR_THREAD *thread /*$a0*/)
+// long /*$ra*/ MRPop(MR_THREAD *thread /*$a0*/)
  // line 2585, offset 0x00064744
 	/* begin block 1 */
 		// Start line: 2586
@@ -2381,7 +2381,7 @@ long MRPop(MR_THREAD *thread)
 
 // decompiled code
 // original method signature: 
-// long /*$ra*/ MRGetParam(struct MR_THREAD *thread /*$s0*/)
+// long /*$ra*/ MRGetParam(MR_THREAD *thread /*$s0*/)
  // line 2600, offset 0x00064760
 	/* begin block 1 */
 		// Start line: 2601
@@ -2425,7 +2425,7 @@ long MRGetParam(MR_THREAD *thread)
 
 // decompiled code
 // original method signature: 
-// long /*$ra*/ MRGetVariable(struct MR_THREAD *thread /*$a2*/, unsigned long var /*$a1*/)
+// long /*$ra*/ MRGetVariable(MR_THREAD *thread /*$a2*/, unsigned long var /*$a1*/)
  // line 2622, offset 0x000647cc
 	/* begin block 1 */
 		// Start line: 7773
@@ -2466,7 +2466,7 @@ long MRGetVariable(MR_THREAD *thread, ulong var)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MRSetVariable(struct MR_THREAD *thread /*$v1*/, unsigned long var /*$a1*/, long value /*$a2*/)
+// void /*$ra*/ MRSetVariable(MR_THREAD *thread /*$v1*/, unsigned long var /*$a1*/, long value /*$a2*/)
  // line 2648, offset 0x000648b0
 	/* begin block 1 */
 		// Start line: 7828
@@ -2527,14 +2527,14 @@ void MRSetVariable(MR_THREAD *thread, ulong var, long value)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRProcessTarget(struct MR_THREAD *thread /*$s7*/, struct _TARGET *target /*$s5*/)
+// int /*$ra*/ MRProcessTarget(MR_THREAD *thread /*$s7*/, MS_TARGET *target /*$s5*/)
  // line 2701, offset 0x00062470
 	/* begin block 1 */
 		// Start line: 2702
 		// Start offset: 0x00062470
 		// Variables:
-	// 		struct VECTOR tv; // stack offset -96
-	// 		struct VECTOR pv; // stack offset -80
+	// 		VECTOR tv; // stack offset -96
+	// 		VECTOR pv; // stack offset -80
 	// 		int ret; // $fp
 	// 		unsigned long dist; // $s6
 	// 		int slot; // stack offset -48
@@ -2559,7 +2559,7 @@ void MRSetVariable(MR_THREAD *thread, ulong var, long value)
 		// 		int direction; // $s0
 		// 		long pos[4]; // stack offset -64
 		// 		int *inform; // $s4
-		// 		struct _CAR_DATA *cp; // $v0
+		// 		CAR_DATA *cp; // $v0
 		/* end block 1.2 */
 		// End offset: 0x00062BFC
 		// End Line: 2940
@@ -2616,7 +2616,7 @@ void MRSetVariable(MR_THREAD *thread, ulong var, long value)
 /* WARNING: Could not reconcile some variable overlaps */
 
 // [D] [T]
-int MRProcessTarget(MR_THREAD *thread, _TARGET *target)
+int MRProcessTarget(MR_THREAD *thread, MS_TARGET *target)
 {
 	int phrase;
 	int playerId;
@@ -2835,7 +2835,7 @@ int MRProcessTarget(MR_THREAD *thread, _TARGET *target)
 		case 2: // car target
 		{
 			
-			_CAR_DATA* cp;
+			CAR_DATA* cp;
 			tv.vx = target->data[3];
 			tv.vz = target->data[4];
 			tv.vy = 0;
@@ -3293,7 +3293,7 @@ int MRProcessTarget(MR_THREAD *thread, _TARGET *target)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRRequestCar(struct _TARGET *target /*$a0*/)
+// int /*$ra*/ MRRequestCar(MS_TARGET *target /*$a0*/)
  // line 3296, offset 0x000649e4
 	/* begin block 1 */
 		// Start line: 9124
@@ -3306,7 +3306,7 @@ int MRProcessTarget(MR_THREAD *thread, _TARGET *target)
 	// End Line: 9126
 
 // [D] [T]
-int MRRequestCar(_TARGET *target)
+int MRRequestCar(MS_TARGET *target)
 {
 	if (Mission.CarTarget == NULL && GameType != GAME_SURVIVAL) 
 	{
@@ -3345,7 +3345,7 @@ void MRHandleCarRequests(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MRCreateCar(struct _TARGET *target /*$s1*/)
+// int /*$ra*/ MRCreateCar(MS_TARGET *target /*$s1*/)
  // line 3311, offset 0x00063728
 	/* begin block 1 */
 		// Start line: 3312
@@ -3375,7 +3375,7 @@ void MRHandleCarRequests(void)
 	// End Line: 7216
 
 // [D] [T]
-int MRCreateCar(_TARGET *target)
+int MRCreateCar(MS_TARGET *target)
 {
 	int curslot;
 	int newslot;
@@ -3416,7 +3416,7 @@ int MRCreateCar(_TARGET *target)
 	{
 		playerid = 0xff;
 
-		InitPlayer((_PLAYER *)(player + 1), &car_data[curslot], 4, target->data[5], (long(*)[4])pos, target->data[7], target->data[8], (char *)&playerid);
+		InitPlayer((PLAYER *)(player + 1), &car_data[curslot], 4, target->data[5], (long(*)[4])pos, target->data[7], target->data[8], (char *)&playerid);
 
 		EnablePercentageBar(&DamageBar, target->data[13]);
 		NewLeadDelay = 0;
@@ -3452,7 +3452,7 @@ int MRCreateCar(_TARGET *target)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MRCancelCarRequest(struct _TARGET *target /*$a0*/)
+// void /*$ra*/ MRCancelCarRequest(MS_TARGET *target /*$a0*/)
  // line 3392, offset 0x00064a50
 	/* begin block 1 */
 		// Start line: 9316
@@ -3465,7 +3465,7 @@ int MRCreateCar(_TARGET *target)
 	// End Line: 9318
 
 // [D] [T]
-void MRCancelCarRequest(_TARGET *target)
+void MRCancelCarRequest(MS_TARGET *target)
 {
 	if (Mission.CarTarget == target)
 		Mission.CarTarget = NULL;
@@ -3481,7 +3481,7 @@ void MRCancelCarRequest(_TARGET *target)
 		// Start line: 3400
 		// Start offset: 0x000639A0
 		// Variables:
-	// 		struct _TARGET *target; // $s0
+	// 		MS_TARGET *target; // $s0
 	// 		int i; // $s1
 	/* end block 1 */
 	// End offset: 0x00063B78
@@ -3512,7 +3512,7 @@ void MRCancelCarRequest(_TARGET *target)
 // [D] [T]
 void PreProcessTargets(void)
 {
-	_TARGET *target;
+	MS_TARGET *target;
 	int i;
 
 	for (i = 0; i < MissionHeader->nCutscenes; i++)
@@ -3638,8 +3638,8 @@ int Handle321Go(void)
 			// Start line: 3474
 			// Start offset: 0x00063BB8
 			// Variables:
-		// 		struct _PLAYER *lp; // $s0
-		// 		struct _CAR_DATA *cp; // $a2
+		// 		PLAYER *lp; // $s0
+		// 		CAR_DATA *cp; // $a2
 		// 		int i; // $s2
 		// 		int playersdead; // $s3
 
@@ -3684,8 +3684,8 @@ int HandleGameOver(void)
 	int player_id;
 	int playersdead;
 
-	_PLAYER* lp;
-	_CAR_DATA *cp;
+	PLAYER* lp;
+	CAR_DATA *cp;
 
 	if (Mission.gameover_delay != -1) 
 	{
@@ -3868,7 +3868,7 @@ int HandleGameOver(void)
 // [D] [T]
 void CompleteAllActiveTargets(int player)
 {
-	_TARGET *pTarget;
+	MS_TARGET *pTarget;
 	int i;
 	int flag2;
 	int flag1;
@@ -3982,7 +3982,7 @@ void SetMissionComplete(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetMissionFailed(enum FAIL_REASON reason /*$a0*/)
+// void /*$ra*/ SetMissionFailed(FAIL_REASON reason /*$a0*/)
  // line 3684, offset 0x00064b38
 	/* begin block 1 */
 		// Start line: 9846
@@ -4014,7 +4014,7 @@ void SetMissionFailed(FAIL_REASON reason)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetMissionOver(enum PAUSEMODE mode /*$a0*/)
+// void /*$ra*/ SetMissionOver(PAUSEMODE mode /*$a0*/)
  // line 3704, offset 0x00064bd8
 	/* begin block 1 */
 		// Start line: 9950
@@ -4072,7 +4072,7 @@ void SetMissionOver(PAUSEMODE mode)
 void ActivateNextFlag(void)
 {
 	int j;
-	_TARGET *target;
+	MS_TARGET *target;
 	int i;
 
 	if (last_flag == -1)
@@ -4149,7 +4149,7 @@ int CalcLapTime(int player, int time, int lap)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetCarToBeStolen(struct _TARGET *target /*$s0*/, int player /*$s1*/)
+// void /*$ra*/ SetCarToBeStolen(MS_TARGET *target /*$s0*/, int player /*$s1*/)
  // line 3770, offset 0x00064c60
 	/* begin block 1 */
 		// Start line: 10085
@@ -4162,7 +4162,7 @@ int CalcLapTime(int player, int time, int lap)
 	// End Line: 10089
 
 // [D]
-void SetCarToBeStolen(_TARGET *target, int player)
+void SetCarToBeStolen(MS_TARGET *target, int player)
 {
 	if (target->data[10] & 0x800000)
 		MakePhantomCarEqualPlayerCar();

--- a/src_rebuild/GAME/C/MISSION.H
+++ b/src_rebuild/GAME/C/MISSION.H
@@ -68,7 +68,7 @@ extern int MaxPlayerDamage[2];
 
 extern COP_DATA gCopData;
 
-extern _TARGET *MissionTargets;
+extern MS_TARGET *MissionTargets;
 extern unsigned long *MissionScript;
 extern char *MissionStrings;
 
@@ -94,7 +94,7 @@ extern void LoadMission(int missionnum); // 0x00060A74
 
 extern void HandleMission(); // 0x00061274
 
-extern void HandleTimer(struct MR_TIMER *timer); // 0x000614A4
+extern void HandleTimer(MR_TIMER *timer); // 0x000614A4
 
 extern void RegisterChaseHit(int car1, int car2); // 0x00061684
 
@@ -104,9 +104,9 @@ extern void SetMissionMessage(char *message, int priority, int seconds); // 0x00
 
 extern void SetPlayerMessage(int player, char *message, int priority, int seconds); // 0x00064348
 
-extern int TargetComplete(struct _TARGET *target, int player); // 0x000643C4
+extern int TargetComplete(MS_TARGET *target, int player); // 0x000643C4
 
-extern int TargetActive(struct _TARGET *target, int player); // 0x00064408
+extern int TargetActive(MS_TARGET *target, int player); // 0x00064408
 
 extern int Swap2Cars(int curslot, int newslot); // 0x00061784
 
@@ -114,41 +114,41 @@ extern void SetConfusedCar(int slot); // 0x0006444C
 
 extern void HandleMissionThreads(); // 0x00061C5C
 
-extern int MRCommand(struct MR_THREAD *thread, unsigned long cmd); // 0x00061E3C
+extern int MRCommand(MR_THREAD *thread, unsigned long cmd); // 0x00061E3C
 
-extern int MROperator(struct MR_THREAD *thread, unsigned long op); // 0x00064498
+extern int MROperator(MR_THREAD *thread, unsigned long op); // 0x00064498
 
-extern int MRFunction(struct MR_THREAD *thread, unsigned long fnc); // 0x000645AC
+extern int MRFunction(MR_THREAD *thread, unsigned long fnc); // 0x000645AC
 
-extern void MRInitialiseThread(struct MR_THREAD *thread, unsigned long *pc, unsigned char player); // 0x00064614
+extern void MRInitialiseThread(MR_THREAD *thread, unsigned long *pc, unsigned char player); // 0x00064614
 
-extern void MRStartThread(struct MR_THREAD *callingthread, unsigned long addr, unsigned char player); // 0x00064630
+extern void MRStartThread(MR_THREAD *callingthread, unsigned long addr, unsigned char player); // 0x00064630
 
-extern int MRStopThread(struct MR_THREAD *thread); // 0x00064690
+extern int MRStopThread(MR_THREAD *thread); // 0x00064690
 
 extern void MRCommitThreadGenocide(); // 0x0006469C
 
-extern int MRJump(struct MR_THREAD *thread, long jump); // 0x000646E0
+extern int MRJump(MR_THREAD *thread, long jump); // 0x000646E0
 
-extern void MRPush(struct MR_THREAD *thread, long value); // 0x0006472C
+extern void MRPush(MR_THREAD *thread, long value); // 0x0006472C
 
-extern long MRPop(struct MR_THREAD *thread); // 0x00064744
+extern long MRPop(MR_THREAD *thread); // 0x00064744
 
-extern long MRGetParam(struct MR_THREAD *thread); // 0x00064760
+extern long MRGetParam(MR_THREAD *thread); // 0x00064760
 
-extern long MRGetVariable(struct MR_THREAD *thread, unsigned long var); // 0x000647CC
+extern long MRGetVariable(MR_THREAD *thread, unsigned long var); // 0x000647CC
 
-extern void MRSetVariable(struct MR_THREAD *thread, unsigned long var, long value); // 0x000648B0
+extern void MRSetVariable(MR_THREAD *thread, unsigned long var, long value); // 0x000648B0
 
-extern int MRProcessTarget(struct MR_THREAD *thread, struct _TARGET *target); // 0x00062470
+extern int MRProcessTarget(MR_THREAD *thread, MS_TARGET *target); // 0x00062470
 
-extern int MRRequestCar(struct _TARGET *target); // 0x000649E4
+extern int MRRequestCar(MS_TARGET *target); // 0x000649E4
 
 extern void MRHandleCarRequests(); // 0x00064A24
 
-extern int MRCreateCar(struct _TARGET *target); // 0x00063728
+extern int MRCreateCar(MS_TARGET *target); // 0x00063728
 
-extern void MRCancelCarRequest(struct _TARGET *target); // 0x00064A50
+extern void MRCancelCarRequest(MS_TARGET *target); // 0x00064A50
 
 extern void PreProcessTargets(); // 0x000639A0
 
@@ -160,15 +160,15 @@ extern void CompleteAllActiveTargets(int player); // 0x00064AD0
 
 extern void SetMissionComplete(); // 0x00063F84
 
-extern void SetMissionFailed(enum FAIL_REASON reason); // 0x00064B38
+extern void SetMissionFailed(FAIL_REASON reason); // 0x00064B38
 
-extern void SetMissionOver(enum PAUSEMODE mode); // 0x00064BD8
+extern void SetMissionOver(PAUSEMODE mode); // 0x00064BD8
 
 extern void ActivateNextFlag(); // 0x000641A8
 
 extern int CalcLapTime(int player, int time, int lap); // 0x00064C24
 
-extern void SetCarToBeStolen(struct _TARGET *target, int player); // 0x00064C60
+extern void SetCarToBeStolen(MS_TARGET *target, int player); // 0x00064C60
 
 extern void MakePhantomCarEqualPlayerCar(); // 0x00064CD0
 

--- a/src_rebuild/GAME/C/MODELS.C
+++ b/src_rebuild/GAME/C/MODELS.C
@@ -31,8 +31,8 @@ MODEL* pLodModels[1536];
 	// 		int size; // $v0
 	// 		int modelamt; // $a3
 	// 		char *mdsfile; // $a0
-	// 		struct MODEL *model; // $a0
-	// 		struct MODEL *parentmodel; // $a1
+	// 		MODEL *model; // $a0
+	// 		MODEL *parentmodel; // $a1
 	/* end block 1 */
 	// End offset: 0x00064E6C
 	// End Line: 94
@@ -156,7 +156,7 @@ void ProcessMDSLump(char *lump_file, int lump_size)
 			// Start line: 231
 			// Start offset: 0x00064EB0
 			// Variables:
-		// 		struct MODEL *model; // $v0
+		// 		MODEL *model; // $v0
 		// 		int mem; // $a1
 		/* end block 1.1 */
 		// End offset: 0x00064F88
@@ -316,13 +316,13 @@ int ProcessCarModelLump(char *lump_ptr, int lump_size)
 
 // decompiled code
 // original method signature: 
-// struct MODEL * /*$ra*/ GetCarModel(char *src /*$s2*/, char **dest /*$s1*/, int KeepNormals /*$s3*/)
+// MODEL * /*$ra*/ GetCarModel(char *src /*$s2*/, char **dest /*$s1*/, int KeepNormals /*$s3*/)
  // line 391, offset 0x00065134
 	/* begin block 1 */
 		// Start line: 392
 		// Start offset: 0x00065134
 		// Variables:
-	// 		struct MODEL *model; // $s0
+	// 		MODEL *model; // $s0
 	// 		int size; // $a2
 	// 		char *mem; // $v1
 

--- a/src_rebuild/GAME/C/MODELS.H
+++ b/src_rebuild/GAME/C/MODELS.H
@@ -21,7 +21,7 @@ extern void ProcessMDSLump(char *lump_file, int lump_size); // 0x00064CFC
 
 extern int ProcessCarModelLump(char *lump_ptr, int lump_size); // 0x00064E6C
 
-extern struct MODEL * GetCarModel(char *src, char **dest, int KeepNormals); // 0x00065134
+extern MODEL * GetCarModel(char *src, char **dest, int KeepNormals); // 0x00065134
 
 
 #endif

--- a/src_rebuild/GAME/C/MOTION_C.C
+++ b/src_rebuild/GAME/C/MOTION_C.C
@@ -377,7 +377,7 @@ void ProcessMotionLump(char *lump_ptr, int lump_size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupPedMotionData(struct PEDESTRIAN *pPed /*$a0*/)
+// void /*$ra*/ SetupPedMotionData(PEDESTRIAN *pPed /*$a0*/)
  // line 944, offset 0x00069ab8
 	/* begin block 1 */
 		// Start line: 5388
@@ -399,7 +399,7 @@ void SetupPedMotionData(PEDESTRIAN *pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupPedestrian(struct PEDESTRIAN *pedptr /*$a0*/)
+// void /*$ra*/ SetupPedestrian(PEDESTRIAN *pedptr /*$a0*/)
  // line 955, offset 0x00069b6c
 	/* begin block 1 */
 		// Start line: 2236
@@ -444,7 +444,7 @@ void SetupPedestrian(PEDESTRIAN *pedptr)
 		// Start line: 979
 		// Start offset: 0x0006520C
 		// Variables:
-	// 		struct TEXTURE_DETAILS *body_texture; // $s2
+	// 		TEXTURE_DETAILS *body_texture; // $s2
 	// 		int x0; // $s5
 	// 		int x1; // $s6
 	// 		int y0; // $fp
@@ -462,7 +462,7 @@ void SetupPedestrian(PEDESTRIAN *pedptr)
 	// 		int s; // $a2
 	// 		int clut; // $a2
 	// 		int tpage; // $t0
-	// 		struct POLY_FT4 *prims; // $t2
+	// 		POLY_FT4 *prims; // $t2
 	// 		int z1; // stack offset -44
 	// 		int pal; // $v1
 
@@ -784,10 +784,10 @@ void DrawBodySprite(PEDESTRIAN *pDrawingPed, int boneId, VERTTYPE v1[2], VERTTYP
 	// 		int i; // $t1
 	// 		int j; // $a3
 	// 		int numVerts; // $t3
-	// 		struct MODEL *pModel; // $t0
-	// 		struct SVECTOR *pVerts; // $a2
+	// 		MODEL *pModel; // $t0
+	// 		SVECTOR *pVerts; // $a2
 	// 		int counter; // $t4
-	// 		struct BONE *pBone; // $a0
+	// 		BONE *pBone; // $a0
 	/* end block 1 */
 	// End offset: 0x00065AD8
 	// End Line: 1346
@@ -918,10 +918,10 @@ void StoreVertexLists(void)
 		// Start offset: 0x00065AD8
 		// Variables:
 	// 		int i; // $t1
-	// 		struct BONE *pBone; // $a3
+	// 		BONE *pBone; // $a3
 	// 		char *pC; // $v0
-	// 		struct SVECTOR *store; // $t4
-	// 		struct SVECTOR_NOPAD *pSVNP; // $v1
+	// 		SVECTOR *store; // $t4
+	// 		SVECTOR_NOPAD *pSVNP; // $v1
 	/* end block 1 */
 	// End offset: 0x00065CD8
 	// End Line: 1413
@@ -1082,33 +1082,33 @@ void SetupTannerSkeleton(PEDESTRIAN *pDrawingPed)
 		// Start line: 1423
 		// Start offset: 0x00065CD8
 		// Variables:
-	// 		struct VECTOR *playerPos; // $a2
-	// 		struct VECTOR *camPos; // $a1
-	// 		struct VECTOR *vJPos; // $s1
-	// 		struct VECTOR v; // stack offset -128
-	// 		struct MODEL *pModel; // $t0
-	// 		struct SVECTOR *mVerts; // $a1
+	// 		VECTOR *playerPos; // $a2
+	// 		VECTOR *camPos; // $a1
+	// 		VECTOR *vJPos; // $s1
+	// 		VECTOR v; // stack offset -128
+	// 		MODEL *pModel; // $t0
+	// 		SVECTOR *mVerts; // $a1
 	// 		int i; // $s2
 	// 		int j; // $a3
 	// 		int c; // $a3
 	// 		int id; // $a2
 	// 		int limbs; // $a0
-	// 		struct BONE *pBone; // $s0
+	// 		BONE *pBone; // $s0
 	// 		int lval; // $t1
 
 		/* begin block 1.1 */
 			// Start line: 1530
 			// Start offset: 0x000660A0
 			// Variables:
-		// 		struct BONE *pBone; // $s0
-		// 		struct VECTOR *v1; // $a2
-		// 		struct VECTOR *v2; // $a1
+		// 		BONE *pBone; // $s0
+		// 		VECTOR *v1; // $a2
+		// 		VECTOR *v2; // $a1
 
 			/* begin block 1.1.1 */
 				// Start line: 1530
 				// Start offset: 0x000660A0
 				// Variables:
-			// 		struct SVECTOR *data; // $t1
+			// 		SVECTOR *data; // $t1
 			// 		long t1; // stack offset -92
 			// 		long t0; // stack offset -96
 			// 		int z2; // stack offset -80
@@ -1125,15 +1125,15 @@ void SetupTannerSkeleton(PEDESTRIAN *pDrawingPed)
 			// Start line: 1536
 			// Start offset: 0x000661F8
 			// Variables:
-		// 		struct BONE *pBone; // $s0
-		// 		struct VECTOR *v1; // $a0
-		// 		struct VECTOR *v2; // $a2
+		// 		BONE *pBone; // $s0
+		// 		VECTOR *v1; // $a0
+		// 		VECTOR *v2; // $a2
 
 			/* begin block 1.2.1 */
 				// Start line: 1536
 				// Start offset: 0x000661F8
 				// Variables:
-			// 		struct SVECTOR *data; // $t0
+			// 		SVECTOR *data; // $t0
 			// 		long t1; // stack offset -72
 			// 		long t0; // stack offset -76
 			// 		int z2; // stack offset -60
@@ -1150,8 +1150,8 @@ void SetupTannerSkeleton(PEDESTRIAN *pDrawingPed)
 			// Start line: 1542
 			// Start offset: 0x00066330
 			// Variables:
-		// 		struct SVECTOR v1; // stack offset -112
-		// 		struct SVECTOR v2; // stack offset -104
+		// 		SVECTOR v1; // stack offset -112
+		// 		SVECTOR v2; // stack offset -104
 		/* end block 1.3 */
 		// End offset: 0x00066330
 		// End Line: 1544
@@ -1160,15 +1160,15 @@ void SetupTannerSkeleton(PEDESTRIAN *pDrawingPed)
 			// Start line: 1569
 			// Start offset: 0x0006648C
 			// Variables:
-		// 		struct BONE *pBone; // $s0
-		// 		struct VECTOR *v1; // $a2
-		// 		struct VECTOR *v2; // $a1
+		// 		BONE *pBone; // $s0
+		// 		VECTOR *v1; // $a2
+		// 		VECTOR *v2; // $a1
 
 			/* begin block 1.4.1 */
 				// Start line: 1569
 				// Start offset: 0x0006648C
 				// Variables:
-			// 		struct SVECTOR *data; // $t1
+			// 		SVECTOR *data; // $t1
 			// 		long t1; // stack offset -52
 			// 		long t0; // stack offset -56
 			// 		int z2; // stack offset -40
@@ -1509,7 +1509,7 @@ void newShowTanner(PEDESTRIAN *pDrawingPed)
 
 // decompiled code
 // original method signature: 
-// struct SVECTOR * /*$ra*/ GetModelVertPtr(int boneId /*$a1*/, int modelType /*$a1*/)
+// SVECTOR * /*$ra*/ GetModelVertPtr(int boneId /*$a1*/, int modelType /*$a1*/)
  // line 1774, offset 0x00066fb8
 	/* begin block 1 */
 		// Start line: 4462
@@ -1568,28 +1568,28 @@ SVECTOR* GetModelVertPtr(PEDESTRIAN *pDrawingPed, int boneId, int modelType)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ newRotateBones(struct BONE *poBone /*$a0*/)
+// void /*$ra*/ newRotateBones(BONE *poBone /*$a0*/)
  // line 1606, offset 0x00066648
 	/* begin block 1 */
 		// Start line: 1608
 		// Start offset: 0x00066648
 		// Variables:
-	// 		struct MATRIX mStore[32]; // stack offset -1088
-	// 		struct MATRIX *pMatrix; // $s2
-	// 		struct MATRIX *oMatrix; // $s5
-	// 		struct SVECTOR *svBone; // $s6
-	// 		struct VECTOR *vBoneRotated; // $s3
-	// 		struct BONE *pBone; // $s1
+	// 		MATRIX mStore[32]; // stack offset -1088
+	// 		MATRIX *pMatrix; // $s2
+	// 		MATRIX *oMatrix; // $s5
+	// 		SVECTOR *svBone; // $s6
+	// 		VECTOR *vBoneRotated; // $s3
+	// 		BONE *pBone; // $s1
 	// 		int id; // $s0
-	// 		struct SVECTOR *pVerts; // $a3
-	// 		struct SVECTOR *pmVerts; // $s0
+	// 		SVECTOR *pVerts; // $a3
+	// 		SVECTOR *pmVerts; // $s0
 	// 		int numVerts; // $t0
-	// 		struct MODEL *pModel; // $v0
+	// 		MODEL *pModel; // $v0
 	// 		int i; // $a2
-	// 		struct SVECTOR *pD; // $a0
+	// 		SVECTOR *pD; // $a0
 	// 		int c; // $s4
 	// 		int j; // $a1
-	// 		struct VECTOR sv; // stack offset -64
+	// 		VECTOR sv; // stack offset -64
 
 		/* begin block 1.1 */
 			// Start line: 1609
@@ -1838,29 +1838,29 @@ void newRotateBones(PEDESTRIAN *pDrawingPed, BONE *poBone)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawCiv(struct PEDESTRIAN *pPed /*$fp*/)
+// void /*$ra*/ DrawCiv(PEDESTRIAN *pPed /*$fp*/)
  // line 1834, offset 0x000670cc
 	/* begin block 1 */
 		// Start line: 1835
 		// Start offset: 0x000670CC
 		// Variables:
 	// 		int i; // $s5
-	// 		struct DVECTOR *outpoints; // $t9
+	// 		DVECTOR *outpoints; // $t9
 	// 		long *outlongs; // $s5
-	// 		struct SVECTOR *psrLerpData; // $t8
+	// 		SVECTOR *psrLerpData; // $t8
 	// 		long *zbuff; // $s4
-	// 		struct SVECTOR *pLerpData; // $s0
-	// 		struct SVECTOR pos; // stack offset -160
-	// 		struct VECTOR pos1; // stack offset -152
-	// 		struct SVECTOR *vert1; // $a1
-	// 		struct SVECTOR *vert2; // $a0
-	// 		struct SVECTOR temp1; // stack offset -136
-	// 		struct SVECTOR temp2; // stack offset -128
+	// 		SVECTOR *pLerpData; // $s0
+	// 		SVECTOR pos; // stack offset -160
+	// 		VECTOR pos1; // stack offset -152
+	// 		SVECTOR *vert1; // $a1
+	// 		SVECTOR *vert2; // $a0
+	// 		SVECTOR temp1; // stack offset -136
+	// 		SVECTOR temp2; // stack offset -128
 	// 		int cnt3; // $a2
 	// 		int bHeadModel; // stack offset -56
 	// 		int shift; // $t0
 	// 		int frame; // $a2
-	// 		struct MATRIX workmatrix; // stack offset -120
+	// 		MATRIX workmatrix; // stack offset -120
 	// 		int j; // $s7
 
 		/* begin block 1.1 */
@@ -1882,9 +1882,9 @@ void newRotateBones(PEDESTRIAN *pDrawingPed, BONE *poBone)
 			// Start line: 1964
 			// Start offset: 0x000677C0
 			// Variables:
-		// 		struct SVECTOR sV; // stack offset -88
-		// 		struct SVECTOR sV2; // stack offset -80
-		// 		struct VECTOR v; // stack offset -72
+		// 		SVECTOR sV; // stack offset -88
+		// 		SVECTOR sV2; // stack offset -80
+		// 		VECTOR v; // stack offset -72
 		/* end block 1.2 */
 		// End offset: 0x000677FC
 		// End Line: 1976
@@ -1893,8 +1893,8 @@ void newRotateBones(PEDESTRIAN *pDrawingPed, BONE *poBone)
 			// Start line: 1985
 			// Start offset: 0x000677FC
 			// Variables:
-		// 		struct CVECTOR cv; // stack offset -88
-		// 		struct VECTOR pos; // stack offset -80
+		// 		CVECTOR cv; // stack offset -88
+		// 		VECTOR pos; // stack offset -80
 		// 		int phase; // $s0
 		/* end block 1.3 */
 		// End offset: 0x000678A0
@@ -2210,16 +2210,16 @@ void SetSkelModelPointers(int type)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawTanner(struct PEDESTRIAN *pPed /*$s2*/)
+// void /*$ra*/ DrawTanner(PEDESTRIAN *pPed /*$s2*/)
  // line 2041, offset 0x000678d0
 	/* begin block 1 */
 		// Start line: 2042
 		// Start offset: 0x000678D0
 		// Variables:
-	// 		struct VECTOR v; // stack offset -112
-	// 		struct CVECTOR cV; // stack offset -96
-	// 		struct MATRIX mRotStore; // stack offset -88
-	// 		struct MATRIX iMatrix; // stack offset -56
+	// 		VECTOR v; // stack offset -112
+	// 		CVECTOR cV; // stack offset -96
+	// 		MATRIX mRotStore; // stack offset -88
+	// 		MATRIX iMatrix; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 2042
@@ -2305,16 +2305,16 @@ void DrawTanner(PEDESTRIAN *pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ DrawCharacter(struct PEDESTRIAN *pPed /*$s1*/)
+// int /*$ra*/ DrawCharacter(PEDESTRIAN *pPed /*$s1*/)
  // line 2120, offset 0x00067d44
 	/* begin block 1 */
 		// Start line: 2121
 		// Start offset: 0x00067D44
 		// Variables:
-	// 		struct MATRIX mRotStore; // stack offset -128
-	// 		struct MATRIX iMatrix; // stack offset -96
-	// 		struct CVECTOR cV; // stack offset -64
-	// 		struct VECTOR v; // stack offset -56
+	// 		MATRIX mRotStore; // stack offset -128
+	// 		MATRIX iMatrix; // stack offset -96
+	// 		CVECTOR cV; // stack offset -64
+	// 		VECTOR v; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 2121
@@ -2335,8 +2335,8 @@ void DrawTanner(PEDESTRIAN *pPed)
 			// Start line: 2175
 			// Start offset: 0x00068134
 			// Variables:
-		// 		struct CVECTOR cv; // stack offset -40
-		// 		struct VECTOR pos; // stack offset -32
+		// 		CVECTOR cv; // stack offset -40
+		// 		VECTOR pos; // stack offset -32
 		// 		int phase; // $s0
 		/* end block 1.2 */
 		// End offset: 0x000681D0
@@ -2440,7 +2440,7 @@ int DrawCharacter(PEDESTRIAN *pPed)
 		// Start line: 2203
 		// Start offset: 0x000681EC
 		// Variables:
-	// 		struct CVECTOR cV; // stack offset -8
+	// 		CVECTOR cV; // stack offset -8
 	// 		int i; // $a3
 	/* end block 1 */
 	// End offset: 0x00068358
@@ -2556,7 +2556,7 @@ void InitTannerShadow(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TannerShadow(struct VECTOR *pPedPos /*$s6*/, struct SVECTOR *pLightPos /*$s7*/, struct CVECTOR *col /*$a2*/, short angle /*$a3*/)
+// void /*$ra*/ TannerShadow(VECTOR *pPedPos /*$s6*/, SVECTOR *pLightPos /*$s7*/, CVECTOR *col /*$a2*/, short angle /*$a3*/)
  // line 2258, offset 0x00068358
 	/* begin block 1 */
 		// Start line: 2259
@@ -2567,15 +2567,15 @@ void InitTannerShadow(void)
 	// 		int z1; // stack offset -68
 	// 		int z2; // stack offset -64
 	// 		int z3; // stack offset -60
-	// 		struct SVECTOR vert[4]; // stack offset -272
-	// 		struct VECTOR d; // stack offset -240
-	// 		struct DR_ENV *pDE; // $s3
-	// 		struct DRAWENV drEnv; // stack offset -224
-	// 		struct VECTOR cp; // stack offset -128
-	// 		struct SVECTOR ca; // stack offset -112
-	// 		struct VECTOR v1; // stack offset -104
+	// 		SVECTOR vert[4]; // stack offset -272
+	// 		VECTOR d; // stack offset -240
+	// 		DR_ENV *pDE; // $s3
+	// 		DRAWENV drEnv; // stack offset -224
+	// 		VECTOR cp; // stack offset -128
+	// 		SVECTOR ca; // stack offset -112
+	// 		VECTOR v1; // stack offset -104
 	// 		int i; // $s4
-	// 		struct VECTOR myVector; // stack offset -88
+	// 		VECTOR myVector; // stack offset -88
 	// 		int avalue2; // $v0
 	// 		int w; // $v1
 
@@ -2776,19 +2776,19 @@ void TannerShadow(PEDESTRIAN* pDrawingPed, VECTOR *pPedPos, SVECTOR *pLightPos, 
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DoCivHead(struct SVECTOR *vert1 /*$s1*/, struct SVECTOR *vert2 /*$s3*/)
+// void /*$ra*/ DoCivHead(SVECTOR *vert1 /*$s1*/, SVECTOR *vert2 /*$s3*/)
  // line 2442, offset 0x00068b2c
 	/* begin block 1 */
 		// Start line: 2443
 		// Start offset: 0x00068B2C
 		// Variables:
-	// 		struct VECTOR headpos; // stack offset -184
-	// 		struct SVECTOR final_rotation; // stack offset -168
-	// 		struct SVECTOR spos1; // stack offset -160
-	// 		struct MODEL *model; // $s5
-	// 		struct MATRIX work2matrix; // stack offset -152
-	// 		struct MATRIX mRotStore; // stack offset -120
-	// 		struct VECTOR pos1; // stack offset -88
+	// 		VECTOR headpos; // stack offset -184
+	// 		SVECTOR final_rotation; // stack offset -168
+	// 		SVECTOR spos1; // stack offset -160
+	// 		MODEL *model; // $s5
+	// 		MATRIX work2matrix; // stack offset -152
+	// 		MATRIX mRotStore; // stack offset -120
+	// 		VECTOR pos1; // stack offset -88
 	// 		int pal; // $v1
 	// 		int ci; // $s6
 
@@ -2824,7 +2824,7 @@ void TannerShadow(PEDESTRIAN* pDrawingPed, VECTOR *pPedPos, SVECTOR *pLightPos, 
 			// Start line: 2535
 			// Start offset: 0x00069274
 			// Variables:
-		// 		struct MATRIX comb; // stack offset -72
+		// 		MATRIX comb; // stack offset -72
 		/* end block 1.3 */
 		// End offset: 0x00069274
 		// End Line: 2537
@@ -2915,15 +2915,15 @@ void DoCivHead(PEDESTRIAN *pPed, SVECTOR *vert1, SVECTOR *vert2)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawObject(struct MODEL *model /*$t8*/, struct MATRIX *matrix /*$a1*/, struct VECTOR *pos /*$a2*/, int z_correct /*$a3*/)
+// void /*$ra*/ DrawObject(MODEL *model /*$t8*/, MATRIX *matrix /*$a1*/, VECTOR *pos /*$a2*/, int z_correct /*$a3*/)
  // line 2562, offset 0x00069438
 	/* begin block 1 */
 		// Start line: 2563
 		// Start offset: 0x00069438
 		// Variables:
-	// 		struct DVECTOR *outpoints; // $t7
+	// 		DVECTOR *outpoints; // $t7
 	// 		short *zbuff; // $t5
-	// 		struct SVECTOR *verts; // $t6
+	// 		SVECTOR *verts; // $t6
 	// 		char *polys; // $s0
 	// 		int cnt3; // $t1
 	// 		int i; // $s1
@@ -3119,10 +3119,10 @@ void DrawObject(MODEL *model, MATRIX *matrix, VECTOR *pos, int z_correct)
 		// Start line: 2692
 		// Start offset: 0x00069874
 		// Variables:
-	// 		struct POLYFT3 *src; // $a3
+	// 		POLYFT3 *src; // $a3
 	// 		short *zbuff; // $t2
 	// 		long *outlongs; // $a2
-	// 		struct POLY_FT3 *prims; // $t1
+	// 		POLY_FT3 *prims; // $t1
 	// 		unsigned long clut; // $t0
 	// 		unsigned long tpage; // $a1
 	// 		int z; // $a2

--- a/src_rebuild/GAME/C/OBJANIM.C
+++ b/src_rebuild/GAME/C/OBJANIM.C
@@ -173,8 +173,8 @@ int cycle_timer = 0;
 		// Start offset: 0x000149B4
 		// Variables:
 	// 		int i; // $s0
-	// 		struct CYCLE_OBJECT *cyc; // $s1
-	// 		struct RECT vram; // stack offset -24
+	// 		CYCLE_OBJECT *cyc; // $s1
+	// 		RECT vram; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00014A58
 	// End Line: 278
@@ -225,8 +225,8 @@ void InitCyclingPals(void)
 		// Start offset: 0x00013980
 		// Variables:
 	// 		int i; // $s5
-	// 		struct CYCLE_OBJECT *cyc; // $s2
-	// 		struct RECT vram; // stack offset -56
+	// 		CYCLE_OBJECT *cyc; // $s2
+	// 		RECT vram; // stack offset -56
 	// 		unsigned short *bufaddr; // $s0
 	// 		unsigned short length; // $v0
 	// 		unsigned short temp; // $s1
@@ -370,7 +370,7 @@ void ColourCycle(void)
 		// Start line: 462
 		// Start offset: 0x00014950
 		// Variables:
-	// 		struct SMASHABLE_OBJECT *sip; // $s0
+	// 		SMASHABLE_OBJECT *sip; // $s0
 	/* end block 1 */
 	// End offset: 0x000149A8
 	// End Line: 468
@@ -420,11 +420,11 @@ void FindSmashableObjects(void)
 		// Start line: 483
 		// Start offset: 0x00013CAC
 		// Variables:
-	// 		struct ANIMATED_OBJECT *aop; // $s1
+	// 		ANIMATED_OBJECT *aop; // $s1
 	// 		int loop; // $s0
 	// 		int count1; // $a0
 	// 		int count; // $a2
-	// 		struct MODEL *modelPtr; // $a0
+	// 		MODEL *modelPtr; // $a0
 	/* end block 1 */
 	// End offset: 0x00013DF8
 	// End Line: 528
@@ -498,7 +498,7 @@ void InitAnimatingObjects(void)
 		// Start line: 537
 		// Start offset: 0x00014828
 		// Variables:
-	// 		struct ANIMATED_OBJECT *aop; // $a1
+	// 		ANIMATED_OBJECT *aop; // $a1
 	// 		int i; // $a2
 	/* end block 1 */
 	// End offset: 0x00014898
@@ -570,13 +570,13 @@ void int_garage_door(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ DrawAnimatingObject(struct MODEL *model /*$a0*/, struct CELL_OBJECT *cop /*$s3*/, struct VECTOR *pos /*$a2*/)
+// int /*$ra*/ DrawAnimatingObject(MODEL *model /*$a0*/, CELL_OBJECT *cop /*$s3*/, VECTOR *pos /*$a2*/)
  // line 578, offset 0x000148a0
 	/* begin block 1 */
 		// Start line: 579
 		// Start offset: 0x000148A0
 		// Variables:
-	// 		struct ANIMATED_OBJECT *aop; // $s1
+	// 		ANIMATED_OBJECT *aop; // $s1
 	// 		int loop; // $s2
 	// 		int type; // $s0
 	/* end block 1 */
@@ -627,7 +627,7 @@ void DrawAllAnimatingObjects(CELL_OBJECT** objects, int num_animated)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ animate_object(struct CELL_OBJECT *cop /*$s2*/, int type /*$a1*/)
+// void /*$ra*/ animate_object(CELL_OBJECT *cop /*$s2*/, int type /*$a1*/)
  // line 613, offset 0x00013df8
 	/* begin block 1 */
 		// Start line: 614

--- a/src_rebuild/GAME/C/OBJCOLL.C
+++ b/src_rebuild/GAME/C/OBJCOLL.C
@@ -17,16 +17,16 @@
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ CellEmpty(struct VECTOR *pPosition /*$s1*/, int radius /*$s2*/)
+// char /*$ra*/ CellEmpty(VECTOR *pPosition /*$s1*/, int radius /*$s2*/)
  // line 63, offset 0x00069ba4
 	/* begin block 1 */
 		// Start line: 64
 		// Start offset: 0x00069BA4
 		// Variables:
-	// 		struct CELL_ITERATOR ci; // stack offset -48
+	// 		CELL_ITERATOR ci; // stack offset -48
 	// 		int cell_x; // $a0
-	// 		struct CELL_OBJECT *pCellObject; // $a2
-	// 		struct MODEL *pModel; // $a3
+	// 		CELL_OBJECT *pCellObject; // $a2
+	// 		MODEL *pModel; // $a3
 
 		/* begin block 1.1 */
 			// Start line: 100
@@ -42,7 +42,7 @@
 				// Variables:
 			// 		int box_loop; // $t3
 			// 		int num_cb; // $t6
-			// 		struct COLLISION_PACKET *collide; // $t0
+			// 		COLLISION_PACKET *collide; // $t0
 
 				/* begin block 1.1.1.1 */
 					// Start line: 119
@@ -259,7 +259,7 @@ char CellEmpty(VECTOR *pPosition, int radius)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ GlobalPositionToCellNumber(struct VECTOR *pPosition /*$a0*/)
+// int /*$ra*/ GlobalPositionToCellNumber(VECTOR *pPosition /*$a0*/)
  // line 155, offset 0x0006b2ec
 	/* begin block 1 */
 		// Start line: 156
@@ -318,7 +318,7 @@ int GlobalPositionToCellNumber(VECTOR *pPosition)
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ CellAtPositionEmpty(struct VECTOR *pPosition /*$s0*/, int radius /*$s1*/)
+// char /*$ra*/ CellAtPositionEmpty(VECTOR *pPosition /*$s0*/, int radius /*$s1*/)
  // line 183, offset 0x0006b3e4
 	/* begin block 1 */
 		// Start line: 184
@@ -350,21 +350,21 @@ char CellAtPositionEmpty(VECTOR *pPosition, int radius)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ RaySlabsIntersection(struct tRay *ray /*$t5*/, struct tAABB *bbox /*$t4*/)
+// int /*$ra*/ RaySlabsIntersection(tRay *ray /*$t5*/, tAABB *bbox /*$t4*/)
  // line 217, offset 0x00069e1c
 	/* begin block 1 */
 		// Start line: 218
 		// Start offset: 0x00069E1C
 		// Variables:
 	// 		int i; // $t1
-	// 		struct tRange inside; // stack offset -24
+	// 		tRange inside; // stack offset -24
 
 		/* begin block 1.1 */
 			// Start line: 226
 			// Start offset: 0x00069E40
 			// Variables:
-		// 		struct tRange cabbage; // stack offset -16
-		// 		struct tRange scaledCabbage; // stack offset -8
+		// 		tRange cabbage; // stack offset -16
+		// 		tRange scaledCabbage; // stack offset -8
 		// 		int dir; // $a2
 		/* end block 1.1 */
 		// End offset: 0x00069F94
@@ -456,7 +456,7 @@ int RaySlabsIntersection(tRay *ray, tAABB *bbox)
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ lineClear(struct VECTOR *v1 /*stack 0*/, struct VECTOR *v2 /*stack 4*/)
+// char /*$ra*/ lineClear(VECTOR *v1 /*stack 0*/, VECTOR *v2 /*stack 4*/)
  // line 259, offset 0x00069fb4
 	/* begin block 1 */
 		// Start line: 260
@@ -465,9 +465,9 @@ int RaySlabsIntersection(tRay *ray, tAABB *bbox)
 	// 		int we; // stack offset -56
 	// 		int ocx; // $t2
 	// 		int ocz; // $t3
-	// 		struct VECTOR pos; // stack offset -184
-	// 		struct VECTOR va; // stack offset -168
-	// 		struct VECTOR vb; // stack offset -152
+	// 		VECTOR pos; // stack offset -184
+	// 		VECTOR va; // stack offset -168
+	// 		VECTOR vb; // stack offset -152
 
 		/* begin block 1.1 */
 			// Start line: 279
@@ -475,14 +475,14 @@ int RaySlabsIntersection(tRay *ray, tAABB *bbox)
 			// Variables:
 		// 		int cell_x; // $fp
 		// 		int cell_z; // $s7
-		// 		struct CELL_ITERATOR ci; // stack offset -136
-		// 		struct CELL_OBJECT *pCellObject; // $s4
+		// 		CELL_ITERATOR ci; // stack offset -136
+		// 		CELL_OBJECT *pCellObject; // $s4
 
 			/* begin block 1.1.1 */
 				// Start line: 299
 				// Start offset: 0x0006A134
 				// Variables:
-			// 		struct MODEL *pModel; // $a1
+			// 		MODEL *pModel; // $a1
 
 				/* begin block 1.1.1.1 */
 					// Start line: 307
@@ -498,13 +498,13 @@ int RaySlabsIntersection(tRay *ray, tAABB *bbox)
 						// Variables:
 					// 		int box_loop; // $s5
 					// 		int num_cb; // $s6
-					// 		struct COLLISION_PACKET *collide; // $s3
+					// 		COLLISION_PACKET *collide; // $s3
 
 						/* begin block 1.1.1.1.1.1 */
 							// Start line: 323
 							// Start offset: 0x0006A1F0
 							// Variables:
-						// 		struct MATRIX *mat; // $a0
+						// 		MATRIX *mat; // $a0
 						// 		int cx; // $v1
 						// 		int cy; // $a2
 						// 		int cz; // $v0
@@ -515,8 +515,8 @@ int RaySlabsIntersection(tRay *ray, tAABB *bbox)
 								// Start line: 323
 								// Start offset: 0x0006A1F0
 								// Variables:
-							// 		struct tRay ray; // stack offset -112
-							// 		struct tAABB box; // stack offset -80
+							// 		tRay ray; // stack offset -112
+							// 		tAABB box; // stack offset -80
 							/* end block 1.1.1.1.1.1.1 */
 							// End offset: 0x0006A414
 							// End Line: 347
@@ -770,7 +770,7 @@ char lineClear(VECTOR *v1, VECTOR *v2)
 		// Start line: 379
 		// Start offset: 0x0006B430
 		// Variables:
-	// 		struct XZPAIR cell; // stack offset -16
+	// 		XZPAIR cell; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0006B45C
 	// End Line: 384
@@ -829,19 +829,19 @@ void BuildCollisionCopList(int *count)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CollisionCopList(struct XZPAIR *pos /*$a0*/, int *count /*$s0*/)
+// void /*$ra*/ CollisionCopList(XZPAIR *pos /*$a0*/, int *count /*$s0*/)
  // line 391, offset 0x0006a498
 	/* begin block 1 */
 		// Start line: 392
 		// Start offset: 0x0006A498
 		// Variables:
-	// 		static struct XZPAIR initial; // offset 0x0
+	// 		static XZPAIR initial; // offset 0x0
 
 		/* begin block 1.1 */
 			// Start line: 402
 			// Start offset: 0x0006A4E8
 			// Variables:
-		// 		struct XZPAIR cell; // stack offset -72
+		// 		XZPAIR cell; // stack offset -72
 		// 		int i; // $a0
 		// 		int j; // $t1
 
@@ -849,10 +849,10 @@ void BuildCollisionCopList(int *count)
 				// Start line: 411
 				// Start offset: 0x0006A508
 				// Variables:
-			// 		struct CELL_ITERATOR ci; // stack offset -64
-			// 		struct XZPAIR cbr; // stack offset -40
+			// 		CELL_ITERATOR ci; // stack offset -64
+			// 		XZPAIR cbr; // stack offset -40
 			// 		int barrelRegion; // $v0
-			// 		struct CELL_OBJECT *cop; // $a0
+			// 		CELL_OBJECT *cop; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x0006A5F8
 			// End Line: 429
@@ -950,16 +950,16 @@ void CollisionCopList(XZPAIR *pos, int *count)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CheckScenaryCollisions(struct _CAR_DATA *cp /*$s7*/)
+// void /*$ra*/ CheckScenaryCollisions(CAR_DATA *cp /*$s7*/)
  // line 439, offset 0x0006a64c
 	/* begin block 1 */
 		// Start line: 440
 		// Start offset: 0x0006A64C
 		// Variables:
-	// 		struct MODEL *model; // stack offset -76
-	// 		struct CELL_OBJECT *cop; // $s5
-	// 		struct VECTOR player_pos; // stack offset -152
-	// 		struct COLLISION_PACKET *collide; // $s1
+	// 		MODEL *model; // stack offset -76
+	// 		CELL_OBJECT *cop; // $s5
+	// 		VECTOR player_pos; // stack offset -152
+	// 		COLLISION_PACKET *collide; // $s1
 	// 		int cell_x; // $a0
 	// 		int xd; // $v1
 	// 		int zd; // $a0
@@ -967,10 +967,10 @@ void CollisionCopList(XZPAIR *pos, int *count)
 	// 		int box_loop; // $s6
 	// 		int sphere_sq; // $v0
 	// 		int x1; // stack offset -68
-	// 		struct BUILDING_BOX bbox; // stack offset -136
+	// 		BUILDING_BOX bbox; // stack offset -136
 	// 		int mdcount; // stack offset -80
 	// 		int coll_test_count; // $t0
-	// 		struct XZPAIR box; // stack offset -104
+	// 		XZPAIR box; // stack offset -104
 	// 		int lbody; // stack offset -64
 	// 		int extraDist; // stack offset -60
 
@@ -978,9 +978,9 @@ void CollisionCopList(XZPAIR *pos, int *count)
 			// Start line: 519
 			// Start offset: 0x0006A934
 			// Variables:
-		// 		struct BUILDING_BOX *pbox; // $s4
-		// 		struct MATRIX *mat; // $a1
-		// 		struct VECTOR offset; // stack offset -96
+		// 		BUILDING_BOX *pbox; // $s4
+		// 		MATRIX *mat; // $a1
+		// 		VECTOR offset; // stack offset -96
 		/* end block 1.1 */
 		// End offset: 0x0006AD48
 		// End Line: 591
@@ -1003,7 +1003,7 @@ ushort gLastModelCollisionCheck;
 int ExBoxDamage = 0;
 
 // [D] [T]
-void CheckScenaryCollisions(_CAR_DATA *cp)
+void CheckScenaryCollisions(CAR_DATA *cp)
 {
 	int count;
 	int num_cb;
@@ -1183,16 +1183,16 @@ void CheckScenaryCollisions(_CAR_DATA *cp)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ QuickBuildingCollisionCheck(struct VECTOR *pPos /*$s5*/, int dir /*stack 4*/, int l /*stack 8*/, int w /*$fp*/, int extra /*stack 16*/)
+// int /*$ra*/ QuickBuildingCollisionCheck(VECTOR *pPos /*$s5*/, int dir /*stack 4*/, int l /*stack 8*/, int w /*$fp*/, int extra /*stack 16*/)
  // line 609, offset 0x0006adbc
 	/* begin block 1 */
 		// Start line: 610
 		// Start offset: 0x0006ADBC
 		// Variables:
-	// 		struct MODEL *model; // $a1
-	// 		struct CELL_OBJECT *cop; // $s3
-	// 		struct VECTOR player_pos; // stack offset -112
-	// 		struct COLLISION_PACKET *collide; // $s0
+	// 		MODEL *model; // $a1
+	// 		CELL_OBJECT *cop; // $s3
+	// 		VECTOR player_pos; // stack offset -112
+	// 		COLLISION_PACKET *collide; // $s0
 	// 		int cell_x; // $a0
 	// 		int xd; // $v1
 	// 		int zd; // $a0
@@ -1200,16 +1200,16 @@ void CheckScenaryCollisions(_CAR_DATA *cp)
 	// 		int box_loop; // $s4
 	// 		int sphere_sq; // $v0
 	// 		int x1; // $s6
-	// 		struct BUILDING_BOX bbox; // stack offset -96
+	// 		BUILDING_BOX bbox; // stack offset -96
 	// 		int mdcount; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 669
 			// Start offset: 0x0006AFA4
 			// Variables:
-		// 		struct BUILDING_BOX *pbox; // $s1
-		// 		struct MATRIX *mat; // $a1
-		// 		struct VECTOR offset; // stack offset -64
+		// 		BUILDING_BOX *pbox; // $s1
+		// 		MATRIX *mat; // $a1
+		// 		VECTOR offset; // stack offset -64
 
 			/* begin block 1.1.1 */
 				// Start line: 685
@@ -1427,7 +1427,7 @@ int QuickBuildingCollisionCheck(VECTOR *pPos, int dir, int l, int w, int extra)
 		// Start line: 737
 		// Start offset: 0x0006B220
 		// Variables:
-	// 		struct _CAR_DATA *lcp; // $s0
+	// 		CAR_DATA *lcp; // $s0
 	/* end block 1 */
 	// End offset: 0x0006B2EC
 	// End Line: 753
@@ -1457,7 +1457,7 @@ int QuickBuildingCollisionCheck(VECTOR *pPos, int dir, int l, int w, int extra)
 // [D] [T]
 void DoScenaryCollisions(void)
 {
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 
 	cp = &car_data[MAX_CARS - 1];
 

--- a/src_rebuild/GAME/C/OBJCOLL.H
+++ b/src_rebuild/GAME/C/OBJCOLL.H
@@ -19,7 +19,7 @@ extern void BuildCollisionCopList(int *count); // 0x0006B45C
 
 extern void CollisionCopList(XZPAIR *pos, int *count); // 0x0006A498
 
-extern void CheckScenaryCollisions(_CAR_DATA *cp); // 0x0006A64C
+extern void CheckScenaryCollisions(CAR_DATA *cp); // 0x0006A64C
 
 extern int QuickBuildingCollisionCheck(VECTOR *pPos, int dir, int l, int w, int extra); // 0x0006ADBC
 

--- a/src_rebuild/GAME/C/OVERLAY.C
+++ b/src_rebuild/GAME/C/OVERLAY.C
@@ -50,11 +50,11 @@ COLOUR_BAND damageColour[2] =
 
 /* WARNING: Unknown calling convention yet parameter storage is locked */
 
-_PERCENTAGE_BAR PlayerDamageBar;
-_PERCENTAGE_BAR Player2DamageBar;
-_PERCENTAGE_BAR DamageBar;
-_PERCENTAGE_BAR FelonyBar;
-_PERCENTAGE_BAR ProxyBar;
+PERCENTAGE_BAR PlayerDamageBar;
+PERCENTAGE_BAR Player2DamageBar;
+PERCENTAGE_BAR DamageBar;
+PERCENTAGE_BAR FelonyBar;
+PERCENTAGE_BAR ProxyBar;
 
 int gDoOverlays = 1;
 
@@ -185,8 +185,8 @@ void DisplayOverlays(void)
 		// Start line: 380
 		// Start offset: 0x00015E70
 		// Variables:
-	// 		struct DRAWENV drawenv; // stack offset -104
-	// 		struct DR_ENV *dr_env; // $s0
+	// 		DRAWENV drawenv; // stack offset -104
+	// 		DR_ENV *dr_env; // $s0
 	/* end block 1 */
 	// End offset: 0x00015F20
 	// End Line: 388
@@ -234,7 +234,7 @@ void SetFullscreenDrawing(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitPercentageBar(struct _PERCENTAGE_BAR *bar /*$a0*/, int size /*$a1*/, struct COLOUR_BAND *pColourBand /*$a2*/, char *tag /*$a3*/)
+// void /*$ra*/ InitPercentageBar(PERCENTAGE_BAR *bar /*$a0*/, int size /*$a1*/, COLOUR_BAND *pColourBand /*$a2*/, char *tag /*$a3*/)
  // line 395, offset 0x00015f20
 	/* begin block 1 */
 		// Start line: 1476
@@ -252,7 +252,7 @@ void SetFullscreenDrawing(void)
 	// End Line: 1486
 
 // [D]
-void InitPercentageBar(_PERCENTAGE_BAR *bar, int size, COLOUR_BAND *pColourBand, char *tag)
+void InitPercentageBar(PERCENTAGE_BAR *bar, int size, COLOUR_BAND *pColourBand, char *tag)
 {
 	bar->xpos = 0x96;
 	bar->ypos = 10;
@@ -270,7 +270,7 @@ void InitPercentageBar(_PERCENTAGE_BAR *bar, int size, COLOUR_BAND *pColourBand,
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ EnablePercentageBar(struct _PERCENTAGE_BAR *bar /*$a0*/, int max /*$a1*/)
+// void /*$ra*/ EnablePercentageBar(PERCENTAGE_BAR *bar /*$a0*/, int max /*$a1*/)
  // line 414, offset 0x00015f58
 	/* begin block 1 */
 		// Start line: 1524
@@ -288,7 +288,7 @@ void InitPercentageBar(_PERCENTAGE_BAR *bar, int size, COLOUR_BAND *pColourBand,
 	// End Line: 1528
 
 // [D]
-void EnablePercentageBar(_PERCENTAGE_BAR *bar, int max)
+void EnablePercentageBar(PERCENTAGE_BAR *bar, int max)
 {
 	bar->position = 0;
 	bar->max = (ushort)max;
@@ -299,14 +299,14 @@ void EnablePercentageBar(_PERCENTAGE_BAR *bar, int max)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawPercentageBar(struct _PERCENTAGE_BAR *bar /*$fp*/)
+// void /*$ra*/ DrawPercentageBar(PERCENTAGE_BAR *bar /*$fp*/)
  // line 426, offset 0x00014da8
 	/* begin block 1 */
 		// Start line: 427
 		// Start offset: 0x00014DA8
 		// Variables:
-	// 		struct POLY_G4 *poly; // $s0
-	// 		struct CVECTOR temp; // stack offset -56
+	// 		POLY_G4 *poly; // $s0
+	// 		CVECTOR temp; // stack offset -56
 	// 		int min_x; // $s1
 	// 		int max_x; // $s7
 	// 		int min_y; // $s2
@@ -332,7 +332,7 @@ void EnablePercentageBar(_PERCENTAGE_BAR *bar, int max)
 	// End Line: 896
 
 // [D]
-void DrawPercentageBar(_PERCENTAGE_BAR *bar)
+void DrawPercentageBar(PERCENTAGE_BAR *bar)
 {
 	short sVar1;
 	short sVar3;
@@ -491,13 +491,13 @@ void DrawPercentageBar(_PERCENTAGE_BAR *bar)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawProximityBar(struct _PERCENTAGE_BAR *bar /*$t3*/)
+// void /*$ra*/ DrawProximityBar(PERCENTAGE_BAR *bar /*$t3*/)
  // line 532, offset 0x000152d4
 	/* begin block 1 */
 		// Start line: 533
 		// Start offset: 0x000152D4
 		// Variables:
-	// 		struct TILE *tile; // $a1
+	// 		TILE *tile; // $a1
 	// 		int min_x; // $s1
 	// 		int max_x; // $s7
 	// 		int min_y; // $s2
@@ -529,7 +529,7 @@ void DrawPercentageBar(_PERCENTAGE_BAR *bar)
 	// End Line: 1179
 
 // [D]
-void DrawProximityBar(_PERCENTAGE_BAR *bar)
+void DrawProximityBar(PERCENTAGE_BAR *bar)
 {
 	int iVar3;
 	TILE *tile;
@@ -669,13 +669,13 @@ void DrawProximityBar(_PERCENTAGE_BAR *bar)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetColourByValue(struct COLOUR_BAND *pColourBand /*$a3*/, int value /*$a1*/, struct CVECTOR *pOut /*$t0*/)
+// void /*$ra*/ SetColourByValue(COLOUR_BAND *pColourBand /*$a3*/, int value /*$a1*/, CVECTOR *pOut /*$t0*/)
  // line 631, offset 0x00015f6c
 	/* begin block 1 */
 		// Start line: 632
 		// Start offset: 0x00015F6C
 		// Variables:
-	// 		struct COLOUR_BAND *pPrevColourBand; // $a2
+	// 		COLOUR_BAND *pPrevColourBand; // $a2
 	// 		int scale; // $a0
 	// 		int temp; // $a1
 	/* end block 1 */
@@ -740,7 +740,7 @@ void SetColourByValue(COLOUR_BAND *pColourBand, int value, CVECTOR *pOut)
 		// Start line: 670
 		// Start offset: 0x00016098
 		// Variables:
-	// 		struct DR_TPAGE *null; // $a2
+	// 		DR_TPAGE *null; // $a2
 	/* end block 1 */
 	// End offset: 0x00016114
 	// End Line: 676
@@ -842,7 +842,7 @@ void UpdateFlashValue(void)
 		// Start line: 709
 		// Start offset: 0x000157F4
 		// Variables:
-	// 		struct SCORE_ENTRY *table; // $s1
+	// 		SCORE_ENTRY *table; // $s1
 	// 		char string[32]; // stack offset -64
 	// 		int i; // $s1
 	// 		int x; // $s3

--- a/src_rebuild/GAME/C/OVERLAY.H
+++ b/src_rebuild/GAME/C/OVERLAY.H
@@ -1,11 +1,11 @@
 #ifndef OVERLAY_H
 #define OVERLAY_H
 
-extern _PERCENTAGE_BAR PlayerDamageBar;
-extern _PERCENTAGE_BAR Player2DamageBar;
-extern _PERCENTAGE_BAR DamageBar;
-extern _PERCENTAGE_BAR FelonyBar;
-extern _PERCENTAGE_BAR ProxyBar;
+extern PERCENTAGE_BAR PlayerDamageBar;
+extern PERCENTAGE_BAR Player2DamageBar;
+extern PERCENTAGE_BAR DamageBar;
+extern PERCENTAGE_BAR FelonyBar;
+extern PERCENTAGE_BAR ProxyBar;
 
 extern char OverlayFlashValue;
 
@@ -15,15 +15,15 @@ extern void DisplayOverlays(); // 0x00014C3C
 
 extern void SetFullscreenDrawing(); // 0x00015E70
 
-extern void InitPercentageBar(struct _PERCENTAGE_BAR *bar, int size, struct COLOUR_BAND *pColourBand, char *tag); // 0x00015F20
+extern void InitPercentageBar(PERCENTAGE_BAR *bar, int size, COLOUR_BAND *pColourBand, char *tag); // 0x00015F20
 
-extern void EnablePercentageBar(struct _PERCENTAGE_BAR *bar, int max); // 0x00015F58
+extern void EnablePercentageBar(PERCENTAGE_BAR *bar, int max); // 0x00015F58
 
-extern void DrawPercentageBar(struct _PERCENTAGE_BAR *bar); // 0x00014DA8
+extern void DrawPercentageBar(PERCENTAGE_BAR *bar); // 0x00014DA8
 
-extern void DrawProximityBar(struct _PERCENTAGE_BAR *bar); // 0x000152D4
+extern void DrawProximityBar(PERCENTAGE_BAR *bar); // 0x000152D4
 
-extern void SetColourByValue(struct COLOUR_BAND *pColourBand, int value, struct CVECTOR *pOut); // 0x00015F6C
+extern void SetColourByValue(COLOUR_BAND *pColourBand, int value, CVECTOR *pOut); // 0x00015F6C
 
 extern void TransparencyOn(void *potz, unsigned short tpage); // 0x00016098
 

--- a/src_rebuild/GAME/C/OVERMAP.C
+++ b/src_rebuild/GAME/C/OVERMAP.C
@@ -116,14 +116,14 @@ static int gUseRotatedMap = 0;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawTargetBlip(struct VECTOR *pos /*$t0*/, unsigned char r /*$s2*/, unsigned char g /*$s3*/, unsigned char b /*$s4*/, unsigned long flags /*stack 16*/)
+// void /*$ra*/ DrawTargetBlip(VECTOR *pos /*$t0*/, unsigned char r /*$s2*/, unsigned char g /*$s3*/, unsigned char b /*$s4*/, unsigned long flags /*stack 16*/)
  // line 685, offset 0x00016280
 	/* begin block 1 */
 		// Start line: 686
 		// Start offset: 0x00016280
 		// Variables:
-	// 		struct POLY_FT4 *poly; // $t0
-	// 		struct VECTOR vec; // stack offset -40
+	// 		POLY_FT4 *poly; // $t0
+	// 		VECTOR vec; // stack offset -40
 	// 		int ysize; // $a2
 	/* end block 1 */
 	// End offset: 0x00016558
@@ -246,16 +246,16 @@ void DrawTargetBlip(VECTOR *pos, unsigned char r, unsigned char g, unsigned char
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawTargetArrow(struct VECTOR *pos /*$a2*/, unsigned long flags /*$s3*/)
+// void /*$ra*/ DrawTargetArrow(VECTOR *pos /*$a2*/, unsigned long flags /*$s3*/)
  // line 815, offset 0x00016578
 	/* begin block 1 */
 		// Start line: 816
 		// Start offset: 0x00016578
 		// Variables:
-	// 		struct VECTOR vec; // stack offset -56
-	// 		struct VECTOR vec2; // stack offset -40
-	// 		struct POLY_FT3 *null; // $t1
-	// 		struct POLY_G3 *poly; // $s2
+	// 		VECTOR vec; // stack offset -56
+	// 		VECTOR vec2; // stack offset -40
+	// 		POLY_FT3 *null; // $t1
+	// 		POLY_G3 *poly; // $s2
 	// 		int dx; // $s1
 	// 		int dy; // $s0
 	/* end block 1 */
@@ -371,18 +371,18 @@ void DrawTargetArrow(VECTOR *pos, ulong flags)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawPlayerDot(struct VECTOR *pos /*$a1*/, short rot /*$s2*/, unsigned char r /*$s5*/, unsigned char g /*$s4*/, int b /*stack 16*/, unsigned long flags /*stack 20*/)
+// void /*$ra*/ DrawPlayerDot(VECTOR *pos /*$a1*/, short rot /*$s2*/, unsigned char r /*$s5*/, unsigned char g /*$s4*/, int b /*stack 16*/, unsigned long flags /*stack 20*/)
  // line 883, offset 0x00016814
 	/* begin block 1 */
 		// Start line: 884
 		// Start offset: 0x00016814
 		// Variables:
-	// 		struct MATRIX matrix; // stack offset -168
-	// 		struct VECTOR direction; // stack offset -136
-	// 		struct SVECTOR apos[3]; // stack offset -120
-	// 		struct VECTOR opos[3]; // stack offset -96
-	// 		struct POLY_F3 *poly; // $t0
-	// 		struct VECTOR vec; // stack offset -48
+	// 		MATRIX matrix; // stack offset -168
+	// 		VECTOR direction; // stack offset -136
+	// 		SVECTOR apos[3]; // stack offset -120
+	// 		VECTOR opos[3]; // stack offset -96
+	// 		POLY_F3 *poly; // $t0
+	// 		VECTOR vec; // stack offset -48
 	/* end block 1 */
 	// End offset: 0x00016AC4
 	// End Line: 946
@@ -501,7 +501,7 @@ void DrawPlayerDot(VECTOR *pos, short rot, unsigned char r, unsigned char g, int
 		// Start line: 955
 		// Start offset: 0x00016AE8
 		// Variables:
-	// 		struct TEXTURE_DETAILS info; // stack offset -32
+	// 		TEXTURE_DETAILS info; // stack offset -32
 	// 		int i; // $a1
 	// 		int x; // $v0
 	// 		int y; // $a0
@@ -553,13 +553,13 @@ void ProcessOverlayLump(char *lump_ptr, int lump_size)
 
 // decompiled code
 // original method signature: 
-// unsigned long /*$ra*/ Long2DDistance(struct VECTOR *pPoint1 /*$a0*/, struct VECTOR *pPoint2 /*$a2*/)
+// unsigned long /*$ra*/ Long2DDistance(VECTOR *pPoint1 /*$a0*/, VECTOR *pPoint2 /*$a2*/)
  // line 994, offset 0x00016c0c
 	/* begin block 1 */
 		// Start line: 995
 		// Start offset: 0x00016C0C
 		// Variables:
-	// 		struct VECTOR delta; // stack offset -24
+	// 		VECTOR delta; // stack offset -24
 	// 		unsigned int result; // $v0
 
 		/* begin block 1.1 */
@@ -736,15 +736,15 @@ void InitOverheadMap(void)
 	// 		int MeshWidth; // $s6
 	// 		int MeshHeight; // $s7
 	// 		long flag; // stack offset -104
-	// 		struct SVECTOR MapMesh[5][5]; // stack offset -784
-	// 		struct VECTOR MapMeshO[5][5]; // stack offset -584
-	// 		struct MAPTEX MapTex[4]; // stack offset -184
-	// 		struct SVECTOR direction; // stack offset -152
-	// 		struct POLY_FT4 *spt; // $a3
-	// 		struct POLY_F4 *sptb; // $a0
-	// 		struct DR_AREA *draw_area; // $s2
-	// 		struct RECT clipped_size; // stack offset -144
-	// 		struct VECTOR translate; // stack offset -136
+	// 		SVECTOR MapMesh[5][5]; // stack offset -784
+	// 		VECTOR MapMeshO[5][5]; // stack offset -584
+	// 		MAPTEX MapTex[4]; // stack offset -184
+	// 		SVECTOR direction; // stack offset -152
+	// 		POLY_FT4 *spt; // $a3
+	// 		POLY_F4 *sptb; // $a0
+	// 		DR_AREA *draw_area; // $s2
+	// 		RECT clipped_size; // stack offset -144
+	// 		VECTOR translate; // stack offset -136
 
 		/* begin block 1.1 */
 			// Start line: 1112
@@ -773,8 +773,8 @@ void InitOverheadMap(void)
 				// Start line: 1139
 				// Start offset: 0x00016FA8
 				// Variables:
-			// 		struct VECTOR vec; // stack offset -120
-			// 		struct TILE_1 *tile1; // $a0
+			// 		VECTOR vec; // stack offset -120
+			// 		TILE_1 *tile1; // $a0
 			/* end block 1.3.1 */
 			// End offset: 0x000170F4
 			// End Line: 1142
@@ -786,7 +786,7 @@ void InitOverheadMap(void)
 			// Start line: 1146
 			// Start offset: 0x000170F4
 			// Variables:
-		// 		struct _CAR_DATA *cp; // $s0
+		// 		CAR_DATA *cp; // $s0
 		/* end block 1.4 */
 		// End offset: 0x00017218
 		// End Line: 1161
@@ -874,7 +874,7 @@ void DrawOverheadMap(void)
 	SVECTOR *pSVar21;
 	char cVar22;
 	SVECTOR *v0;
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 	char *pcVar24;
 	char *pbVar25;
 	VECTOR *v1;
@@ -1330,12 +1330,12 @@ LAB_00016fac:
 		// Start line: 1376
 		// Start offset: 0x00017C30
 		// Variables:
-	// 		struct TILE *polys; // $v0
-	// 		struct POLY_FT4 *back; // $a1
-	// 		struct POLY_FT3 *null; // $a2
-	// 		struct SVECTOR Mesh[4]; // stack offset -192
-	// 		struct VECTOR MeshO[4]; // stack offset -160
-	// 		struct VECTOR target; // stack offset -96
+	// 		TILE *polys; // $v0
+	// 		POLY_FT4 *back; // $a1
+	// 		POLY_FT3 *null; // $a2
+	// 		SVECTOR Mesh[4]; // stack offset -192
+	// 		VECTOR MeshO[4]; // stack offset -160
+	// 		VECTOR target; // stack offset -96
 	// 		long flag; // stack offset -64
 	// 		long count; // $s4
 	// 		int width; // stack offset -60
@@ -1374,8 +1374,8 @@ LAB_00016fac:
 				// Start line: 1620
 				// Start offset: 0x000182B0
 				// Variables:
-			// 		struct VECTOR vec; // stack offset -80
-			// 		struct TILE_1 *tile1; // $v1
+			// 		VECTOR vec; // stack offset -80
+			// 		TILE_1 *tile1; // $v1
 			/* end block 1.3.1 */
 			// End offset: 0x000182B0
 			// End Line: 1620
@@ -1710,7 +1710,7 @@ LAB_00017f8c:
 		// Start offset: 0x000183E8
 		// Variables:
 	// 		static int ft[16]; // offset 0x188
-	// 		struct _CAR_DATA *cp; // $s0
+	// 		CAR_DATA *cp; // $s0
 	// 		int fade; // $s1
 	// 		int cc; // $s3
 	// 		int cs; // $s2
@@ -1769,7 +1769,7 @@ void DrawCopIndicators(void)
 	int iVar4;
 	int iVar5;
 	int iVar6;
-	_CAR_DATA *cp;
+	CAR_DATA *cp;
 
 	sVar1 = rcossin_tbl[(player[0].dir & 0xfffU) * 2 + 1];
 	sVar2 = rcossin_tbl[(player[0].dir & 0xfffU) * 2];
@@ -1814,7 +1814,7 @@ void DrawCopIndicators(void)
 		// Start line: 1680
 		// Start offset: 0x000198E0
 		// Variables:
-	// 		struct RECT rect; // stack offset -48
+	// 		RECT rect; // stack offset -48
 	// 		char filename[32]; // stack offset -40
 	/* end block 1 */
 	// End offset: 0x00019994
@@ -1871,9 +1871,9 @@ void InitMultiplayerMap(void)
 		// Start line: 1699
 		// Start offset: 0x000185A0
 		// Variables:
-	// 		struct POLY_FT4 *poly; // $a2
-	// 		struct LINE_F2 *line2; // $s1
-	// 		struct VECTOR target; // stack offset -64
+	// 		POLY_FT4 *poly; // $a2
+	// 		LINE_F2 *line2; // $s1
+	// 		VECTOR target; // stack offset -64
 	// 		int i; // $s3
 	// 		int y; // $s7
 	/* end block 1 */
@@ -1910,7 +1910,7 @@ void DrawMultiplayerMap(void)
 	ulong *puVar4;
 	POLY_FT4 *poly;
 	char *pcVar5;
-	_PLAYER *pPVar6;
+	PLAYER *pPVar6;
 	int iVar7;
 	char *pcVar8;
 	unsigned char g;
@@ -2034,7 +2034,7 @@ void DrawMultiplayerMap(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WorldToMultiplayerMap(struct VECTOR *in /*$a3*/, struct VECTOR *out /*$a2*/)
+// void /*$ra*/ WorldToMultiplayerMap(VECTOR *in /*$a3*/, VECTOR *out /*$a2*/)
  // line 1778, offset 0x00019994
 	/* begin block 1 */
 		// Start line: 1779
@@ -2184,7 +2184,7 @@ void ProcessPalletLump(char *lump_ptr, int lump_size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ load_civ_palettes(struct RECT *cluts /*$a0*/)
+// void /*$ra*/ load_civ_palettes(RECT *cluts /*$a0*/)
  // line 2043, offset 0x0001a094
 	/* begin block 1 */
 		// Start line: 8350
@@ -2216,7 +2216,7 @@ void load_civ_palettes(RECT16 *cluts)
 		// Start line: 2321
 		// Start offset: 0x00018980
 		// Variables:
-	// 		struct TILE *tile; // $a3
+	// 		TILE *tile; // $a3
 	/* end block 1 */
 	// End offset: 0x00018AA0
 	// End Line: 2341
@@ -2292,7 +2292,7 @@ void FlashOverheadMap(int r, int g, int b)
 		// Start line: 2351
 		// Start offset: 0x00018AA0
 		// Variables:
-	// 		struct RECT MapSegment; // stack offset -16
+	// 		RECT MapSegment; // stack offset -16
 	// 		int temp; // $a0
 	// 		int count; // $a2
 	// 		int idx; // $a3
@@ -2395,8 +2395,8 @@ void SetMapPos(void)
 		// Start line: 2407
 		// Start offset: 0x00018BF4
 		// Variables:
-	// 		struct LINE_F4 *line4; // $s0
-	// 		struct LINE_F2 *line2; // $s1
+	// 		LINE_F4 *line4; // $s0
+	// 		LINE_F2 *line2; // $s1
 	/* end block 1 */
 	// End offset: 0x00018D54
 	// End Line: 2427
@@ -2468,21 +2468,21 @@ void draw_box(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawN(struct VECTOR *pScreenPosition /*$s2*/, int direct /*$s7*/)
+// void /*$ra*/ DrawN(VECTOR *pScreenPosition /*$s2*/, int direct /*$s7*/)
  // line 2435, offset 0x00018d54
 	/* begin block 1 */
 		// Start line: 2436
 		// Start offset: 0x00018D54
 		// Variables:
-	// 		struct XYPAIR lastPoint; // stack offset -48
-	// 		struct XYPAIR *pPoint; // $s0
+	// 		XYPAIR lastPoint; // stack offset -48
+	// 		XYPAIR *pPoint; // $s0
 	// 		char loop; // $s4
 
 		/* begin block 1.1 */
 			// Start line: 2446
 			// Start offset: 0x00018DC4
 			// Variables:
-		// 		struct LINE_F2 *pLine; // $a2
+		// 		LINE_F2 *pLine; // $a2
 		/* end block 1.1 */
 		// End offset: 0x00018EC4
 		// End Line: 2469
@@ -2574,8 +2574,8 @@ void DrawN(VECTOR *pScreenPosition, int direct)
 		// Start line: 2481
 		// Start offset: 0x00018F18
 		// Variables:
-	// 		struct VECTOR position[5]; // stack offset -88
-	// 		struct XYPAIR *pNorth; // $a1
+	// 		VECTOR position[5]; // stack offset -88
+	// 		XYPAIR *pNorth; // $a1
 	// 		int scale; // $a0
 
 		/* begin block 1.1 */
@@ -2583,14 +2583,14 @@ void DrawN(VECTOR *pScreenPosition, int direct)
 			// Start offset: 0x00018F18
 			// Variables:
 		// 		char loop; // $t2
-		// 		struct VECTOR *pPosition; // $a3
+		// 		VECTOR *pPosition; // $a3
 		// 		void *pot; // $s0
 
 			/* begin block 1.1.1 */
 				// Start line: 2511
 				// Start offset: 0x000190B8
 				// Variables:
-			// 		struct LINE_G2 *pLine; // $a0
+			// 		LINE_G2 *pLine; // $a0
 			/* end block 1.1.1 */
 			// End offset: 0x000190B8
 			// End Line: 2511
@@ -2696,21 +2696,21 @@ void DrawCompass(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawBigCompass(struct VECTOR *root /*$a0*/, int angle /*$a1*/)
+// void /*$ra*/ DrawBigCompass(VECTOR *root /*$a0*/, int angle /*$a1*/)
  // line 2534, offset 0x00019194
 	/* begin block 1 */
 		// Start line: 2535
 		// Start offset: 0x00019194
 		// Variables:
-	// 		struct VECTOR position[5]; // stack offset -96
-	// 		struct VECTOR *pPosition; // $s0
+	// 		VECTOR position[5]; // stack offset -96
+	// 		VECTOR *pPosition; // $s0
 	// 		char loop; // $s1
 
 		/* begin block 1.1 */
 			// Start line: 2557
 			// Start offset: 0x00019300
 			// Variables:
-		// 		struct LINE_G2 *pLine; // $a1
+		// 		LINE_G2 *pLine; // $a1
 		/* end block 1.1 */
 		// End offset: 0x00019300
 		// End Line: 2557
@@ -2812,7 +2812,7 @@ void DrawBigCompass(VECTOR *root, int angle)
 		// Start line: 2578
 		// Start offset: 0x000193B4
 		// Variables:
-	// 		struct POLY_F3 *tri; // $a2
+	// 		POLY_F3 *tri; // $a2
 	// 		int str2; // $fp
 	// 		void *pot; // stack offset -56
 	/* end block 1 */
@@ -2896,14 +2896,14 @@ void CopIndicator(int xpos, int strength)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawSightCone(struct COP_SIGHT_DATA *pCopSightData /*$a0*/, struct VECTOR *pPosition /*$a1*/, int direction /*$t6*/)
+// void /*$ra*/ DrawSightCone(COP_SIGHT_DATA *pCopSightData /*$a0*/, VECTOR *pPosition /*$a1*/, int direction /*$t6*/)
  // line 2609, offset 0x00019594
 	/* begin block 1 */
 		// Start line: 2610
 		// Start offset: 0x00019594
 		// Variables:
-	// 		struct VECTOR vertex[9]; // stack offset -160
-	// 		struct VECTOR *pVertex; // $t0
+	// 		VECTOR vertex[9]; // stack offset -160
+	// 		VECTOR *pVertex; // $t0
 	// 		int angle; // $a3
 	// 		int frontViewAngle; // $t1
 	// 		int negFrontViewAngle; // $a2
@@ -2932,15 +2932,15 @@ void CopIndicator(int xpos, int strength)
 			// Start line: 2643
 			// Start offset: 0x0001966C
 			// Variables:
-		// 		struct VECTOR *pVertex; // $a2
+		// 		VECTOR *pVertex; // $a2
 		// 		void *pot; // $a3
 
 			/* begin block 1.2.1 */
 				// Start line: 2651
 				// Start offset: 0x000196B8
 				// Variables:
-			// 		struct POLY_G3 *poly; // $a1
-			// 		struct VECTOR *pNextVertex; // $a0
+			// 		POLY_G3 *poly; // $a1
+			// 		VECTOR *pNextVertex; // $a0
 			/* end block 1.2.1 */
 			// End offset: 0x000196DC
 			// End Line: 2659
@@ -3053,13 +3053,13 @@ void DrawSightCone(COP_SIGHT_DATA *pCopSightData, VECTOR *pPosition, int directi
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WorldToOverheadMapPositions(struct VECTOR *pGlobalPosition /*$s1*/, struct VECTOR *pOverheadMapPosition /*$s3*/, int count /*$s2*/, char inputRelative /*$s5*/, int outputRelative /*stack 16*/)
+// void /*$ra*/ WorldToOverheadMapPositions(VECTOR *pGlobalPosition /*$s1*/, VECTOR *pOverheadMapPosition /*$s3*/, int count /*$s2*/, char inputRelative /*$s5*/, int outputRelative /*stack 16*/)
  // line 2703, offset 0x00019af0
 	/* begin block 1 */
 		// Start line: 2704
 		// Start offset: 0x00019AF0
 		// Variables:
-	// 		struct MATRIX TempMatrix; // stack offset -80
+	// 		MATRIX TempMatrix; // stack offset -80
 	// 		int sin; // $a1
 	// 		int cos; // $a2
 	// 		int angle; // $v1
@@ -3069,7 +3069,7 @@ void DrawSightCone(COP_SIGHT_DATA *pCopSightData, VECTOR *pPosition, int directi
 			// Start line: 2745
 			// Start offset: 0x00019C20
 			// Variables:
-		// 		struct SVECTOR tempVector; // stack offset -48
+		// 		SVECTOR tempVector; // stack offset -48
 		// 		long flag; // stack offset -40
 		/* end block 1.1 */
 		// End offset: 0x00019CC0
@@ -3154,8 +3154,8 @@ void WorldToOverheadMapPositions(VECTOR *pGlobalPosition, VECTOR *pOverheadMapPo
 		// Start line: 2773
 		// Start offset: 0x00019D0C
 		// Variables:
-	// 		struct VECTOR translate; // stack offset -32
-	// 		struct SVECTOR direction; // stack offset -16
+	// 		VECTOR translate; // stack offset -32
+	// 		SVECTOR direction; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00019DE8
 	// End Line: 2787
@@ -3203,7 +3203,7 @@ void SetFullscreenMapMatrix(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WorldToFullscreenMap(struct VECTOR *in /*$a0*/, struct VECTOR *out /*$a1*/)
+// void /*$ra*/ WorldToFullscreenMap(VECTOR *in /*$a0*/, VECTOR *out /*$a1*/)
  // line 2794, offset 0x00019de8
 	/* begin block 1 */
 		// Start line: 8983
@@ -3232,13 +3232,13 @@ void WorldToFullscreenMap(VECTOR *in, VECTOR *out)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WorldToFullscreenMap2(struct VECTOR *in /*$a0*/, struct VECTOR *out /*$a1*/)
+// void /*$ra*/ WorldToFullscreenMap2(VECTOR *in /*$a0*/, VECTOR *out /*$a1*/)
  // line 2806, offset 0x00019e7c
 	/* begin block 1 */
 		// Start line: 2807
 		// Start offset: 0x00019E7C
 		// Variables:
-	// 		struct SVECTOR pos; // stack offset -24
+	// 		SVECTOR pos; // stack offset -24
 	// 		long flag; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00019F44

--- a/src_rebuild/GAME/C/PAD.C
+++ b/src_rebuild/GAME/C/PAD.C
@@ -64,7 +64,7 @@ DUPLICATION DuplicatePadData;		// [A]
 void InitControllers(void)
 {
 	int i, j;
-	struct PAD* pad;
+	PAD* pad;
 
 	DuplicatePadData.buffer = NULL;
 	DuplicatePadData.size = 0;
@@ -354,7 +354,7 @@ void SetDuplicatePadData(char *buffer, int size)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ MapPad(int pad /*$t2*/, struct PADRAW *pData /*$a3*/)
+// void /*$ra*/ MapPad(int pad /*$t2*/, PADRAW *pData /*$a3*/)
  // line 257, offset 0x0006b6f0
 	/* begin block 1 */
 		// Start line: 258

--- a/src_rebuild/GAME/C/PAD.H
+++ b/src_rebuild/GAME/C/PAD.H
@@ -52,7 +52,7 @@ extern void StopDualShockMotors(); // 0x0006BEEC
 
 extern void SetDuplicatePadData(char *buffer, int size); // 0x0006BEF4
 
-extern void MapPad(int pad, struct PADRAW *pData); // 0x0006B6F0
+extern void MapPad(int pad, PADRAW *pData); // 0x0006B6F0
 
 extern void ClearPad(int pad); // 0x0006BF24
 

--- a/src_rebuild/GAME/C/PATHFIND.C
+++ b/src_rebuild/GAME/C/PATHFIND.C
@@ -190,14 +190,14 @@ void DebugDisplayObstacleMap()
 
 // decompiled code
 // original method signature: 
-// struct tNode /*$ra*/ popNode()
+// tNode /*$ra*/ popNode()
  // line 314, offset 0x000e7000
 	/* begin block 1 */
 		// Start line: 315
 		// Start offset: 0x000E7000
 		// Variables:
 	// 		unsigned int lNumHeapEntries; // $s0
-	// 		struct tNode res; // stack offset -24
+	// 		tNode res; // stack offset -24
 	// 		unsigned short f; // $t8
 	// 		unsigned int child; // $a1
 	// 		unsigned int here; // $t5
@@ -295,7 +295,7 @@ tNode* popNode(tNode* __return_storage_ptr__)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WunCell(struct VECTOR *pbase /*$s0*/)
+// void /*$ra*/ WunCell(VECTOR *pbase /*$s0*/)
  // line 426, offset 0x000e7194
 	/* begin block 1 */
 		// Start line: 427
@@ -303,8 +303,8 @@ tNode* popNode(tNode* __return_storage_ptr__)
 		// Variables:
 	// 		int i; // $s2
 	// 		int j; // $s4
-	// 		struct VECTOR v[2]; // stack offset -88
-	// 		struct VECTOR pos; // stack offset -56
+	// 		VECTOR v[2]; // stack offset -88
+	// 		VECTOR pos; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 440
@@ -412,7 +412,7 @@ void WunCell(VECTOR* pbase)
 		// Start line: 455
 		// Start offset: 0x000E735C
 		// Variables:
-	// 		struct VECTOR bPos; // stack offset -16
+	// 		VECTOR bPos; // stack offset -16
 	// 		int count; // $t4
 	// 		int dir; // $t1
 	// 		int p; // $t2
@@ -558,7 +558,7 @@ void InvalidateMap(void)
 		// Start line: 497
 		// Start offset: 0x000E74B0
 		// Variables:
-	// 		struct VECTOR bPos; // stack offset -48
+	// 		VECTOR bPos; // stack offset -48
 	// 		int count; // $s4
 	// 		int dir; // $s0
 	// 		int p; // $s1
@@ -706,13 +706,13 @@ void BloodyHell(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ blocked(struct tNode *v1 /*$a3*/, struct tNode *v2 /*$a2*/)
+// int /*$ra*/ blocked(tNode *v1 /*$a3*/, tNode *v2 /*$a2*/)
  // line 567, offset 0x000e76c4
 	/* begin block 1 */
 		// Start line: 568
 		// Start offset: 0x000E76C4
 		// Variables:
-	// 		struct VECTOR pos; // stack offset -24
+	// 		VECTOR pos; // stack offset -24
 	// 		int res; // $a0
 
 		/* begin block 1.1 */
@@ -782,7 +782,7 @@ int blocked(tNode* v1, tNode* v2)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ setDistance(struct tNode *n /*$a0*/, unsigned short dist /*$a1*/)
+// void /*$ra*/ setDistance(tNode *n /*$a0*/, unsigned short dist /*$a1*/)
  // line 659, offset 0x000e90a4
 	/* begin block 1 */
 		// Start line: 1316
@@ -813,8 +813,8 @@ void setDistance(tNode* n, ushort dist)
 		// Start offset: 0x000E7814
 		// Variables:
 	// 		int dir; // $s2
-	// 		struct tNode itHere; // stack offset -48
-	// 		struct tNode *nbr; // $s4
+	// 		tNode itHere; // stack offset -48
+	// 		tNode *nbr; // $s4
 
 		/* begin block 1.1 */
 			// Start line: 724
@@ -888,7 +888,7 @@ void setDistance(tNode* n, ushort dist)
 				// Start line: 773
 				// Start offset: 0x000E7AAC
 				// Variables:
-			// 		struct tNode *pnode; // $s0
+			// 		tNode *pnode; // $s0
 
 				/* begin block 1.2.2.1 */
 					// Start line: 773
@@ -1140,13 +1140,13 @@ void InitPathFinding(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ getInterpolatedDistance(struct VECTOR *pos /*$s2*/)
+// int /*$ra*/ getInterpolatedDistance(VECTOR *pos /*$s2*/)
  // line 821, offset 0x000e7ca8
 	/* begin block 1 */
 		// Start line: 822
 		// Start offset: 0x000E7CA8
 		// Variables:
-	// 		struct tNode n; // stack offset -72
+	// 		tNode n; // stack offset -72
 	// 		int fx; // $s4
 	// 		int fz; // $s5
 	// 		int a; // $s3
@@ -1159,8 +1159,8 @@ void InitPathFinding(void)
 			// Start line: 822
 			// Start offset: 0x000E7CA8
 			// Variables:
-		// 		struct VECTOR *where; // $s2
-		// 		struct tNode *node; // $s0
+		// 		VECTOR *where; // $s2
+		// 		tNode *node; // $s0
 
 			/* begin block 1.1.1 */
 				// Start line: 822
@@ -1172,13 +1172,13 @@ void InitPathFinding(void)
 					// Start line: 822
 					// Start offset: 0x000E7CA8
 					// Variables:
-				// 		struct tNode *pos; // $s0
+				// 		tNode *pos; // $s0
 
 					/* begin block 1.1.1.1.1 */
 						// Start line: 822
 						// Start offset: 0x000E7CA8
 						// Variables:
-					// 		struct VECTOR sp; // stack offset -56
+					// 		VECTOR sp; // stack offset -56
 
 						/* begin block 1.1.1.1.1.1 */
 							// Start line: 822
@@ -1242,7 +1242,7 @@ void InitPathFinding(void)
 				// Start line: 822
 				// Start offset: 0x000E7DA0
 				// Variables:
-			// 		struct VECTOR sp; // stack offset -56
+			// 		VECTOR sp; // stack offset -56
 
 				/* begin block 1.3.1.1 */
 					// Start line: 822
@@ -1300,7 +1300,7 @@ void InitPathFinding(void)
 				// Start line: 848
 				// Start offset: 0x000E7F28
 				// Variables:
-			// 		struct VECTOR sp; // stack offset -56
+			// 		VECTOR sp; // stack offset -56
 
 				/* begin block 1.5.1.1 */
 					// Start line: 848
@@ -1358,7 +1358,7 @@ void InitPathFinding(void)
 				// Start line: 864
 				// Start offset: 0x000E807C
 				// Variables:
-			// 		struct VECTOR sp; // stack offset -56
+			// 		VECTOR sp; // stack offset -56
 
 				/* begin block 1.7.1.1 */
 					// Start line: 864
@@ -1585,7 +1585,7 @@ int getInterpolatedDistance(VECTOR* pos)
 		// Start line: 893
 		// Start offset: 0x000E822C
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $t5
+	// 		CAR_DATA *cp; // $t5
 
 		/* begin block 1.1 */
 			// Start line: 898
@@ -1653,7 +1653,7 @@ void addCivs(void)
 	int rx, rz;
 	int x, z, vx, vz;
 	int vx2, vz2;
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 
 	cp = car_data;
 	do {
@@ -1709,13 +1709,13 @@ void addCivs(void)
 			// Start line: 946
 			// Start offset: 0x000E83FC
 			// Variables:
-		// 		struct tNode startNode; // stack offset -72
+		// 		tNode startNode; // stack offset -72
 
 			/* begin block 1.2.1 */
 				// Start line: 952
 				// Start offset: 0x000E843C
 				// Variables:
-			// 		struct _CAR_DATA *cp; // $a0
+			// 		CAR_DATA *cp; // $a0
 			/* end block 1.2.1 */
 			// End offset: 0x000E843C
 			// End Line: 952
@@ -1777,7 +1777,7 @@ void addCivs(void)
 							// Start line: 934
 							// Start offset: 0x000E8564
 							// Variables:
-						// 		struct VECTOR sp; // stack offset -56
+						// 		VECTOR sp; // stack offset -56
 
 							/* begin block 1.2.3.1.1.1.1 */
 								// Start line: 934
@@ -1821,7 +1821,7 @@ void addCivs(void)
 				// Start line: 934
 				// Start offset: 0x000E862C
 				// Variables:
-			// 		struct tNode n; // stack offset -56
+			// 		tNode n; // stack offset -56
 			// 		int fx; // $v1
 			// 		int fz; // $v0
 
@@ -2155,7 +2155,7 @@ void UpdateCopMap(void)
 		// restart from new search target position
 		if (player[0].playerType == 1 && (CopsCanSeePlayer != 0 || numActiveCops == 0))
 		{
-			_CAR_DATA* cp;
+			CAR_DATA* cp;
 			cp = &car_data[player[0].playerCarId];
 
 			searchTarget.vx = cp->hd.where.t[0] + FIXEDH(cp->st.n.linearVelocity[0]) * 8;
@@ -2410,7 +2410,7 @@ void UpdateCopMap(void)
 	// 		int d1; // $s2
 	// 		int d2; // $s1
 	// 		int d3; // $s0
-	// 		struct VECTOR pos; // stack offset -48
+	// 		VECTOR pos; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 1051

--- a/src_rebuild/GAME/C/PAUSE.C
+++ b/src_rebuild/GAME/C/PAUSE.C
@@ -28,7 +28,7 @@ static int gScorePosition = 0;
 static int allownameentry = 0;
 
 static MENU_ITEM* ActiveItem[3];
-static struct MENU_HEADER* ActiveMenu;
+static MENU_HEADER* ActiveMenu;
 static int ActiveMenuItem;
 static int VisibleMenu;
 static MENU_HEADER* VisibleMenus[3];
@@ -446,13 +446,13 @@ int playerwithcontrol[3] = { 0 };
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ ShowPauseMenu(enum PAUSEMODE mode /*$s0*/)
+// int /*$ra*/ ShowPauseMenu(PAUSEMODE mode /*$s0*/)
  // line 1004, offset 0x0006bf50
 	/* begin block 1 */
 		// Start line: 1005
 		// Start offset: 0x0006BF50
 		// Variables:
-	// 		enum PAUSEMODE passed_mode; // $s2
+	// 		PAUSEMODE passed_mode; // $s2
 
 		/* begin block 1.1 */
 			// Start line: 1062
@@ -465,7 +465,7 @@ int playerwithcontrol[3] = { 0 };
 			// Start line: 1092
 			// Start offset: 0x0006C178
 			// Variables:
-		// 		struct RECT rect; // stack offset -32
+		// 		RECT rect; // stack offset -32
 		/* end block 1.2 */
 		// End offset: 0x0006C1FC
 		// End Line: 1101
@@ -742,13 +742,13 @@ void EnterName(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ MaxMenuStringLength(struct MENU_HEADER *pMenu /*$v0*/)
+// int /*$ra*/ MaxMenuStringLength(MENU_HEADER *pMenu /*$v0*/)
  // line 1185, offset 0x0006da18
 	/* begin block 1 */
 		// Start line: 1186
 		// Start offset: 0x0006DA18
 		// Variables:
-	// 		struct MENU_ITEM *pItems; // $s1
+	// 		MENU_ITEM *pItems; // $s1
 	// 		int max; // $s2
 	// 		int temp; // $s0
 	/* end block 1 */
@@ -790,13 +790,13 @@ int MaxMenuStringLength(MENU_HEADER *pMenu)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitaliseMenu(enum PAUSEMODE mode /*$a2*/)
+// void /*$ra*/ InitaliseMenu(PAUSEMODE mode /*$a2*/)
  // line 1216, offset 0x0006c2ac
 	/* begin block 1 */
 		// Start line: 1217
 		// Start offset: 0x0006C2AC
 		// Variables:
-	// 		struct MENU_ITEM *pItem; // $a0
+	// 		MENU_ITEM *pItem; // $a0
 	// 		int i; // $a1
 	/* end block 1 */
 	// End offset: 0x0006C6B8
@@ -1004,13 +1004,13 @@ LAB_0006c5d0:
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupMenu(struct MENU_HEADER *menu /*$a0*/, int back /*$a1*/)
+// void /*$ra*/ SetupMenu(MENU_HEADER *menu /*$a0*/, int back /*$a1*/)
  // line 1401, offset 0x0006c6b8
 	/* begin block 1 */
 		// Start line: 1402
 		// Start offset: 0x0006C6B8
 		// Variables:
-	// 		struct MENU_ITEM *pItem; // $a2
+	// 		MENU_ITEM *pItem; // $a2
 	// 		int count; // $a3
 	/* end block 1 */
 	// End offset: 0x0006C7F4
@@ -1089,9 +1089,9 @@ void SetupMenu(MENU_HEADER *menu, int back)
 		// Start line: 1445
 		// Start offset: 0x0006C7F4
 		// Variables:
-	// 		struct MENU_HEADER *pActive; // $s5
-	// 		struct MENU_ITEM *pItem; // $s1
-	// 		struct POLY_FT3 *null; // $a0
+	// 		MENU_HEADER *pActive; // $s5
+	// 		MENU_ITEM *pItem; // $s1
+	// 		POLY_FT3 *null; // $a0
 	// 		int i; // stack offset -48
 	// 		int ypos; // $s3
 	// 		int xpos; // $fp
@@ -1676,7 +1676,7 @@ void MusicVolume(int direction)
 		// Start line: 1789
 		// Start offset: 0x0006D044
 		// Variables:
-	// 		struct SCORE_ENTRY *table; // stack offset -40
+	// 		SCORE_ENTRY *table; // stack offset -40
 	// 		char *username; // $s3
 	// 		unsigned short npad; // $a1
 	// 		int so; // $s0
@@ -1896,7 +1896,7 @@ void EnterScoreName(void)
 		// Start line: 2021
 		// Start offset: 0x0006D694
 		// Variables:
-	// 		struct POLY_FT3 *null; // $a0
+	// 		POLY_FT3 *null; // $a0
 	// 		char text[4]; // stack offset -48
 	// 		unsigned char r; // $s3
 	// 		unsigned char g; // $s5
@@ -1996,7 +1996,7 @@ void DrawHighScoreMenu(int selection)
 //* Stack frame base $sp, size 80
 //* Saved registers at offset - 4: s0 s1 s2 s3 s4 s5 s6 s7 fp ra
 //* /
-//void /*$ra*/ CreateScoreNames(struct SCORE_ENTRY* table /*$s0*/, struct PLAYER_SCORE* score /*stack 4*/, int position /*stack 8*/)
+//void /*$ra*/ CreateScoreNames(SCORE_ENTRY* table /*$s0*/, PLAYER_SCORE* score /*stack 4*/, int position /*stack 8*/)
 //{ // line 1, offset 0x6d324
 //	char* text; // $s1
 //	int min; // $t1

--- a/src_rebuild/GAME/C/PAUSE.H
+++ b/src_rebuild/GAME/C/PAUSE.H
@@ -6,7 +6,7 @@ extern int gDrawPauseMenus;
 extern int pauseflag;
 extern int gMissionCompletionState;
 
-extern int ShowPauseMenu(enum PAUSEMODE mode); // 0x0006BF50
+extern int ShowPauseMenu(PAUSEMODE mode); // 0x0006BF50
 
 extern void DrawPauseMenus(); // 0x0006DCD4
 
@@ -16,11 +16,11 @@ extern void SaveGame(int direction); // 0x0006D9D4
 
 extern void EnterName(); // 0x0006D9F8
 
-extern int MaxMenuStringLength(struct MENU_HEADER *pMenu); // 0x0006DA18
+extern int MaxMenuStringLength(MENU_HEADER *pMenu); // 0x0006DA18
 
-extern void InitaliseMenu(enum PAUSEMODE mode); // 0x0006C2AC
+extern void InitaliseMenu(PAUSEMODE mode); // 0x0006C2AC
 
-extern void SetupMenu(struct MENU_HEADER *menu, int back); // 0x0006C6B8
+extern void SetupMenu(MENU_HEADER *menu, int back); // 0x0006C6B8
 
 extern void DrawVisibleMenus(); // 0x0006C7F4
 
@@ -34,7 +34,7 @@ extern void MusicVolume(int direction); // 0x0006DC04
 
 extern void EnterScoreName(); // 0x0006D044
 
-extern void CreateScoreNames(struct SCORE_ENTRY *table, struct PLAYER_SCORE *score, int position); // 0x0006D324
+extern void CreateScoreNames(SCORE_ENTRY *table, PLAYER_SCORE *score, int position); // 0x0006D324
 
 extern void DrawHighScoreMenu(int selection); // 0x0006D694
 

--- a/src_rebuild/GAME/C/PEDEST.C
+++ b/src_rebuild/GAME/C/PEDEST.C
@@ -110,7 +110,7 @@ static int oldCamView;
 		// Start line: 1139
 		// Start offset: 0x0006DD34
 		// Variables:
-	// 		struct _CAR_DATA *cp; // $t4
+	// 		CAR_DATA *cp; // $t4
 
 		/* begin block 1.1 */
 			// Start line: 1152
@@ -142,7 +142,7 @@ int powerCounter = 0;
 // Havana easter egg.
 void IHaveThePower(void)
 {
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	long force[4] = { 0x9000, 0, 0, 0 };
 	long point[4] = { 0, 0, 90, 0 };
 
@@ -203,24 +203,24 @@ void IHaveThePower(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ProcessTannerPad(struct PEDESTRIAN *pPed /*$s1*/, unsigned long pad /*$a1*/, char PadSteer /*$a2*/, char use_analogue /*$a3*/)
+// void /*$ra*/ ProcessTannerPad(PEDESTRIAN *pPed /*$s1*/, unsigned long pad /*$a1*/, char PadSteer /*$a2*/, char use_analogue /*$a3*/)
  // line 1191, offset 0x0006df54
 	/* begin block 1 */
 		// Start line: 1192
 		// Start offset: 0x0006DF54
 		// Variables:
-	// 		struct VECTOR vec; // stack offset -88
+	// 		VECTOR vec; // stack offset -88
 	// 		int mapheight; // $s2
-	// 		struct VECTOR normal; // stack offset -72
-	// 		struct VECTOR out; // stack offset -56
-	// 		struct _sdPlane *SurfacePtr; // stack offset -24
+	// 		VECTOR normal; // stack offset -72
+	// 		VECTOR out; // stack offset -56
+	// 		sdPlane *SurfacePtr; // stack offset -24
 
 		/* begin block 1.1 */
 			// Start line: 1224
 			// Start offset: 0x0006DFC8
 			// Variables:
-		// 		struct VECTOR tVec; // stack offset -40
-		// 		struct _sdPlane *plane; // $v0
+		// 		VECTOR tVec; // stack offset -40
+		// 		sdPlane *plane; // $v0
 		// 		int mH; // $v1
 		// 		int sI; // $a0
 		/* end block 1.1 */
@@ -255,14 +255,14 @@ void IHaveThePower(void)
 // [D] [T]
 void ProcessTannerPad(PEDESTRIAN* pPed, ulong pad, char PadSteer, char use_analogue)
 {
-	_sdPlane* SurfacePtr;
+	sdPlane* SurfacePtr;
 	int direction;
 	VECTOR vec;
 	VECTOR normal;
 	VECTOR out;
 	VECTOR tVec;
-	_sdPlane* plane;
-	_PLAYER* lcp;
+	sdPlane* plane;
+	PLAYER* lcp;
 
 	int padId;
 
@@ -511,13 +511,13 @@ void InitTanner(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetTannerPosition(struct VECTOR *pVec /*$a0*/)
+// void /*$ra*/ SetTannerPosition(VECTOR *pVec /*$a0*/)
  // line 1440, offset 0x00072478
 	/* begin block 1 */
 		// Start line: 1441
 		// Start offset: 0x00072478
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $a1
+	// 		PEDESTRIAN *pPed; // $a1
 	/* end block 1 */
 	// End offset: 0x00072500
 	// End Line: 1459
@@ -571,7 +571,7 @@ void SetTannerPosition(VECTOR* pVec)
 		// Start offset: 0x0006E5C4
 		// Variables:
 	// 		int loop; // $a1
-	// 		struct SEATED_PEDESTRIANS *seatedptr; // $s2
+	// 		SEATED_PEDESTRIANS *seatedptr; // $s2
 	/* end block 1 */
 	// End offset: 0x0006E6C4
 	// End Line: 1513
@@ -701,8 +701,8 @@ void DestroyPedestrians(void)
 		// Start line: 1543
 		// Start offset: 0x00072FD0
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $v1
-	// 		struct PEDESTRIAN *pHPed; // $s0
+	// 		PEDESTRIAN *pPed; // $v1
+	// 		PEDESTRIAN *pHPed; // $s0
 	/* end block 1 */
 	// End offset: 0x00073038
 	// End Line: 1559
@@ -749,7 +749,7 @@ void DestroyCivPedestrians(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DestroyPedestrian(struct PEDESTRIAN *pPed /*$a1*/)
+// void /*$ra*/ DestroyPedestrian(PEDESTRIAN *pPed /*$a1*/)
  // line 1567, offset 0x00071fb4
 	/* begin block 1 */
 		// Start line: 1568
@@ -759,7 +759,7 @@ void DestroyCivPedestrians(void)
 			// Start line: 1605
 			// Start offset: 0x00072064
 			// Variables:
-		// 		struct SEATED_PEDESTRIANS *seatedptr; // $a0
+		// 		SEATED_PEDESTRIANS *seatedptr; // $a0
 		/* end block 1.1 */
 		// End offset: 0x00072090
 		// End Line: 1608
@@ -828,15 +828,15 @@ void DestroyPedestrian(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ ActivatePlayerPedestrian(struct _CAR_DATA *pCar /*$s6*/, char *padId /*stack 4*/, int direction /*$a1*/, long (*position)[4] /*$a3*/, int playerType /*stack 16*/)
+// int /*$ra*/ ActivatePlayerPedestrian(CAR_DATA *pCar /*$s6*/, char *padId /*stack 4*/, int direction /*$a1*/, long (*position)[4] /*$a3*/, int playerType /*stack 16*/)
  // line 1623, offset 0x0006e6c4
 	/* begin block 1 */
 		// Start line: 1624
 		// Start offset: 0x0006E6C4
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $s1
-	// 		struct PEDESTRIAN *pSPed; // $a0
-	// 		struct VECTOR v; // stack offset -72
+	// 		PEDESTRIAN *pPed; // $s1
+	// 		PEDESTRIAN *pSPed; // $a0
+	// 		VECTOR v; // stack offset -72
 	// 		int nx; // $s4
 	// 		int nz; // $s2
 	// 		long w; // $s0
@@ -889,7 +889,7 @@ void DestroyPedestrian(PEDESTRIAN* pPed)
 /* WARNING: Type propagation algorithm not settling */
 
 // [D] [T]
-int ActivatePlayerPedestrian(_CAR_DATA* pCar, char* padId, int direction, long(*position)[4], PED_MODEL_TYPES playerType)
+int ActivatePlayerPedestrian(CAR_DATA* pCar, char* padId, int direction, long(*position)[4], PED_MODEL_TYPES playerType)
 {
 	int wbody;
 	int side;
@@ -900,7 +900,7 @@ int ActivatePlayerPedestrian(_CAR_DATA* pCar, char* padId, int direction, long(*
 	VECTOR v;
 	long y;
 	long d;
-	_PLAYER* lp;
+	PLAYER* lp;
 	int x, z;
 
 	if (numTannerPeds > 7)
@@ -1099,7 +1099,7 @@ int ActivatePlayerPedestrian(_CAR_DATA* pCar, char* padId, int direction, long(*
 
 // decompiled code
 // original method signature: 
-// struct PEDESTRIAN * /*$ra*/ CreatePedestrian()
+// PEDESTRIAN * /*$ra*/ CreatePedestrian()
  // line 1842, offset 0x000720ac
 	/* begin block 1 */
 		// Start line: 1844
@@ -1167,8 +1167,8 @@ PEDESTRIAN* CreatePedestrian(void)
 		// Start line: 1879
 		// Start offset: 0x0006EC88
 		// Variables:
-	// 		struct _CAR_DATA *pCar; // $a0
-	// 		struct _CAR_DATA (*pCopCars[16]); // stack offset -152
+	// 		CAR_DATA *pCar; // $a0
+	// 		CAR_DATA (*pCopCars[16]); // stack offset -152
 	// 		int numCops; // $fp
 
 		/* begin block 1.1 */
@@ -1181,7 +1181,7 @@ PEDESTRIAN* CreatePedestrian(void)
 		// 		int i; // $s7
 		// 		int s1; // $s1
 		// 		int s2; // $a3
-		// 		struct VECTOR vert; // stack offset -88
+		// 		VECTOR vert; // stack offset -88
 		// 		long disp[4]; // stack offset -72
 		// 		long dir[4]; // stack offset -56
 		// 		int alpha; // $s1
@@ -1221,11 +1221,11 @@ void PlaceRoadBlockCops(void)
 	int lbody;
 	int cs, sn;
 	uint dir;
-	_CAR_DATA* cp;
-	_CAR_DATA* pCar;
+	CAR_DATA* cp;
+	CAR_DATA* pCar;
 	int i;
 	int numCops;
-	_CAR_DATA* pCopCars[16];
+	CAR_DATA* pCopCars[16];
 	long disp[4];
 
 	if (numCopPeds >= 8)
@@ -1294,7 +1294,7 @@ void PlaceRoadBlockCops(void)
 		// Start line: 1976
 		// Start offset: 0x0006F00C
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $s0
+	// 		PEDESTRIAN *pPed; // $s0
 	/* end block 1 */
 	// End offset: 0x0006F16C
 	// End Line: 2045
@@ -1369,9 +1369,9 @@ int CreatePedAtLocation(long(*pPos)[4], int pedType)
 		// Start line: 2054
 		// Start offset: 0x00072290
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $s0
+	// 		PEDESTRIAN *pPed; // $s0
 	// 		int pedType; // $s2
-	// 		struct MATRIX mStore; // stack offset -56
+	// 		MATRIX mStore; // stack offset -56
 
 		/* begin block 1.1 */
 			// Start line: 2071
@@ -1478,7 +1478,7 @@ void DrawAllPedestrians(void)
 		// Start line: 2147
 		// Start offset: 0x00072430
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $a0
+	// 		PEDESTRIAN *pPed; // $a0
 	/* end block 1 */
 	// End offset: 0x00072478
 	// End Line: 2158
@@ -1526,9 +1526,9 @@ int TannerActionHappening(void)
 		// Start line: 2170
 		// Start offset: 0x0006F16C
 		// Variables:
-	// 		struct PEDESTRIAN *pPed; // $s0
-	// 		struct PEDESTRIAN *pPedNext; // $s2
-	// 		struct _CAR_DATA *pCar; // $v0
+	// 		PEDESTRIAN *pPed; // $s0
+	// 		PEDESTRIAN *pPedNext; // $s2
+	// 		CAR_DATA *pCar; // $v0
 
 		/* begin block 1.1 */
 			// Start line: 2225
@@ -1568,7 +1568,7 @@ int bAvoidBomb = -1;
 // [D] [T]
 void ControlPedestrians(void)
 {
-	_CAR_DATA* pCar;
+	CAR_DATA* pCar;
 	PEDESTRIAN* pPed;
 	PEDESTRIAN* pPedNext;
 
@@ -1635,7 +1635,7 @@ void ControlPedestrians(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupDoNowt(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupDoNowt(PEDESTRIAN *pPed /*$s0*/)
  // line 2256, offset 0x00073038
 	/* begin block 1 */
 		// Start line: 20024
@@ -1663,7 +1663,7 @@ void SetupDoNowt(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupWalker(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupWalker(PEDESTRIAN *pPed /*$s0*/)
  // line 2275, offset 0x0007307c
 	/* begin block 1 */
 		// Start line: 20767
@@ -1684,7 +1684,7 @@ void SetupWalker(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupRunner(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupRunner(PEDESTRIAN *pPed /*$s0*/)
  // line 2291, offset 0x000730b8
 	/* begin block 1 */
 		// Start line: 20802
@@ -1706,7 +1706,7 @@ void SetupRunner(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupBack(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupBack(PEDESTRIAN *pPed /*$s0*/)
  // line 2302, offset 0x000730fc
 	/* begin block 1 */
 		// Start line: 20826
@@ -1728,14 +1728,14 @@ void SetupBack(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivGetIn(struct PEDESTRIAN *pPed /*$s2*/)
+// void /*$ra*/ CivGetIn(PEDESTRIAN *pPed /*$s2*/)
  // line 2325, offset 0x00072dfc
 	/* begin block 1 */
 		// Start line: 2326
 		// Start offset: 0x00072DFC
 		// Variables:
-	// 		struct DRIVER2_STRAIGHT *str; // $s1
-	// 		struct DRIVER2_CURVE *crv; // $s0
+	// 		DRIVER2_STRAIGHT *str; // $s1
+	// 		DRIVER2_CURVE *crv; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 2326
@@ -1762,7 +1762,7 @@ void SetupBack(PEDESTRIAN* pPed)
 	/* end block 4 */
 	// End Line: 18694
 
-_CAR_DATA* pCivCarToGetIn = NULL;
+CAR_DATA* pCivCarToGetIn = NULL;
 
 // [D] [T]
 void CivGetIn(PEDESTRIAN* pPed)		// [A] UNUSED
@@ -1790,13 +1790,13 @@ void CivGetIn(PEDESTRIAN* pPed)		// [A] UNUSED
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CopStand(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ CopStand(PEDESTRIAN *pPed /*$s0*/)
  // line 2353, offset 0x00072da0
 	/* begin block 1 */
 		// Start line: 2354
 		// Start offset: 0x00072DA0
 		// Variables:
-	// 		struct VECTOR v; // stack offset -24
+	// 		VECTOR v; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00072DFC
 	// End Line: 2377
@@ -1826,7 +1826,7 @@ void CopStand(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedDoNothing(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedDoNothing(PEDESTRIAN *pPed /*$s0*/)
  // line 2385, offset 0x0006f2dc
 	/* begin block 1 */
 		// Start line: 5187
@@ -1958,7 +1958,7 @@ void PedDoNothing(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedUserRunner(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedUserRunner(PEDESTRIAN *pPed /*$s0*/)
  // line 2523, offset 0x0006f5ac
 	/* begin block 1 */
 		// Start line: 2524
@@ -2054,7 +2054,7 @@ void PedUserRunner(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedUserWalker(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedUserWalker(PEDESTRIAN *pPed /*$s0*/)
  // line 2639, offset 0x00072944
 	/* begin block 1 */
 		// Start line: 2640
@@ -2115,7 +2115,7 @@ void PedUserWalker(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedCarryOutAnimation(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedCarryOutAnimation(PEDESTRIAN *pPed /*$s0*/)
  // line 2702, offset 0x00072a10
 	/* begin block 1 */
 		// Start line: 17238
@@ -2196,7 +2196,7 @@ void PedCarryOutAnimation(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedGetOutCar(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedGetOutCar(PEDESTRIAN *pPed /*$s0*/)
  // line 2796, offset 0x00072bec
 	/* begin block 1 */
 		// Start line: 17673
@@ -2208,7 +2208,7 @@ void PedCarryOutAnimation(PEDESTRIAN* pPed)
 	/* end block 2 */
 	// End Line: 5593
 
-_CAR_DATA* carToGetIn;
+CAR_DATA* carToGetIn;
 int bReverseYRotation = 0;
 
 // [D] [T]
@@ -2242,7 +2242,7 @@ void PedGetOutCar(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupGetOutCar(struct PEDESTRIAN *pPed /*$s5*/, struct _CAR_DATA *pCar /*$s3*/, int side /*$s7*/)
+// void /*$ra*/ SetupGetOutCar(PEDESTRIAN *pPed /*$s5*/, CAR_DATA *pCar /*$s3*/, int side /*$s7*/)
  // line 2827, offset 0x0006f80c
 	/* begin block 1 */
 		// Start line: 2828
@@ -2251,7 +2251,7 @@ void PedGetOutCar(PEDESTRIAN* pPed)
 	// 		int alpha; // $s2
 	// 		long disp[4]; // stack offset -80
 	// 		long dir[4]; // stack offset -64
-	// 		struct SVECTOR vert; // stack offset -48
+	// 		SVECTOR vert; // stack offset -48
 	// 		int x; // $s4
 	// 		int z; // $s0
 	// 		int a; // $s6
@@ -2274,7 +2274,7 @@ void PedGetOutCar(PEDESTRIAN* pPed)
 int lastCarCameraView = 0;
 
 // [D] [T]
-void SetupGetOutCar(PEDESTRIAN* pPed, _CAR_DATA* pCar, int side)
+void SetupGetOutCar(PEDESTRIAN* pPed, CAR_DATA* pCar, int side)
 {
 	bool entrySide;
 	int sn, cs;
@@ -2323,7 +2323,7 @@ void SetupGetOutCar(PEDESTRIAN* pPed, _CAR_DATA* pCar, int side)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupGetInCar(struct PEDESTRIAN *pPed /*$s2*/)
+// void /*$ra*/ SetupGetInCar(PEDESTRIAN *pPed /*$s2*/)
  // line 2898, offset 0x0006fa3c
 	/* begin block 1 */
 		// Start line: 2899
@@ -2332,7 +2332,7 @@ void SetupGetOutCar(PEDESTRIAN* pPed, _CAR_DATA* pCar, int side)
 	// 		int alpha; // $s1
 	// 		long disp[4]; // stack offset -72
 	// 		long dir[4]; // stack offset -56
-	// 		struct SVECTOR vert; // stack offset -40
+	// 		SVECTOR vert; // stack offset -40
 
 		/* begin block 1.1 */
 			// Start line: 2934
@@ -2441,7 +2441,7 @@ void SetupGetInCar(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedGetInCar(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedGetInCar(PEDESTRIAN *pPed /*$s0*/)
  // line 2994, offset 0x00072b5c
 	/* begin block 1 */
 		// Start line: 2995
@@ -2449,7 +2449,7 @@ void SetupGetInCar(PEDESTRIAN* pPed)
 		// Variables:
 	// 		long disp[4]; // stack offset -48
 	// 		long dir[4]; // stack offset -32
-	// 		struct SVECTOR vert; // stack offset -16
+	// 		SVECTOR vert; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00072BEC
 	// End Line: 3018
@@ -2491,7 +2491,7 @@ void PedGetInCar(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupPressButton(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupPressButton(PEDESTRIAN *pPed /*$s0*/)
  // line 3026, offset 0x00072904
 	/* begin block 1 */
 		// Start line: 17494
@@ -2518,7 +2518,7 @@ void SetupPressButton(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedPressButton(struct PEDESTRIAN *pPed /*$v1*/)
+// void /*$ra*/ PedPressButton(PEDESTRIAN *pPed /*$v1*/)
  // line 3040, offset 0x00072c90
 	/* begin block 1 */
 		// Start line: 18175
@@ -2546,7 +2546,7 @@ void PedPressButton(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupTannerSitDown(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupTannerSitDown(PEDESTRIAN *pPed /*$s0*/)
  // line 3060, offset 0x000728c8
 	/* begin block 1 */
 		// Start line: 6120
@@ -2566,7 +2566,7 @@ void SetupTannerSitDown(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TannerCameraHandler(struct PEDESTRIAN *pPed /*$a0*/)
+// void /*$ra*/ TannerCameraHandler(PEDESTRIAN *pPed /*$a0*/)
  // line 3074, offset 0x0006fd08
 	/* begin block 1 */
 		// Start line: 3076
@@ -2612,7 +2612,7 @@ void TannerCameraHandler(PEDESTRIAN* pPed)
 	int value;
 	short extra;
 	int padSteer;
-	_PLAYER* lcp;
+	PLAYER* lcp;
 
 	int padid;
 
@@ -2690,13 +2690,13 @@ void TannerCameraHandler(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TannerSitDown(struct PEDESTRIAN *pPed /*$a2*/)
+// void /*$ra*/ TannerSitDown(PEDESTRIAN *pPed /*$a2*/)
  // line 3157, offset 0x0006ff48
 	/* begin block 1 */
 		// Start line: 3158
 		// Start offset: 0x0006FF48
 		// Variables:
-	// 		struct VECTOR angle; // stack offset -24
+	// 		VECTOR angle; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x000700D0
 	// End Line: 3219
@@ -2769,7 +2769,7 @@ void TannerSitDown(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AnimatePed(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ AnimatePed(PEDESTRIAN *pPed /*$s0*/)
  // line 3227, offset 0x000700d0
 	/* begin block 1 */
 		// Start line: 3228
@@ -2786,7 +2786,7 @@ void TannerSitDown(PEDESTRIAN* pPed)
 				// Start line: 3241
 				// Start offset: 0x000700F0
 				// Variables:
-			// 		struct VECTOR vec; // stack offset -32
+			// 		VECTOR vec; // stack offset -32
 			/* end block 1.1.1 */
 			// End offset: 0x0007015C
 			// End Line: 3266
@@ -2914,16 +2914,16 @@ void AnimatePed(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DeActivatePlayerPedestrian(struct PEDESTRIAN *pPed /*$s3*/)
+// void /*$ra*/ DeActivatePlayerPedestrian(PEDESTRIAN *pPed /*$s3*/)
  // line 3357, offset 0x0007216c
 	/* begin block 1 */
 		// Start line: 3358
 		// Start offset: 0x0007216C
 		// Variables:
 	// 		int distToCarSq; // stack offset -32
-	// 		struct _CAR_DATA *closestCar; // $s1
-	// 		struct _PLAYER *pPlayer; // $v0
-	// 		struct VECTOR point; // stack offset -48
+	// 		CAR_DATA *closestCar; // $s1
+	// 		PLAYER *pPlayer; // $v0
+	// 		VECTOR point; // stack offset -48
 	// 		int getIn; // $s2
 
 		/* begin block 1.1 */
@@ -2944,7 +2944,7 @@ void AnimatePed(PEDESTRIAN* pPed)
 // [D] [T]
 void DeActivatePlayerPedestrian(PEDESTRIAN* pPed)
 {
-	_CAR_DATA* cp;
+	CAR_DATA* cp;
 	int playerId;
 	int getIn;
 	int distToCarSq;
@@ -2981,7 +2981,7 @@ void DeActivatePlayerPedestrian(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivPedDoNothing(struct PEDESTRIAN *pPed /*$a0*/)
+// void /*$ra*/ CivPedDoNothing(PEDESTRIAN *pPed /*$a0*/)
  // line 3402, offset 0x00072ce0
 	/* begin block 1 */
 		// Start line: 18899
@@ -3002,13 +3002,13 @@ void CivPedDoNothing(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupCivPedRouteData(struct VECTOR *pPos /*$s1*/)
+// void /*$ra*/ SetupCivPedRouteData(VECTOR *pPos /*$s1*/)
  // line 3411, offset 0x0007313c
 	/* begin block 1 */
 		// Start line: 3412
 		// Start offset: 0x0007313C
 		// Variables:
-	// 		struct VECTOR baseLoc; // stack offset -32
+	// 		VECTOR baseLoc; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x000731F8
 	// End Line: 3435
@@ -3054,13 +3054,13 @@ void SetupCivPedRouteData(VECTOR* pPos)
 		// Start offset: 0x0007047C
 		// Variables:
 	// 		int bFound; // $s1
-	// 		struct VECTOR randomLoc; // stack offset -88
-	// 		struct VECTOR baseLoc; // stack offset -72
+	// 		VECTOR randomLoc; // stack offset -88
+	// 		VECTOR baseLoc; // stack offset -72
 	// 		int i; // $s2
 	// 		int pingInDist; // $a2
-	// 		struct VECTOR position; // stack offset -56
-	// 		struct VECTOR target; // stack offset -40
-	// 		struct PEDESTRIAN *pedestrian; // $s1
+	// 		VECTOR position; // stack offset -56
+	// 		VECTOR target; // stack offset -40
+	// 		PEDESTRIAN *pedestrian; // $s1
 
 		/* begin block 1.1 */
 			// Start line: 3484
@@ -3070,7 +3070,7 @@ void SetupCivPedRouteData(VECTOR* pPos)
 				// Start line: 3502
 				// Start offset: 0x000705F8
 				// Variables:
-			// 		struct PEDESTRIAN *pPed; // $a2
+			// 		PEDESTRIAN *pPed; // $a2
 
 				/* begin block 1.1.1.1 */
 					// Start line: 3520
@@ -3252,7 +3252,7 @@ void PingInPedestrians(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TannerCollision(struct PEDESTRIAN *pPed /*$s1*/)
+// void /*$ra*/ TannerCollision(PEDESTRIAN *pPed /*$s1*/)
  // line 3640, offset 0x00072ee4
 	/* begin block 1 */
 		// Start line: 3641
@@ -3281,14 +3281,14 @@ void PingInPedestrians(void)
 // [D] [T]
 void TannerCollision(PEDESTRIAN* pPed)
 {
-	_CAR_DATA* pcdTanner;
+	CAR_DATA* pcdTanner;
 
 	if (pPed->type == PED_ACTION_SIT)
 		return;
 
 	pcdTanner = &car_data[TANNER_COLLIDER_CARID];
 
-	ClearMem((char*)pcdTanner, sizeof(_CAR_DATA));
+	ClearMem((char*)pcdTanner, sizeof(CAR_DATA));
 
 	pcdTanner->id = 21;
 	pcdTanner->controlType = 6;
@@ -3319,7 +3319,7 @@ void TannerCollision(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ FindPointOfCollision(struct _CAR_DATA *pCar /*$s3*/, struct VECTOR *pPos /*$a1*/)
+// int /*$ra*/ FindPointOfCollision(CAR_DATA *pCar /*$s3*/, VECTOR *pPos /*$a1*/)
  // line 3685, offset 0x00070878
 	/* begin block 1 */
 		// Start line: 3686
@@ -3336,7 +3336,7 @@ void TannerCollision(PEDESTRIAN* pPed)
 	// 		int s1; // $a2
 	// 		int s2; // $v1
 	// 		int carLength[2]; // stack offset -40
-	// 		static struct CRET2D collisionResult; // offset 0x0
+	// 		static CRET2D collisionResult; // offset 0x0
 	/* end block 1 */
 	// End offset: 0x00070A9C
 	// End Line: 3753
@@ -3352,7 +3352,7 @@ void TannerCollision(PEDESTRIAN* pPed)
 	// End Line: 8378
 
 // [D] [T]
-int FindPointOfCollision(_CAR_DATA* pCar, PEDESTRIAN* pPed)
+int FindPointOfCollision(CAR_DATA* pCar, PEDESTRIAN* pPed)
 {
 	int dx, dz;
 	int minZ;
@@ -3433,16 +3433,16 @@ int FindPointOfCollision(_CAR_DATA* pCar, PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ TannerCarCollisionCheck(struct VECTOR *pPos /*$s5*/, int dir /*$a1*/, int bQuick /*stack 8*/)
+// int /*$ra*/ TannerCarCollisionCheck(VECTOR *pPos /*$s5*/, int dir /*$a1*/, int bQuick /*stack 8*/)
  // line 3762, offset 0x00070a9c
 	/* begin block 1 */
 		// Start line: 3763
 		// Start offset: 0x00070A9C
 		// Variables:
 	// 		int carLength[2]; // stack offset -120
-	// 		struct _CAR_DATA *cp0; // $s0
-	// 		struct _CAR_DATA *cp1; // $s1
-	// 		static struct CRET2D collisionResult; // offset 0x30
+	// 		CAR_DATA *cp0; // $s0
+	// 		CAR_DATA *cp1; // $s1
+	// 		static CRET2D collisionResult; // offset 0x30
 	// 		unsigned int dNewLBODY[2]; // stack offset -112
 	// 		int speed; // $v0
 
@@ -3461,7 +3461,7 @@ int FindPointOfCollision(_CAR_DATA* pCar, PEDESTRIAN* pPed)
 				// Start line: 3815
 				// Start offset: 0x00070C04
 				// Variables:
-			// 		struct VECTOR velocity; // stack offset -104
+			// 		VECTOR velocity; // stack offset -104
 			// 		long pointVel[4]; // stack offset -88
 			// 		long reaction[4]; // stack offset -72
 			// 		long lever[4]; // stack offset -56
@@ -3516,14 +3516,14 @@ int FindPointOfCollision(_CAR_DATA* pCar, PEDESTRIAN* pPed)
 // [D] [T]
 int TannerCarCollisionCheck(VECTOR* pPos, int dir, int bQuick)
 {
-	_CAR_DATA* cp1;
+	CAR_DATA* cp1;
 	long pointVel[4];
 	long reaction[4];
 	long lever[4];
 	int strikeVel;
 	SVECTOR boxDisp;
 	CAR_COSMETICS* car_cos;
-	_CAR_DATA* pcdTanner;
+	CAR_DATA* pcdTanner;
 
 	CRET2D collisionResult; // offset 0x30
 	CDATA2D cd[2];
@@ -3630,7 +3630,7 @@ int TannerCarCollisionCheck(VECTOR* pPos, int dir, int bQuick)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ PingOutPed(struct PEDESTRIAN *pPed /*$a2*/)
+// int /*$ra*/ PingOutPed(PEDESTRIAN *pPed /*$a2*/)
 // line 3915, offset 0x000731f8
 /* begin block 1 */
 // Start line: 3916
@@ -3675,7 +3675,7 @@ int PingOutPed(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupCivJump(struct PEDESTRIAN *pPed /*$s1*/, struct _CAR_DATA *cp /*$s0*/)
+// void /*$ra*/ SetupCivJump(PEDESTRIAN *pPed /*$s1*/, CAR_DATA *cp /*$s0*/)
 // line 3946, offset 0x00071054
 /* begin block 1 */
 // Start line: 3947
@@ -3715,7 +3715,7 @@ int PingOutPed(PEDESTRIAN* pPed)
 // End Line: 9331
 
 // [D] [T]
-void SetupCivJump(PEDESTRIAN* pPed, _CAR_DATA* cp)
+void SetupCivJump(PEDESTRIAN* pPed, CAR_DATA* cp)
 {
 	int dz;
 	short scale;
@@ -3793,7 +3793,7 @@ void SetupCivJump(PEDESTRIAN* pPed, _CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivPedJump(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ CivPedJump(PEDESTRIAN *pPed /*$s0*/)
 // line 4047, offset 0x00072cf0
 /* begin block 1 */
 // Start line: 4048
@@ -3839,7 +3839,7 @@ void CivPedJump(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupCivPedWalk(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ SetupCivPedWalk(PEDESTRIAN *pPed /*$s0*/)
 // line 4080, offset 0x00073270
 /* begin block 1 */
 // Start line: 24276
@@ -3870,7 +3870,7 @@ void SetupCivPedWalk(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivPedWalk(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ CivPedWalk(PEDESTRIAN *pPed /*$s0*/)
 // line 4101, offset 0x00071324
 /* begin block 1 */
 // Start line: 4102
@@ -3978,7 +3978,7 @@ void CivPedWalk(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CivPedSit(struct PEDESTRIAN *pPed /*$a0*/)
+// void /*$ra*/ CivPedSit(PEDESTRIAN *pPed /*$a0*/)
 // line 4190, offset 0x00072ce8
 /* begin block 1 */
 // Start line: 4192
@@ -4053,7 +4053,7 @@ void HandlePedestrians(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PedestrianActionInit_WalkToTarget(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ PedestrianActionInit_WalkToTarget(PEDESTRIAN *pPed /*$s0*/)
 // line 4465, offset 0x0007283c
 /* begin block 1 */
 // Start line: 4466
@@ -4101,13 +4101,13 @@ void PedestrianActionInit_WalkToTarget(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CorrectPathPosition(struct PEDESTRIAN *pedestrian /*$a0*/, struct VECTOR *position /*$a1*/)
+// void /*$ra*/ CorrectPathPosition(PEDESTRIAN *pedestrian /*$a0*/, VECTOR *position /*$a1*/)
 // line 4508, offset 0x000715fc
 /* begin block 1 */
 // Start line: 4510
 // Start offset: 0x000715FC
 // Variables:
-// 		struct VECTOR vec; // stack offset -16
+// 		VECTOR vec; // stack offset -16
 /* end block 1 */
 // End offset: 0x000715FC
 // End Line: 4610
@@ -4141,7 +4141,7 @@ void CorrectPathPosition(PEDESTRIAN* pedestrian, VECTOR* position)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CalcPedestrianDirection(int last_dir /*$a0*/, int wx /*$s5*/, int wz /*$s6*/, struct VECTOR *target /*$s3*/)
+// int /*$ra*/ CalcPedestrianDirection(int last_dir /*$a0*/, int wx /*$s5*/, int wz /*$s6*/, VECTOR *target /*$s3*/)
 // line 4619, offset 0x00071608
 /* begin block 1 */
 // Start line: 4620
@@ -4263,13 +4263,13 @@ int CalcPedestrianDirection(int last_dir, int wx, int wz, VECTOR* target)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ IsPavement(int x /*$a0*/, int y /*$a1*/, int z /*$a2*/, struct PEDESTRIAN *pPed /*$s0*/)
+// int /*$ra*/ IsPavement(int x /*$a0*/, int y /*$a1*/, int z /*$a2*/, PEDESTRIAN *pPed /*$s0*/)
 // line 4845, offset 0x000725b8
 /* begin block 1 */
 // Start line: 4846
 // Start offset: 0x000725B8
 // Variables:
-// 		struct VECTOR vec; // stack offset -24
+// 		VECTOR vec; // stack offset -24
 // 		int r; // $v1
 /* end block 1 */
 // End offset: 0x00072644
@@ -4319,7 +4319,7 @@ int IsPavement(int x, int y, int z, PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetPedestrianTurn(struct PEDESTRIAN *pedestrian /*$a0*/, int turn /*$a1*/)
+// void /*$ra*/ SetPedestrianTurn(PEDESTRIAN *pedestrian /*$a0*/, int turn /*$a1*/)
 // line 4924, offset 0x00072500
 /* begin block 1 */
 // Start line: 4925
@@ -4371,13 +4371,13 @@ void SetPedestrianTurn(PEDESTRIAN* pedestrian, int turn)
 
 // decompiled code
 // original method signature: 
-// struct SEATED_PEDESTRIANS * /*$ra*/ FindSeated()
+// SEATED_PEDESTRIANS * /*$ra*/ FindSeated()
 // line 4943, offset 0x00072644
 /* begin block 1 */
 // Start line: 4945
 // Start offset: 0x00072644
 // Variables:
-// 		struct SEATED_PEDESTRIANS *seatedptr; // $s0
+// 		SEATED_PEDESTRIANS *seatedptr; // $s0
 
 /* begin block 1.1 */
 // Start line: 4950
@@ -4461,14 +4461,14 @@ SEATED_PEDESTRIANS* FindSeated(void)
 
 // decompiled code
 // original method signature: 
-// struct SEATED_PEDESTRIANS * /*$ra*/ FindTannerASeat(struct PEDESTRIAN *pPed /*$t4*/)
+// SEATED_PEDESTRIANS * /*$ra*/ FindTannerASeat(PEDESTRIAN *pPed /*$t4*/)
 // line 4984, offset 0x000717ac
 /* begin block 1 */
 // Start line: 4985
 // Start offset: 0x000717AC
 // Variables:
-// 		struct SEATED_PEDESTRIANS *seatedptr; // $a2
-// 		struct SEATED_PEDESTRIANS *theOne; // $t1
+// 		SEATED_PEDESTRIANS *seatedptr; // $a2
+// 		SEATED_PEDESTRIANS *theOne; // $t1
 // 		int dx; // $a0
 // 		int dz; // $v1
 // 		int distsqr; // $v0
@@ -4543,13 +4543,13 @@ SEATED_PEDESTRIANS* FindTannerASeat(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ add_seated(struct SEATED_PEDESTRIANS *seatedptr /*$s0*/, int seat_index /*$s2*/)
+// void /*$ra*/ add_seated(SEATED_PEDESTRIANS *seatedptr /*$s0*/, int seat_index /*$s2*/)
 // line 5031, offset 0x000718c8
 /* begin block 1 */
 // Start line: 5032
 // Start offset: 0x000718C8
 // Variables:
-// 		struct PEDESTRIAN *pedestrian; // $s1
+// 		PEDESTRIAN *pedestrian; // $s1
 // 		int index; // $v0
 /* end block 1 */
 // End offset: 0x00071A44
@@ -4618,13 +4618,13 @@ void add_seated(SEATED_PEDESTRIANS* seatedptr, int seat_index)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ set_coll_box(int index /*$t2*/, struct _CAR_DATA *cp /*$t0*/, int offset /*$t3*/)
+// void /*$ra*/ set_coll_box(int index /*$t2*/, CAR_DATA *cp /*$t0*/, int offset /*$t3*/)
 // line 5084, offset 0x00071a5c
 /* begin block 1 */
 // Start line: 5085
 // Start offset: 0x00071A5C
 // Variables:
-// 		struct VECTOR BoxCentre; // stack offset -16
+// 		VECTOR BoxCentre; // stack offset -16
 // 		int boxsize; // $t1
 /* end block 1 */
 // End offset: 0x00071B74
@@ -4636,10 +4636,10 @@ void add_seated(SEATED_PEDESTRIANS* seatedptr, int seat_index)
 // End Line: 11715
 
 CAR_COLLISION_BOX collision_box[8];
-_CAR_DATA* collision_car_ptr[8];
+CAR_DATA* collision_car_ptr[8];
 
 // [D]
-void set_coll_box(int index, _CAR_DATA* cp, int offset)
+void set_coll_box(int index, CAR_DATA* cp, int offset)
 {
 	int isPlayerCar;
 	int boxSize;
@@ -4685,7 +4685,7 @@ void set_coll_box(int index, _CAR_DATA* cp, int offset)
 // Start line: 5120
 // Start offset: 0x00071B7C
 // Variables:
-// 		struct _CAR_DATA *cp; // $s3
+// 		CAR_DATA *cp; // $s3
 // 		int count1; // $s4
 // 		int i; // $t1
 
@@ -4731,8 +4731,8 @@ void BuildCarCollisionBox(void)
 	int dir;
 	int vx, vz;
 	int index;
-	_ExOBJECT* expl;
-	_CAR_DATA* cp;
+	EXOBJECT* expl;
+	CAR_DATA* cp;
 
 	if (player[0].playerCarId != -1) // [A] ASan bug fix
 	{
@@ -4796,7 +4796,7 @@ void BuildCarCollisionBox(void)
 
 // decompiled code
 // original method signature: 
-// struct _CAR_DATA * /*$ra*/ CheckForCar(struct PEDESTRIAN *pedestrian /*$s3*/)
+// CAR_DATA * /*$ra*/ CheckForCar(PEDESTRIAN *pedestrian /*$s3*/)
 // line 5178, offset 0x00072738
 /* begin block 1 */
 // Start line: 5179
@@ -4844,7 +4844,7 @@ void BuildCarCollisionBox(void)
 // End Line: 19532
 
 // [D] [T]
-_CAR_DATA* CheckForCar(PEDESTRIAN* pedestrian)
+CAR_DATA* CheckForCar(PEDESTRIAN* pedestrian)
 {
 	int count;
 
@@ -4881,7 +4881,7 @@ _CAR_DATA* CheckForCar(PEDESTRIAN* pedestrian)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckForPlayerCar(struct PEDESTRIAN *pedestrian /*$a0*/, struct CAR_COLLISION_BOX *collision_box /*$a1*/)
+// int /*$ra*/ CheckForPlayerCar(PEDESTRIAN *pedestrian /*$a0*/, CAR_COLLISION_BOX *collision_box /*$a1*/)
 // line 5231, offset 0x000732c0
 /* begin block 1 */
 // Start line: 26722
@@ -4911,7 +4911,7 @@ int CheckForPlayerCar(PEDESTRIAN* pedestrian, CAR_COLLISION_BOX* collision_box)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ CalculatePedestrianInterest(struct PEDESTRIAN *pPed /*$s0*/)
+// void /*$ra*/ CalculatePedestrianInterest(PEDESTRIAN *pPed /*$s0*/)
 // line 5249, offset 0x00071e0c
 /* begin block 1 */
 // Start line: 5250
@@ -4919,9 +4919,9 @@ int CheckForPlayerCar(PEDESTRIAN* pedestrian, CAR_COLLISION_BOX* collision_box)
 // Variables:
 // 		int interest; // $a2
 // 		int dist; // $v1
-// 		struct _CAR_DATA *pCar; // $a2
-// 		struct VECTOR v1; // stack offset -40
-// 		struct VECTOR v2; // stack offset -24
+// 		CAR_DATA *pCar; // $a2
+// 		VECTOR v1; // stack offset -40
+// 		VECTOR v2; // stack offset -24
 /* end block 1 */
 // End offset: 0x00071F44
 // End Line: 5318
@@ -4946,7 +4946,7 @@ int basic_car_interest;
 // [D] [T]
 void CalculatePedestrianInterest(PEDESTRIAN* pPed)
 {
-	_CAR_DATA* pCar;
+	CAR_DATA* pCar;
 	int carId;
 	int interest;
 	VECTOR v1;
@@ -4999,13 +4999,13 @@ void CalculatePedestrianInterest(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ PedSurfaceType(struct VECTOR *ped_pos /*$a0*/)
+// int /*$ra*/ PedSurfaceType(VECTOR *ped_pos /*$a0*/)
 // line 5325, offset 0x00072584
 /* begin block 1 */
 // Start line: 5330
 // Start offset: 0x00072584
 // Variables:
-// 		struct _sdPlane *sfc_ptr; // $v0
+// 		sdPlane *sfc_ptr; // $v0
 /* end block 1 */
 // End offset: 0x000725B8
 // End Line: 5335
@@ -5028,7 +5028,7 @@ void CalculatePedestrianInterest(PEDESTRIAN* pPed)
 // [D] [T]
 int PedSurfaceType(VECTOR* ped_pos)
 {
-	_sdPlane* sfc_ptr;
+	sdPlane* sfc_ptr;
 	sfc_ptr = sdGetCell(ped_pos);
 
 	if (!sfc_ptr)

--- a/src_rebuild/GAME/C/PEDEST.C
+++ b/src_rebuild/GAME/C/PEDEST.C
@@ -143,8 +143,8 @@ int powerCounter = 0;
 void IHaveThePower(void)
 {
 	CAR_DATA* cp;
-	long force[4] = { 0x9000, 0, 0, 0 };
-	long point[4] = { 0, 0, 90, 0 };
+	LONGVECTOR force = { 0x9000, 0, 0, 0 };
+	LONGVECTOR point = { 0, 0, 90, 0 };
 
 	if (GameLevel != 1)
 		return;
@@ -828,7 +828,7 @@ void DestroyPedestrian(PEDESTRIAN* pPed)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ ActivatePlayerPedestrian(CAR_DATA *pCar /*$s6*/, char *padId /*stack 4*/, int direction /*$a1*/, long (*position)[4] /*$a3*/, int playerType /*stack 16*/)
+// int /*$ra*/ ActivatePlayerPedestrian(CAR_DATA *pCar /*$s6*/, char *padId /*stack 4*/, int direction /*$a1*/, LONGVECTOR* position /*$a3*/, int playerType /*stack 16*/)
  // line 1623, offset 0x0006e6c4
 	/* begin block 1 */
 		// Start line: 1624
@@ -889,7 +889,7 @@ void DestroyPedestrian(PEDESTRIAN* pPed)
 /* WARNING: Type propagation algorithm not settling */
 
 // [D] [T]
-int ActivatePlayerPedestrian(CAR_DATA* pCar, char* padId, int direction, long(*position)[4], PED_MODEL_TYPES playerType)
+int ActivatePlayerPedestrian(CAR_DATA* pCar, char* padId, int direction, LONGVECTOR* position, PED_MODEL_TYPES playerType)
 {
 	int wbody;
 	int side;
@@ -1182,8 +1182,8 @@ PEDESTRIAN* CreatePedestrian(void)
 		// 		int s1; // $s1
 		// 		int s2; // $a3
 		// 		VECTOR vert; // stack offset -88
-		// 		long disp[4]; // stack offset -72
-		// 		long dir[4]; // stack offset -56
+		// 		LONGVECTOR disp; // stack offset -72
+		// 		LONGVECTOR dir; // stack offset -56
 		// 		int alpha; // $s1
 		/* end block 1.1 */
 		// End offset: 0x0006EFDC
@@ -1226,7 +1226,7 @@ void PlaceRoadBlockCops(void)
 	int i;
 	int numCops;
 	CAR_DATA* pCopCars[16];
-	long disp[4];
+	LONGVECTOR disp;
 
 	if (numCopPeds >= 8)
 		return;
@@ -1270,14 +1270,14 @@ void PlaceRoadBlockCops(void)
 		disp[1] = -pCar->hd.where.t[1];
 		disp[2] = pCar->hd.where.t[2] + FIXED(wbody * sn) + FIXED(lbody * cs);
 
-		if (CreatePedAtLocation((long(*)[4])disp, 12) != 0)
+		if (CreatePedAtLocation(&disp, 12) != 0)
 			numCopPeds++;
 
 		disp[0] = pCar->hd.where.t[0] - (FIXED(wbody * cs) - FIXED(-lbody * sn));
 		disp[1] = -pCar->hd.where.t[1];
 		disp[2] = pCar->hd.where.t[2] + FIXED(wbody * sn) + FIXED(-lbody * cs);
 
-		if (CreatePedAtLocation((long(*)[4])disp, 13) != 0)
+		if (CreatePedAtLocation(&disp, 13) != 0)
 			numCopPeds++;
 
 		i++;
@@ -1288,7 +1288,7 @@ void PlaceRoadBlockCops(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CreatePedAtLocation(long (*pPos)[4] /*$s2*/, int pedType /*$s1*/)
+// int /*$ra*/ CreatePedAtLocation(LONGVECTOR* pPos /*$s2*/, int pedType /*$s1*/)
  // line 1975, offset 0x0006f00c
 	/* begin block 1 */
 		// Start line: 1976
@@ -1305,7 +1305,7 @@ void PlaceRoadBlockCops(void)
 	// End Line: 4496
 
 // [D] [T]
-int CreatePedAtLocation(long(*pPos)[4], int pedType)
+int CreatePedAtLocation(LONGVECTOR* pPos, int pedType)
 {
 	PEDESTRIAN* pPed;
 
@@ -2249,8 +2249,8 @@ void PedGetOutCar(PEDESTRIAN* pPed)
 		// Start offset: 0x0006F80C
 		// Variables:
 	// 		int alpha; // $s2
-	// 		long disp[4]; // stack offset -80
-	// 		long dir[4]; // stack offset -64
+	// 		LONGVECTOR disp; // stack offset -80
+	// 		LONGVECTOR dir; // stack offset -64
 	// 		SVECTOR vert; // stack offset -48
 	// 		int x; // $s4
 	// 		int z; // $s0
@@ -2330,8 +2330,8 @@ void SetupGetOutCar(PEDESTRIAN* pPed, CAR_DATA* pCar, int side)
 		// Start offset: 0x0006FA3C
 		// Variables:
 	// 		int alpha; // $s1
-	// 		long disp[4]; // stack offset -72
-	// 		long dir[4]; // stack offset -56
+	// 		LONGVECTOR disp; // stack offset -72
+	// 		LONGVECTOR dir; // stack offset -56
 	// 		SVECTOR vert; // stack offset -40
 
 		/* begin block 1.1 */
@@ -2351,7 +2351,7 @@ void SetupGetOutCar(PEDESTRIAN* pPed, CAR_DATA* pCar, int side)
 			// Start line: 2968
 			// Start offset: 0x0006FC70
 			// Variables:
-		// 		long pos[4]; // stack offset -32
+		// 		LONGVECTOR pos; // stack offset -32
 		/* end block 1.2 */
 		// End offset: 0x0006FC70
 		// End Line: 2969
@@ -2383,7 +2383,7 @@ void SetupGetInCar(PEDESTRIAN* pPed)
 	int playerId;
 	int entrySide;
 
-	long pos[4];
+	LONGVECTOR pos;
 
 	pPed->flags &= ~4;
 	pPed->speed = 0;
@@ -2447,8 +2447,8 @@ void SetupGetInCar(PEDESTRIAN* pPed)
 		// Start line: 2995
 		// Start offset: 0x00072B5C
 		// Variables:
-	// 		long disp[4]; // stack offset -48
-	// 		long dir[4]; // stack offset -32
+	// 		LONGVECTOR disp; // stack offset -48
+	// 		LONGVECTOR dir; // stack offset -32
 	// 		SVECTOR vert; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00072BEC
@@ -3462,9 +3462,9 @@ int FindPointOfCollision(CAR_DATA* pCar, PEDESTRIAN* pPed)
 				// Start offset: 0x00070C04
 				// Variables:
 			// 		VECTOR velocity; // stack offset -104
-			// 		long pointVel[4]; // stack offset -88
-			// 		long reaction[4]; // stack offset -72
-			// 		long lever[4]; // stack offset -56
+			// 		LONGVECTOR pointVel; // stack offset -88
+			// 		LONGVECTOR reaction; // stack offset -72
+			// 		LONGVECTOR lever; // stack offset -56
 			// 		int strikeVel; // $t1
 
 				/* begin block 1.1.2.1 */
@@ -3517,9 +3517,9 @@ int FindPointOfCollision(CAR_DATA* pCar, PEDESTRIAN* pPed)
 int TannerCarCollisionCheck(VECTOR* pPos, int dir, int bQuick)
 {
 	CAR_DATA* cp1;
-	long pointVel[4];
-	long reaction[4];
-	long lever[4];
+	LONGVECTOR pointVel;
+	LONGVECTOR reaction;
+	LONGVECTOR lever;
 	int strikeVel;
 	SVECTOR boxDisp;
 	CAR_COSMETICS* car_cos;
@@ -3681,8 +3681,8 @@ int PingOutPed(PEDESTRIAN* pPed)
 // Start line: 3947
 // Start offset: 0x00071054
 // Variables:
-// 		long disp[4]; // stack offset -48
-// 		long dir[4]; // stack offset -32
+// 		LONGVECTOR disp; // stack offset -48
+// 		LONGVECTOR dir; // stack offset -32
 // 		int angle; // $s0
 
 /* begin block 1.1 */
@@ -3721,7 +3721,7 @@ void SetupCivJump(PEDESTRIAN* pPed, CAR_DATA* cp)
 	short scale;
 	int dx;
 	short angle;
-	long dir[4];
+	LONGVECTOR dir;
 
 	if (pPed->type != PED_ACTION_JUMP)
 	{

--- a/src_rebuild/GAME/C/PEDEST.H
+++ b/src_rebuild/GAME/C/PEDEST.H
@@ -28,9 +28,9 @@ extern void DestroyCivPedestrians(); // 0x00072FD0
 
 extern void DestroyPedestrian(PEDESTRIAN *pPed); // 0x00071FB4
 
-extern int ActivatePlayerPedestrian(_CAR_DATA *pCar, char *padId, int direction, long (*position)[4], PED_MODEL_TYPES playerType); // 0x0006E6C4
+extern int ActivatePlayerPedestrian(CAR_DATA *pCar, char *padId, int direction, long (*position)[4], PED_MODEL_TYPES playerType); // 0x0006E6C4
 
-extern struct PEDESTRIAN * CreatePedestrian(); // 0x000720AC
+extern PEDESTRIAN * CreatePedestrian(); // 0x000720AC
 
 extern void PlaceRoadBlockCops(); // 0x0006EC88
 
@@ -64,7 +64,7 @@ extern void PedCarryOutAnimation(PEDESTRIAN *pPed); // 0x00072A10
 
 extern void PedGetOutCar(PEDESTRIAN *pPed); // 0x00072BEC
 
-extern void SetupGetOutCar(PEDESTRIAN *pPed, struct _CAR_DATA *pCar, int side); // 0x0006F80C
+extern void SetupGetOutCar(PEDESTRIAN *pPed, CAR_DATA *pCar, int side); // 0x0006F80C
 
 extern void SetupGetInCar(PEDESTRIAN *pPed); // 0x0006FA3C
 
@@ -92,13 +92,13 @@ extern void PingInPedestrians(); // 0x0007047C
 
 extern void TannerCollision(PEDESTRIAN *pPed); // 0x00072EE4
 
-extern int FindPointOfCollision(_CAR_DATA *pCar, PEDESTRIAN* pPed); // 0x00070878
+extern int FindPointOfCollision(CAR_DATA *pCar, PEDESTRIAN* pPed); // 0x00070878
 
 extern int TannerCarCollisionCheck(VECTOR *pPos, int dir, int bQuick); // 0x00070A9C
 
 extern int PingOutPed(PEDESTRIAN *pPed); // 0x000731F8
 
-extern void SetupCivJump(PEDESTRIAN *pPed, struct _CAR_DATA *cp); // 0x00071054
+extern void SetupCivJump(PEDESTRIAN *pPed, CAR_DATA *cp); // 0x00071054
 
 extern void CivPedJump(PEDESTRIAN *pPed); // 0x00072CF0
 
@@ -116,21 +116,21 @@ extern void CorrectPathPosition(PEDESTRIAN *pedestrian, VECTOR *position); // 0x
 
 extern int CalcPedestrianDirection(int last_dir, int wx, int wz, VECTOR *target); // 0x00071608
 
-extern int IsPavement(int x, int y, int z, struct PEDESTRIAN *pPed); // 0x000725B8
+extern int IsPavement(int x, int y, int z, PEDESTRIAN *pPed); // 0x000725B8
 
 extern void SetPedestrianTurn(PEDESTRIAN *pedestrian, int turn); // 0x00072500
 
-extern struct SEATED_PEDESTRIANS * FindSeated(); // 0x00072644
+extern SEATED_PEDESTRIANS * FindSeated(); // 0x00072644
 
-extern struct SEATED_PEDESTRIANS * FindTannerASeat(PEDESTRIAN *pPed); // 0x000717AC
+extern SEATED_PEDESTRIANS * FindTannerASeat(PEDESTRIAN *pPed); // 0x000717AC
 
 extern void add_seated(SEATED_PEDESTRIANS *seatedptr, int seat_index); // 0x000718C8
 
-extern void set_coll_box(int index, _CAR_DATA *cp, int offset); // 0x00071A5C
+extern void set_coll_box(int index, CAR_DATA *cp, int offset); // 0x00071A5C
 
 extern void BuildCarCollisionBox(); // 0x00071B7C
 
-extern struct _CAR_DATA * CheckForCar(PEDESTRIAN *pedestrian); // 0x00072738
+extern CAR_DATA * CheckForCar(PEDESTRIAN *pedestrian); // 0x00072738
 
 extern int CheckForPlayerCar(PEDESTRIAN *pedestrian, CAR_COLLISION_BOX *collision_box); // 0x000732C0
 

--- a/src_rebuild/GAME/C/PEDEST.H
+++ b/src_rebuild/GAME/C/PEDEST.H
@@ -28,13 +28,13 @@ extern void DestroyCivPedestrians(); // 0x00072FD0
 
 extern void DestroyPedestrian(PEDESTRIAN *pPed); // 0x00071FB4
 
-extern int ActivatePlayerPedestrian(CAR_DATA *pCar, char *padId, int direction, long (*position)[4], PED_MODEL_TYPES playerType); // 0x0006E6C4
+extern int ActivatePlayerPedestrian(CAR_DATA *pCar, char *padId, int direction, LONGVECTOR* position, PED_MODEL_TYPES playerType); // 0x0006E6C4
 
 extern PEDESTRIAN * CreatePedestrian(); // 0x000720AC
 
 extern void PlaceRoadBlockCops(); // 0x0006EC88
 
-extern int CreatePedAtLocation(long (*pPos)[4], int pedType); // 0x0006F00C
+extern int CreatePedAtLocation(LONGVECTOR* pPos, int pedType); // 0x0006F00C
 
 extern void DrawAllPedestrians(); // 0x00072290
 

--- a/src_rebuild/GAME/C/PLAYERS.C
+++ b/src_rebuild/GAME/C/PLAYERS.C
@@ -15,7 +15,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitPlayer(struct _PLAYER *locPlayer /*$s1*/, struct _CAR_DATA *cp /*$s2*/, char carCtrlType /*$s3*/, int direction /*$s6*/, long (*startPos)[4] /*stack 16*/, int externModel /*stack 20*/, int palette /*stack 24*/, char *padid /*stack 28*/)
+// void /*$ra*/ InitPlayer(PLAYER *locPlayer /*$s1*/, CAR_DATA *cp /*$s2*/, char carCtrlType /*$s3*/, int direction /*$s6*/, long (*startPos)[4] /*stack 16*/, int externModel /*stack 20*/, int palette /*stack 24*/, char *padid /*stack 28*/)
  // line 75, offset 0x000739d8
 	/* begin block 1 */
 		// Start line: 76
@@ -35,16 +35,16 @@
 	// End Line: 151
 
 PEDESTRIAN *pPlayerPed = NULL;
-_PLAYER player[8];
+PLAYER player[8];
 
 // [D] [T]
-void InitPlayer(_PLAYER *locPlayer, _CAR_DATA *cp, char carCtrlType, int direction, long(*startPos)[4], int externModel, int palette, char *padid)
+void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, long(*startPos)[4], int externModel, int palette, char *padid)
 {
 	int model;
 	uint playerType;
 
 	playerType = externModel & 0xFF;
-	ClearMem((char *)locPlayer, sizeof(_PLAYER));
+	ClearMem((char *)locPlayer, sizeof(PLAYER));
 
 	if (gStartOnFoot == 0 || carCtrlType == 4)
 	{
@@ -115,7 +115,7 @@ void InitPlayer(_PLAYER *locPlayer, _CAR_DATA *cp, char carCtrlType, int directi
 		// Start line: 131
 		// Start offset: 0x00073334
 		// Variables:
-	// 		struct _CAR_DATA *lcp; // $s2
+	// 		CAR_DATA *lcp; // $s2
 	/* end block 1 */
 	// End offset: 0x0007350C
 	// End Line: 181
@@ -128,7 +128,7 @@ void InitPlayer(_PLAYER *locPlayer, _CAR_DATA *cp, char carCtrlType, int directi
 // [D] [T]
 void ChangeCarPlayerToPed(int playerID)
 {
-	_CAR_DATA *lcp = &car_data[player[playerID].playerCarId];
+	CAR_DATA *lcp = &car_data[player[playerID].playerCarId];
 
 	//my_sly_var = playerID;
 	player[playerID].headTimer = 0;
@@ -177,13 +177,13 @@ void ChangeCarPlayerToPed(int playerID)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ChangePedPlayerToCar(int playerID /*$s4*/, struct _CAR_DATA *newCar /*$s2*/)
+// void /*$ra*/ ChangePedPlayerToCar(int playerID /*$s4*/, CAR_DATA *newCar /*$s2*/)
  // line 184, offset 0x0007350c
 	/* begin block 1 */
 		// Start line: 185
 		// Start offset: 0x0007350C
 		// Variables:
-	// 		struct _PLAYER *lPlayer; // $s1
+	// 		PLAYER *lPlayer; // $s1
 	// 		int siren; // $s5
 	// 		long *pos; // $s3
 	// 		int carParked; // $s6
@@ -209,14 +209,14 @@ void ChangeCarPlayerToPed(int playerID)
 extern int lastCarCameraView;
 
 // [D] [T]
-void ChangePedPlayerToCar(int playerID, _CAR_DATA *newCar)
+void ChangePedPlayerToCar(int playerID, CAR_DATA *newCar)
 {
 	int carParked;
 	int siren;
 	int channel;
 	int carSampleId;
 
-	_PLAYER* lPlayer;
+	PLAYER* lPlayer;
 
 	lPlayer = &player[playerID];
 
@@ -313,8 +313,8 @@ void ChangePedPlayerToCar(int playerID, _CAR_DATA *newCar)
 		// Start line: 249
 		// Start offset: 0x00073898
 		// Variables:
-	// 		struct _PLAYER *locPlayer; // $t0
-	// 		struct _CAR_DATA *cp; // $v1
+	// 		PLAYER *locPlayer; // $t0
+	// 		CAR_DATA *cp; // $v1
 	/* end block 1 */
 	// End offset: 0x000739D8
 	// End Line: 286
@@ -346,8 +346,8 @@ void UpdatePlayers(void)
 {
 	int carId;
 	PEDESTRIAN *ped;
-	_PLAYER *locPlayer;
-	_CAR_DATA* cp;
+	PLAYER *locPlayer;
+	CAR_DATA* cp;
 
 	pedestrianFelony = 0;
 

--- a/src_rebuild/GAME/C/PLAYERS.C
+++ b/src_rebuild/GAME/C/PLAYERS.C
@@ -15,7 +15,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitPlayer(PLAYER *locPlayer /*$s1*/, CAR_DATA *cp /*$s2*/, char carCtrlType /*$s3*/, int direction /*$s6*/, long (*startPos)[4] /*stack 16*/, int externModel /*stack 20*/, int palette /*stack 24*/, char *padid /*stack 28*/)
+// void /*$ra*/ InitPlayer(PLAYER *locPlayer /*$s1*/, CAR_DATA *cp /*$s2*/, char carCtrlType /*$s3*/, int direction /*$s6*/, LONGVECTOR* startPos /*stack 16*/, int externModel /*stack 20*/, int palette /*stack 24*/, char *padid /*stack 28*/)
  // line 75, offset 0x000739d8
 	/* begin block 1 */
 		// Start line: 76
@@ -38,7 +38,7 @@ PEDESTRIAN *pPlayerPed = NULL;
 PLAYER player[8];
 
 // [D] [T]
-void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, long(*startPos)[4], int externModel, int palette, char *padid)
+void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, LONGVECTOR* startPos, int externModel, int palette, char *padid)
 {
 	int model;
 	uint playerType;

--- a/src_rebuild/GAME/C/PLAYERS.H
+++ b/src_rebuild/GAME/C/PLAYERS.H
@@ -1,14 +1,14 @@
 #ifndef PLAYERS_H
 #define PLAYERS_H
 
-extern _PLAYER player[8];
+extern PLAYER player[8];
 extern PEDESTRIAN *pPlayerPed;
 
-extern void InitPlayer(struct _PLAYER *locPlayer, struct _CAR_DATA *cp, char carCtrlType, int direction, long (*startPos)[4], int externModel, int palette, char *padid); // 0x000739D8
+extern void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, long (*startPos)[4], int externModel, int palette, char *padid); // 0x000739D8
 
 extern void ChangeCarPlayerToPed(int playerID); // 0x00073334
 
-extern void ChangePedPlayerToCar(int playerID, struct _CAR_DATA *newCar); // 0x0007350C
+extern void ChangePedPlayerToCar(int playerID, CAR_DATA *newCar); // 0x0007350C
 
 extern void UpdatePlayers(); // 0x00073898
 

--- a/src_rebuild/GAME/C/PLAYERS.H
+++ b/src_rebuild/GAME/C/PLAYERS.H
@@ -4,7 +4,7 @@
 extern PLAYER player[8];
 extern PEDESTRIAN *pPlayerPed;
 
-extern void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, long (*startPos)[4], int externModel, int palette, char *padid); // 0x000739D8
+extern void InitPlayer(PLAYER *locPlayer, CAR_DATA *cp, char carCtrlType, int direction, LONGVECTOR* startPos, int externModel, int palette, char *padid); // 0x000739D8
 
 extern void ChangeCarPlayerToPed(int playerID); // 0x00073334
 

--- a/src_rebuild/GAME/C/PRES.C
+++ b/src_rebuild/GAME/C/PRES.C
@@ -250,7 +250,7 @@ void PrintStringCentred(char *pString, short y)
 		// Start line: 361
 		// Start offset: 0x00073CC8
 		// Variables:
-	// 		struct RECT dest; // stack offset -24
+	// 		RECT dest; // stack offset -24
 	// 		char *file; // $s1
 	// 		int i; // $v1
 	// 		int nchars; // $s0
@@ -331,7 +331,7 @@ void LoadFont(char *buffer)
 		// Start line: 417
 		// Start offset: 0x00074C28
 		// Variables:
-	// 		struct RECT rect; // stack offset -16
+	// 		RECT rect; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00074C64
 	// End Line: 426
@@ -435,8 +435,8 @@ void SetCLUT16Flags(ushort clutID, ushort mask, char transparent)
 		// Start line: 458
 		// Start offset: 0x00073EA0
 		// Variables:
-	// 		struct OUT_FONTINFO *pFontInfo; // $a1
-	// 		struct SPRT *font; // $s0
+	// 		OUT_FONTINFO *pFontInfo; // $a1
+	// 		SPRT *font; // $s0
 	// 		unsigned char width; // $s1
 	// 		unsigned char c; // $s1
 	// 		int index; // $v1
@@ -562,8 +562,8 @@ int PrintString(char *string, int x, int y)
 		// Start line: 540
 		// Start offset: 0x00074140
 		// Variables:
-	// 		struct FONT_DIGIT *pDigit; // $a1
-	// 		struct SPRT *font; // $t0
+	// 		FONT_DIGIT *pDigit; // $a1
+	// 		SPRT *font; // $t0
 	// 		char width; // $a3
 	// 		char fixedWidth; // $t1
 	// 		char vOff; // $t2
@@ -723,8 +723,8 @@ int PrintStringFeature(char *string, int x, int y, int w, int h, int transparent
 		// Start line: 644
 		// Start offset: 0x00074364
 		// Variables:
-	// 		struct OUT_FONTINFO *pFontInfo; // $a1
-	// 		struct SPRT *font; // $s0
+	// 		OUT_FONTINFO *pFontInfo; // $a1
+	// 		SPRT *font; // $s0
 	// 		char word[32]; // stack offset -64
 	// 		char *wpt; // $t0
 	// 		char c; // $a0
@@ -897,8 +897,8 @@ void InitButtonTextures(void)
 		// Start line: 727
 		// Start offset: 0x000745DC
 		// Variables:
-	// 		struct FONT_DIGIT *pDigit; // $a2
-	// 		struct POLY_FT4 *font; // $t0
+	// 		FONT_DIGIT *pDigit; // $a2
+	// 		POLY_FT4 *font; // $t0
 	// 		int x; // $s0
 	// 		int width; // $t3
 	// 		int height; // $t6
@@ -1068,8 +1068,8 @@ char * GetNextWord(char *string, char *word)
 		// Start line: 820
 		// Start offset: 0x00074858
 		// Variables:
-	// 		struct TEXTURE_DETAILS *btn; // $a1
-	// 		struct POLY_FT3 *null; // $s0
+	// 		TEXTURE_DETAILS *btn; // $a1
+	// 		POLY_FT3 *null; // $s0
 	/* end block 1 */
 	// End offset: 0x00074A10
 	// End Line: 853
@@ -1143,7 +1143,7 @@ void* DrawButton(unsigned char button, void *prim, int x, int y)
 		// Start line: 856
 		// Start offset: 0x00074D94
 		// Variables:
-	// 		struct POLY_FT3 *null; // $s0
+	// 		POLY_FT3 *null; // $s0
 	/* end block 1 */
 	// End offset: 0x00074E54
 	// End Line: 871

--- a/src_rebuild/GAME/C/REPLAYS.C
+++ b/src_rebuild/GAME/C/REPLAYS.C
@@ -30,7 +30,7 @@ char *replayptr = NULL;
 int ReplaySize = 0;
 
 unsigned long PingBufferPos = 0;
-_PING_PACKET *PingBuffer = NULL;
+PING_PACKET *PingBuffer = NULL;
 
 SXYPAIR *PlayerWayRecordPtr = NULL;
 PLAYBACKCAMERA *PlaybackCamera = NULL;
@@ -96,8 +96,8 @@ void InitPadRecording(void)
 
 		PlaybackCamera = (PLAYBACKCAMERA *)(PlayerWayRecordPtr + MAX_REPLAY_WAYPOINTS);
 
-		PingBuffer = (_PING_PACKET *)(PlaybackCamera + MAX_REPLAY_CAMERAS);
-		setMem8((u_char*)PingBuffer, -1, sizeof(_PING_PACKET) * MAX_REPLAY_PINGS);
+		PingBuffer = (PING_PACKET *)(PlaybackCamera + MAX_REPLAY_CAMERAS);
+		setMem8((u_char*)PingBuffer, -1, sizeof(PING_PACKET) * MAX_REPLAY_PINGS);
 
 		replayptr = (char*)(PingBuffer + MAX_REPLAY_PINGS);
 
@@ -140,7 +140,7 @@ void InitPadRecording(void)
 		// Start line: 658
 		// Start offset: 0x0001A234
 		// Variables:
-	// 		struct REPLAY_SAVE_HEADER *header; // $s2
+	// 		REPLAY_SAVE_HEADER *header; // $s2
 	// 		int i; // $a2
 	// 		int size; // $s1
 	// 		int numstreams; // $s6
@@ -236,8 +236,8 @@ int SaveReplayToBuffer(char *buffer)
 	memcpy(pt, PlaybackCamera, sizeof(PLAYBACKCAMERA) * MAX_REPLAY_CAMERAS);
 	pt += sizeof(PLAYBACKCAMERA) * MAX_REPLAY_CAMERAS;
 
-	memcpy(pt, PingBuffer, sizeof(_PING_PACKET) * MAX_REPLAY_PINGS);
-	pt += sizeof(_PING_PACKET) * MAX_REPLAY_PINGS;
+	memcpy(pt, PingBuffer, sizeof(PING_PACKET) * MAX_REPLAY_PINGS);
+	pt += sizeof(PING_PACKET) * MAX_REPLAY_PINGS;
 
 	// [A] is that ever valid?
 	if (gHaveStoredData)
@@ -263,8 +263,8 @@ int SaveReplayToBuffer(char *buffer)
 		// Start line: 742
 		// Start offset: 0x0001A798
 		// Variables:
-	// 		struct REPLAY_SAVE_HEADER *header; // $s3
-	// 		struct REPLAY_STREAM_HEADER *sheader; // $t0
+	// 		REPLAY_SAVE_HEADER *header; // $s3
+	// 		REPLAY_STREAM_HEADER *sheader; // $t0
 	// 		int i; // $a1
 	// 		int size; // $s0
 	/* end block 1 */
@@ -492,9 +492,9 @@ int LoadReplayFromBuffer(char *buffer)
 	pt += sizeof(PLAYBACKCAMERA) * MAX_REPLAY_CAMERAS;
 
 	PingBufferPos = 0;
-	PingBuffer = (_PING_PACKET *)(PlaybackCamera + MAX_REPLAY_CAMERAS);
-	memcpy(PingBuffer, pt, sizeof(_PING_PACKET) * MAX_REPLAY_PINGS);
-	pt += sizeof(_PING_PACKET) * MAX_REPLAY_PINGS;
+	PingBuffer = (PING_PACKET *)(PlaybackCamera + MAX_REPLAY_CAMERAS);
+	memcpy(PingBuffer, pt, sizeof(PING_PACKET) * MAX_REPLAY_PINGS);
+	pt += sizeof(PING_PACKET) * MAX_REPLAY_PINGS;
 
 	replayptr = (char*)(PingBuffer + MAX_REPLAY_PINGS);
 
@@ -558,7 +558,7 @@ int LoadAttractReplay(int mission)
 		// Start line: 1183
 		// Start offset: 0x0001B090
 		// Variables:
-	// 		struct _PING_PACKET *pp; // $a1
+	// 		_PING_PACKET *pp; // $a1
 	// 		char retCarId; // $v0
 	/* end block 1 */
 	// End offset: 0x0001B118
@@ -578,7 +578,7 @@ int LoadAttractReplay(int mission)
 char GetPingInfo(char *cookieCount)
 {
 	char retCarId;
-	_PING_PACKET *pp;
+	PING_PACKET *pp;
 
 	retCarId = -1;
 
@@ -606,7 +606,7 @@ char GetPingInfo(char *cookieCount)
 // [A] Stores ping info into replay buffer
 int StorePingInfo(int cookieCount, int carId)
 {
-	_PING_PACKET* packet;
+	PING_PACKET* packet;
 
 	if (CurrentGameMode == GAMEMODE_REPLAY || gInGameChaseActive != 0)
 		return 0;
@@ -643,7 +643,7 @@ int IsPingInfoAvailable()
 		// Start line: 1224
 		// Start offset: 0x0001AF34
 		// Variables:
-	// 		struct XYPAIR region_coords; // stack offset -8
+	// 		XYPAIR region_coords; // stack offset -8
 	// 		int region; // $a0
 	/* end block 1 */
 	// End offset: 0x0001AFFC
@@ -860,7 +860,7 @@ void cjpRecord(int stream, ulong *ppad, char *psteer, char *ptype)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AllocateReplayStream(struct REPLAY_STREAM *stream /*$a0*/, int maxpad /*$a1*/)
+// void /*$ra*/ AllocateReplayStream(REPLAY_STREAM *stream /*$a0*/, int maxpad /*$a1*/)
  // line 1383, offset 0x0001b17c
 	/* begin block 1 */
 		// Start line: 3101
@@ -915,7 +915,7 @@ void AllocateReplayStream(REPLAY_STREAM *stream, int maxpad)
 		// Start line: 1403
 		// Start offset: 0x0001B1F0
 		// Variables:
-	// 		struct REPLAY_STREAM *rstream; // $a2
+	// 		REPLAY_STREAM *rstream; // $a2
 	// 		unsigned long t0; // $a0
 	/* end block 1 */
 	// End offset: 0x0001B280
@@ -974,7 +974,7 @@ int Get(int stream, ulong *pt0)
 		// Start line: 1442
 		// Start offset: 0x0001B280
 		// Variables:
-	// 		struct REPLAY_STREAM *rstream; // $a0
+	// 		REPLAY_STREAM *rstream; // $a0
 	// 		unsigned char **pstream; // $a3
 	// 		unsigned long t0; // $a1
 	/* end block 1 */

--- a/src_rebuild/GAME/C/REPLAYS.H
+++ b/src_rebuild/GAME/C/REPLAYS.H
@@ -11,7 +11,7 @@ extern char *ReplayStart;
 extern char *replayptr;
 
 extern unsigned long PingBufferPos;
-extern _PING_PACKET *PingBuffer;
+extern PING_PACKET *PingBuffer;
 
 extern int TimeToWay;
 extern short PlayerWaypoints;
@@ -40,7 +40,7 @@ extern int cjpPlay(int stream, unsigned long *ppad, char *psteer, char *ptype); 
 
 extern void cjpRecord(int stream, unsigned long *ppad, char *psteer, char *ptype); // 0x0001AD50
 
-extern void AllocateReplayStream(struct REPLAY_STREAM *stream, int maxpad); // 0x0001B17C
+extern void AllocateReplayStream(REPLAY_STREAM *stream, int maxpad); // 0x0001B17C
 
 extern int Get(int stream, unsigned long *pt0); // 0x0001B1F0
 

--- a/src_rebuild/GAME/C/ROADBITS.C
+++ b/src_rebuild/GAME/C/ROADBITS.C
@@ -4,7 +4,7 @@
 
 // decompiled code
 // original method signature: 
-// char /*$ra*/ ROADS_GetRouteData(int x /*$a0*/, int z /*$a1*/, struct ROUTE_DATA *pRouteData /*$a2*/)
+// char /*$ra*/ ROADS_GetRouteData(int x /*$a0*/, int z /*$a1*/, ROUTE_DATA *pRouteData /*$a2*/)
  // line 147, offset 0x00074eb4
 	/* begin block 1 */
 		// Start line: 294

--- a/src_rebuild/GAME/C/SCORES.C
+++ b/src_rebuild/GAME/C/SCORES.C
@@ -73,13 +73,13 @@ void InitialiseScoreTables(void)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ OnScoreTable(struct SCORE_ENTRY **tablept /*$s1*/)
+// int /*$ra*/ OnScoreTable(SCORE_ENTRY **tablept /*$s1*/)
  // line 86, offset 0x0007503c
 	/* begin block 1 */
 		// Start line: 87
 		// Start offset: 0x0007503C
 		// Variables:
-	// 		struct SCORE_ENTRY *table; // $s0
+	// 		SCORE_ENTRY *table; // $s0
 	// 		int position; // $v0
 	/* end block 1 */
 	// End offset: 0x000751F8
@@ -142,7 +142,7 @@ int OnScoreTable(SCORE_ENTRY **tablept)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddScoreToTable(struct SCORE_ENTRY *table /*$a2*/, int entry /*$a1*/)
+// void /*$ra*/ AddScoreToTable(SCORE_ENTRY *table /*$a2*/, int entry /*$a1*/)
  // line 133, offset 0x000751f8
 	/* begin block 1 */
 		// Start line: 134
@@ -192,7 +192,7 @@ void AddScoreToTable(SCORE_ENTRY *table, int entry)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckGetawayPlacing(struct SCORE_ENTRY *table /*$a0*/)
+// int /*$ra*/ CheckGetawayPlacing(SCORE_ENTRY *table /*$a0*/)
  // line 162, offset 0x0007526c
 	/* begin block 1 */
 		// Start line: 163
@@ -240,7 +240,7 @@ int CheckGetawayPlacing(SCORE_ENTRY *table)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckTrailblazerPlacing(struct SCORE_ENTRY *table /*$a0*/)
+// int /*$ra*/ CheckTrailblazerPlacing(SCORE_ENTRY *table /*$a0*/)
  // line 188, offset 0x000752bc
 	/* begin block 1 */
 		// Start line: 189
@@ -304,7 +304,7 @@ int CheckTrailblazerPlacing(SCORE_ENTRY *table)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckCheckpointPlacing(struct SCORE_ENTRY *table /*$a0*/)
+// int /*$ra*/ CheckCheckpointPlacing(SCORE_ENTRY *table /*$a0*/)
  // line 218, offset 0x00075338
 	/* begin block 1 */
 		// Start line: 219
@@ -351,7 +351,7 @@ int CheckCheckpointPlacing(SCORE_ENTRY *table)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ CheckSurvivalPlacing(struct SCORE_ENTRY *table /*$a0*/)
+// int /*$ra*/ CheckSurvivalPlacing(SCORE_ENTRY *table /*$a0*/)
  // line 243, offset 0x00075388
 	/* begin block 1 */
 		// Start line: 244
@@ -397,7 +397,7 @@ int CheckSurvivalPlacing(SCORE_ENTRY *table)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ResetTable(struct SCORE_ENTRY *table /*$a0*/)
+// void /*$ra*/ ResetTable(SCORE_ENTRY *table /*$a0*/)
  // line 261, offset 0x000753d8
 	/* begin block 1 */
 		// Start line: 262

--- a/src_rebuild/GAME/C/SCORES.H
+++ b/src_rebuild/GAME/C/SCORES.H
@@ -6,19 +6,19 @@ extern PLAYER_SCORE gPlayerScore;
 
 extern void InitialiseScoreTables(); // 0x00074EC0
 
-extern int OnScoreTable(struct SCORE_ENTRY **tablept); // 0x0007503C
+extern int OnScoreTable(SCORE_ENTRY **tablept); // 0x0007503C
 
-extern void AddScoreToTable(struct SCORE_ENTRY *table, int entry); // 0x000751F8
+extern void AddScoreToTable(SCORE_ENTRY *table, int entry); // 0x000751F8
 
-extern int CheckGetawayPlacing(struct SCORE_ENTRY *table); // 0x0007526C
+extern int CheckGetawayPlacing(SCORE_ENTRY *table); // 0x0007526C
 
-extern int CheckTrailblazerPlacing(struct SCORE_ENTRY *table); // 0x000752BC
+extern int CheckTrailblazerPlacing(SCORE_ENTRY *table); // 0x000752BC
 
-extern int CheckCheckpointPlacing(struct SCORE_ENTRY *table); // 0x00075338
+extern int CheckCheckpointPlacing(SCORE_ENTRY *table); // 0x00075338
 
-extern int CheckSurvivalPlacing(struct SCORE_ENTRY *table); // 0x00075388
+extern int CheckSurvivalPlacing(SCORE_ENTRY *table); // 0x00075388
 
-extern void ResetTable(struct SCORE_ENTRY *table); // 0x000753D8
+extern void ResetTable(SCORE_ENTRY *table); // 0x000753D8
 
 
 #endif

--- a/src_rebuild/GAME/C/SHADOW.C
+++ b/src_rebuild/GAME/C/SHADOW.C
@@ -84,16 +84,16 @@ void InitTyreTracks(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetTyreTrackPositions(struct _CAR_DATA *cp /*$s3*/, int player_id /*$s7*/)
+// void /*$ra*/ GetTyreTrackPositions(CAR_DATA *cp /*$s3*/, int player_id /*$s7*/)
  // line 272, offset 0x00075408
 	/* begin block 1 */
 		// Start line: 273
 		// Start offset: 0x00075408
 		// Variables:
-	// 		struct CAR_COSMETICS *car_cos; // $s4
-	// 		struct VECTOR WheelPos; // stack offset -88
-	// 		struct VECTOR target_pos; // stack offset -72
-	// 		struct VECTOR normal; // stack offset -56
+	// 		CAR_COSMETICS *car_cos; // $s4
+	// 		VECTOR WheelPos; // stack offset -88
+	// 		VECTOR target_pos; // stack offset -72
+	// 		VECTOR normal; // stack offset -56
 	// 		int loop; // $s2
 
 		/* begin block 1.1 */
@@ -112,7 +112,7 @@ void InitTyreTracks(void)
 	// End Line: 545
 
 // [D] [T]
-void GetTyreTrackPositions(_CAR_DATA *cp, int player_id)
+void GetTyreTrackPositions(CAR_DATA *cp, int player_id)
 {
 	int track;
 	uint loop;
@@ -199,30 +199,30 @@ void SetTyreTrackOldPositions(int player_id)
 		// Start line: 331
 		// Start offset: 0x00075540
 		// Variables:
-	// 		struct VECTOR New1; // stack offset -168
-	// 		struct VECTOR New2; // stack offset -152
-	// 		struct VECTOR New3; // stack offset -136
-	// 		struct VECTOR New4; // stack offset -120
-	// 		struct VECTOR *old; // $s5
-	// 		struct VECTOR *new; // $s3
-	// 		struct TYRE_TRACK *tt_p; // $s1
+	// 		VECTOR New1; // stack offset -168
+	// 		VECTOR New2; // stack offset -152
+	// 		VECTOR New3; // stack offset -136
+	// 		VECTOR New4; // stack offset -120
+	// 		VECTOR *old; // $s5
+	// 		VECTOR *new; // $s3
+	// 		TYRE_TRACK *tt_p; // $s1
 	// 		int x; // $v1
 	// 		int z; // $a1
 	// 		int c; // $t1
 	// 		int s; // $t0
 	// 		unsigned int index; // $a2
 	// 		static int Cont[4]; // offset 0x0
-	// 		struct VECTOR psxoffset; // stack offset -104
-	// 		struct VECTOR SmokeDrift; // stack offset -88
-	// 		struct VECTOR SmokePosition; // stack offset -72
+	// 		VECTOR psxoffset; // stack offset -104
+	// 		VECTOR SmokeDrift; // stack offset -88
+	// 		VECTOR SmokePosition; // stack offset -72
 	// 		char trackSurface; // $s0
 
 		/* begin block 1.1 */
 			// Start line: 364
 			// Start offset: 0x00075610
 			// Variables:
-		// 		struct ROUTE_DATA routeData; // stack offset -56
-		// 		struct _sdPlane *SurfaceDataPtr; // $v0
+		// 		ROUTE_DATA routeData; // stack offset -56
+		// 		sdPlane *SurfaceDataPtr; // $v0
 		/* end block 1.1 */
 		// End offset: 0x0007569C
 		// End Line: 399
@@ -238,7 +238,7 @@ void SetTyreTrackOldPositions(int player_id)
 			// Start line: 421
 			// Start offset: 0x0007572C
 			// Variables:
-		// 		struct VECTOR grass_vector; // stack offset -48
+		// 		VECTOR grass_vector; // stack offset -48
 		/* end block 1.3 */
 		// End offset: 0x0007572C
 		// End Line: 421
@@ -263,7 +263,7 @@ void AddTyreTrack(int wheel, int tracksAndSmoke, int padid)
 
 	short x;
 	short z;
-	_sdPlane *SurfaceDataPtr;
+	sdPlane *SurfaceDataPtr;
 	char trackSurface;
 	TYRE_TRACK *tt_p;
 	VECTOR *newtp;
@@ -421,17 +421,17 @@ void AddTyreTrack(int wheel, int tracksAndSmoke, int padid)
 		// Start line: 519
 		// Start offset: 0x000759E0
 		// Variables:
-	// 		struct VECTOR p[4]; // stack offset -136
-	// 		struct SVECTOR ps[4]; // stack offset -72
-	// 		struct TYRE_TRACK *tt_p; // $t0
+	// 		VECTOR p[4]; // stack offset -136
+	// 		SVECTOR ps[4]; // stack offset -72
+	// 		TYRE_TRACK *tt_p; // $t0
 	// 		int z; // stack offset -40
 	// 		int temp; // $a2
 	// 		int loop; // $t7
 	// 		int wheel_loop; // $s0
 	// 		int index; // $t2
 	// 		char last_duff; // $s1
-	// 		struct POLY_FT4 *poly; // $a3
-	// 		struct POLY_FT4 *lasttyre; // $t8
+	// 		POLY_FT4 *poly; // $a3
+	// 		POLY_FT4 *lasttyre; // $t8
 	/* end block 1 */
 	// End offset: 0x00075F34
 	// End Line: 645
@@ -599,8 +599,8 @@ void DrawTyreTracks(void)
 		// Start line: 661
 		// Start offset: 0x00075F34
 		// Variables:
-	// 		struct TPAN pos; // stack offset -16
-	// 		struct TEXINF *texinf; // $v0
+	// 		TPAN pos; // stack offset -16
+	// 		TEXINF *texinf; // $v0
 	// 		int i; // $a2
 	// 		int j; // $a3
 
@@ -681,13 +681,13 @@ void InitShadow(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SubdivShadow(long z0 /*$t7*/, long z1 /*$t9*/, long z2 /*$t8*/, long z3 /*$t6*/, struct POLY_FT4 *sps /*stack 16*/)
+// void /*$ra*/ SubdivShadow(long z0 /*$t7*/, long z1 /*$t9*/, long z2 /*$t8*/, long z3 /*$t6*/, POLY_FT4 *sps /*stack 16*/)
  // line 717, offset 0x00076108
 	/* begin block 1 */
 		// Start line: 718
 		// Start offset: 0x00076108
 		// Variables:
-	// 		struct POLY_FT4 *spd; // $t3
+	// 		POLY_FT4 *spd; // $t3
 	// 		int i; // $t4
 
 		/* begin block 1.1 */
@@ -971,19 +971,19 @@ void SubdivShadow(long z0, long z1, long z2, long z3, POLY_FT4 *sps)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlaceShadowForCar(struct VECTOR *shadowPoints /*$t0*/, int slot /*$s0*/, struct VECTOR *CarPos /*$a2*/, int zclip /*$a3*/)
+// void /*$ra*/ PlaceShadowForCar(VECTOR *shadowPoints /*$t0*/, int slot /*$s0*/, VECTOR *CarPos /*$a2*/, int zclip /*$a3*/)
  // line 864, offset 0x000766cc
 	/* begin block 1 */
 		// Start line: 865
 		// Start offset: 0x000766CC
 		// Variables:
-	// 		struct SVECTOR points[4]; // stack offset -64
+	// 		SVECTOR points[4]; // stack offset -64
 	// 		long z; // $a0
 	// 		long z0; // stack offset -32
 	// 		long z1; // stack offset -28
 	// 		long z2; // stack offset -24
 	// 		long z3; // stack offset -20
-	// 		struct POLY_FT4 *spt; // $a3
+	// 		POLY_FT4 *spt; // $a3
 	/* end block 1 */
 	// End offset: 0x00076A40
 	// End Line: 933
@@ -1074,9 +1074,9 @@ void PlaceShadowForCar(VECTOR *shadowPoints, int subdiv, int zOfs, int flag)
 		// Variables:
 	// 		int srccount; // $t4
 	// 		int dstcount; // $t5
-	// 		struct SVECTOR *current; // $t2
-	// 		struct SVECTOR *previous; // $t1
-	// 		struct SVECTOR *dst; // $a3
+	// 		SVECTOR *current; // $t2
+	// 		SVECTOR *previous; // $t1
+	// 		SVECTOR *dst; // $a3
 	// 		int flags; // $t3
 
 		/* begin block 1.1 */
@@ -1223,7 +1223,7 @@ int clipAgainstZ(void)
 	// 		int i; // $a3
 	// 		int j; // $t0
 	// 		int z1; // $v1
-	// 		struct POLY_G3 *pg3; // $s0
+	// 		POLY_G3 *pg3; // $s0
 	// 		int z[3]; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00077128
@@ -1403,7 +1403,7 @@ void clippedPoly(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ sQuad(struct SVECTOR *v0 /*$a0*/, struct SVECTOR *v1 /*$s5*/, struct SVECTOR *v2 /*$s6*/, struct SVECTOR *v3 /*$s4*/)
+// void /*$ra*/ sQuad(SVECTOR *v0 /*$a0*/, SVECTOR *v1 /*$s5*/, SVECTOR *v2 /*$s6*/, SVECTOR *v3 /*$s4*/)
  // line 1160, offset 0x00077138
 	/* begin block 1 */
 		// Start line: 1161
@@ -1416,7 +1416,7 @@ void clippedPoly(void)
 			// Start line: 1168
 			// Start offset: 0x000771B4
 			// Variables:
-		// 		struct POLY_G4 *pf4; // $t2
+		// 		POLY_G4 *pf4; // $t2
 		/* end block 1.1 */
 		// End offset: 0x000772B4
 		// End Line: 1190

--- a/src_rebuild/GAME/C/SHADOW.H
+++ b/src_rebuild/GAME/C/SHADOW.H
@@ -7,7 +7,7 @@ extern UV shadowuv;
 
 extern void InitTyreTracks(); // 0x00077524
 
-extern void GetTyreTrackPositions(_CAR_DATA *cp, int player_id); // 0x00075408
+extern void GetTyreTrackPositions(CAR_DATA *cp, int player_id); // 0x00075408
 
 extern void SetTyreTrackOldPositions(int player_id); // 0x00077558
 

--- a/src_rebuild/GAME/C/SKY.C
+++ b/src_rebuild/GAME/C/SKY.C
@@ -105,7 +105,7 @@ VECTOR tunnelPos[3][2] =
 		// Start line: 147
 		// Start offset: 0x000775C8
 		// Variables:
-	// 		struct RECT rect; // stack offset -96
+	// 		RECT rect; // stack offset -96
 	// 		char name[16]; // stack offset -88
 	// 		int x; // $s6
 	// 		int y; // $a1
@@ -380,15 +380,15 @@ void DrawSkyDome(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplaySun(struct DVECTOR *pos /*$a0*/, struct CVECTOR *col /*$a1*/, int flare_col /*$a2*/)
+// void /*$ra*/ DisplaySun(DVECTOR *pos /*$a0*/, CVECTOR *col /*$a1*/, int flare_col /*$a2*/)
  // line 527, offset 0x000780bc
 	/* begin block 1 */
 		// Start line: 528
 		// Start offset: 0x000780BC
 		// Variables:
-	// 		struct POLY_FT4 *polys; // $a1
-	// 		struct POLY_FT3 *null; // $a3
-	// 		struct VECTOR output; // stack offset -32
+	// 		POLY_FT4 *polys; // $a1
+	// 		POLY_FT3 *null; // $a3
+	// 		VECTOR output; // stack offset -32
 	// 		int width; // $t5
 	// 		int height; // $t4
 	/* end block 1 */
@@ -523,14 +523,14 @@ void DisplaySun(DVECTOR* pos, CVECTOR* col, int flare_col)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DisplayMoon(struct DVECTOR *pos /*$t4*/, struct CVECTOR *col /*$t6*/, int flip /*$a2*/)
+// void /*$ra*/ DisplayMoon(DVECTOR *pos /*$t4*/, CVECTOR *col /*$t6*/, int flip /*$a2*/)
  // line 609, offset 0x00078544
 	/* begin block 1 */
 		// Start line: 610
 		// Start offset: 0x00078544
 		// Variables:
-	// 		struct POLY_FT3 *null; // $a0
-	// 		struct VECTOR output; // stack offset -16
+	// 		POLY_FT3 *null; // $a0
+	// 		VECTOR output; // stack offset -16
 	// 		int width; // $t5
 	// 		int height; // $t3
 	/* end block 1 */
@@ -630,9 +630,9 @@ void DisplayMoon(DVECTOR* pos, CVECTOR* col, int flip)
 		// Variables:
 	// 		static char last_attempt_failed; // offset 0x0
 	// 		static short buffer[160]; // offset 0x0
-	// 		struct DVECTOR sun_pers_conv_position; // stack offset -64
-	// 		struct RECT source; // stack offset -56
-	// 		struct DR_MOVE *sample_sun; // $s0
+	// 		DVECTOR sun_pers_conv_position; // stack offset -64
+	// 		RECT source; // stack offset -56
+	// 		DR_MOVE *sample_sun; // $s0
 	// 		int distance_to_sun; // $s0
 	// 		int xpos; // $t1
 	// 		int ypos; // $v0
@@ -641,8 +641,8 @@ void DisplayMoon(DVECTOR* pos, CVECTOR* col, int flip)
 	// 		int flarez; // stack offset -40
 	// 		int shade; // $t4
 	// 		int sun_intensity; // $s3
-	// 		struct POLY_FT4 *polys; // $a1
-	// 		struct CVECTOR col; // stack offset -48
+	// 		POLY_FT4 *polys; // $a1
+	// 		CVECTOR col; // stack offset -48
 	// 		int r; // $a2
 	// 		int g; // $a3
 	// 		int b; // $a0
@@ -668,7 +668,7 @@ void DisplayMoon(DVECTOR* pos, CVECTOR* col, int flip)
 				// Start line: 458
 				// Start offset: 0x00077DD0
 				// Variables:
-			// 		struct FLAREREC *pFlareInfo; // $t3
+			// 		FLAREREC *pFlareInfo; // $t3
 			// 		int flaresize; // $t0
 			/* end block 1.2.1 */
 			// End offset: 0x00077FAC
@@ -925,8 +925,8 @@ void DrawLensFlare(void)
 		// 		int dX; // $v1
 		// 		int dZ; // $v0
 		// 		int len; // $a1
-		// 		struct VECTOR *v1; // $t1
-		// 		struct VECTOR *v2; // $t0
+		// 		VECTOR *v1; // $t1
+		// 		VECTOR *v2; // $t0
 
 			/* begin block 1.1.1 */
 				// Start line: 725
@@ -1136,9 +1136,9 @@ void calc_sky_brightness(void)
 		// Start line: 856
 		// Start offset: 0x00078B18
 		// Variables:
-	// 		struct POLYFT4 *src; // $t1
-	// 		struct DVECTOR *outpoints; // $t0
-	// 		struct POLY_FT4 *prims; // $t2
+	// 		POLYFT4 *src; // $t1
+	// 		DVECTOR *outpoints; // $t0
+	// 		POLY_FT4 *prims; // $t2
 	/* end block 1 */
 	// End offset: 0x00078EBC
 	// End Line: 894
@@ -1218,13 +1218,13 @@ void PlotSkyPoly(POLYFT4* polys, int skytexnum, unsigned char r, unsigned char g
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ PlotHorizonMDL(struct MODEL *model /*$s6*/, int horizontaboffset /*$a1*/)
+// void /*$ra*/ PlotHorizonMDL(MODEL *model /*$s6*/, int horizontaboffset /*$a1*/)
  // line 896, offset 0x00078ec4
 	/* begin block 1 */
 		// Start line: 897
 		// Start offset: 0x00078EC4
 		// Variables:
-	// 		struct SVECTOR *verts; // $v1
+	// 		SVECTOR *verts; // $v1
 	// 		char *polys; // $s1
 	// 		int i; // $s0
 	// 		int p; // stack offset -56

--- a/src_rebuild/GAME/C/SKY.H
+++ b/src_rebuild/GAME/C/SKY.H
@@ -18,7 +18,7 @@ extern void calc_sky_brightness(); // 0x00078964
 
 extern void PlotSkyPoly(POLYFT4* polys, int skytexnum, unsigned char r, unsigned char g, unsigned char b, int offset); // 0x00078B18
 
-extern void PlotHorizonMDL(struct MODEL *model, int horizontaboffset); // 0x00078EC4
+extern void PlotHorizonMDL(MODEL *model, int horizontaboffset); // 0x00078EC4
 
 
 #endif

--- a/src_rebuild/GAME/C/SOUND.C
+++ b/src_rebuild/GAME/C/SOUND.C
@@ -20,7 +20,7 @@
 
 #define SPU_CHANNEL_COUNT 24
 
-long dummylong[4] = { 0, 0, 0, 0 };
+LONGVECTOR dummylong = { 0, 0, 0, 0 };
 
 long bankaddr[2] = { 0 };
 long banksize[2] = { 88064, 412672 };

--- a/src_rebuild/GAME/C/SOUND.C
+++ b/src_rebuild/GAME/C/SOUND.C
@@ -449,7 +449,7 @@ int StartSound(int channel, int bank, int sample, int volume, int pitch)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ Start3DTrackingSound(int channel /*$s1*/, int bank /*$s0*/, int sample /*$s3*/, struct VECTOR *position /*$s2*/, long *velocity /*stack 16*/)
+// int /*$ra*/ Start3DTrackingSound(int channel /*$s1*/, int bank /*$s0*/, int sample /*$s3*/, VECTOR *position /*$s2*/, long *velocity /*stack 16*/)
  // line 342, offset 0x0007a994
 	/* begin block 1 */
 		// Start line: 684
@@ -704,7 +704,7 @@ void SetChannelVolume(int channel, int volume, int proximity)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ComputeDoppler(struct CHANNEL_DATA *ch /*$s1*/)
+// void /*$ra*/ ComputeDoppler(CHANNEL_DATA *ch /*$s1*/)
  // line 501, offset 0x000795c4
 	/* begin block 1 */
 		// Start line: 502
@@ -712,7 +712,7 @@ void SetChannelVolume(int channel, int volume, int proximity)
 		// Variables:
 	// 		int dist; // $s0
 	// 		int seperationrate; // $v0
-	// 		struct _PLAYER *pl; // $s0
+	// 		PLAYER *pl; // $s0
 	/* end block 1 */
 	// End offset: 0x00079720
 	// End Line: 527
@@ -733,7 +733,7 @@ void ComputeDoppler(CHANNEL_DATA *ch)
 	int iVar6;
 	int iVar7;
 	long *srcVel;
-	_PLAYER *pl;
+	PLAYER *pl;
 
 	srcPos = ch->srcposition;
 
@@ -773,7 +773,7 @@ void ComputeDoppler(CHANNEL_DATA *ch)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetChannelPosition3(int channel /*$s1*/, struct VECTOR *position /*$a0*/, long *velocity /*$t0*/, int volume /*$t2*/, int pitch /*stack 16*/, int proximity /*stack 20*/)
+// void /*$ra*/ SetChannelPosition3(int channel /*$s1*/, VECTOR *position /*$a0*/, long *velocity /*$t0*/, int volume /*$t2*/, int pitch /*stack 16*/, int proximity /*stack 20*/)
  // line 588, offset 0x0007abcc
 	/* begin block 1 */
 		// Start line: 589
@@ -1554,7 +1554,7 @@ void UpdateXMSamples(int num_samps)
 		// Start line: 905
 		// Start offset: 0x00079BCC
 		// Variables:
-	// 		static struct __LSBDinfo tabs; // offset 0x0
+	// 		static __LSBDinfo tabs; // offset 0x0
 	// 		int i; // $a3
 	// 		int num_samples; // $s1
 	// 		int slength; // $s0
@@ -1920,8 +1920,8 @@ int GetFreeChannel(void)
 	// 		long ang; // $s0
 	// 		long dist; // $s6
 	// 		int player_id; // $a3
-	// 		struct VECTOR *pos; // $s3
-	// 		struct VECTOR *cam_pos; // $s4
+	// 		VECTOR *pos; // $s3
+	// 		VECTOR *cam_pos; // $s4
 	// 		int cam_ang; // $fp
 	// 		long damp; // $v1
 
@@ -2184,7 +2184,7 @@ void UpdateVolumeAttributesM(int channel)
 		// Start offset: 0x0007A360
 		// Variables:
 	// 		int volume; // $s0
-	// 		struct VECTOR *pp; // $a3
+	// 		VECTOR *pp; // $a3
 
 		/* begin block 1.1 */
 			// Start line: 1266
@@ -2196,7 +2196,7 @@ void UpdateVolumeAttributesM(int channel)
 				// Start line: 1271
 				// Start offset: 0x0007A3F4
 				// Variables:
-			// 		struct VECTOR ofse; // stack offset -24
+			// 		VECTOR ofse; // stack offset -24
 			/* end block 1.1.1 */
 			// End offset: 0x0007A3F4
 			// End Line: 1274
@@ -2294,7 +2294,7 @@ int CalculateVolume(int channel)
 		// Start line: 1304
 		// Start offset: 0x0007AB3C
 		// Variables:
-	// 		struct SpuReverbAttr r_attr; // stack offset -40
+	// 		SpuReverbAttr r_attr; // stack offset -40
 	/* end block 1 */
 	// End offset: 0x0007AB94
 	// End Line: 1319

--- a/src_rebuild/GAME/C/SOUND.H
+++ b/src_rebuild/GAME/C/SOUND.H
@@ -39,7 +39,7 @@ extern void SetChannelPitch(int channel, int pitch); // 0x00079504
 
 extern void SetChannelVolume(int channel, int volume, int proximity); // 0x0007AA78
 
-extern void ComputeDoppler(struct CHANNEL_DATA *ch); // 0x000795C4
+extern void ComputeDoppler(CHANNEL_DATA *ch); // 0x000795C4
 
 extern void SetChannelPosition3(int channel, VECTOR *position, long *velocity, int volume, int pitch, int proximity); // 0x0007ABCC
 

--- a/src_rebuild/GAME/C/SPOOL.C
+++ b/src_rebuild/GAME/C/SPOOL.C
@@ -112,7 +112,7 @@ int new_area_location;
 int LoadingArea = 0;
 unsigned short *newmodels;
 
-struct SPOOLQ spooldata[48];
+SPOOLQ spooldata[48];
 
 #ifdef _DEBUG
 #define SPOOL_INFO printInfo
@@ -302,7 +302,7 @@ void startReadLevSectorsPC(int sector)
 		// Start line: 534
 		// Start offset: 0x0007B228
 		// Variables:
-	// 		struct SPOOLQ *current; // $a3
+	// 		SPOOLQ *current; // $a3
 	/* end block 1 */
 	// End offset: 0x0007B3B4
 	// End Line: 588
@@ -414,7 +414,7 @@ void test_changemode(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ changemode(struct SPOOLQ *current /*$a0*/)
+// void /*$ra*/ changemode(SPOOLQ *current /*$a0*/)
  // line 591, offset 0x0007e1a8
 	/* begin block 1 */
 		// Start line: 1182
@@ -485,7 +485,7 @@ void changemode(SPOOLQ *current)
 		// Start line: 627
 		// Start offset: 0x0007B3C4
 		// Variables:
-	// 		struct AREA_LOAD_INFO regions_to_unpack[3]; // stack offset -160
+	// 		AREA_LOAD_INFO regions_to_unpack[3]; // stack offset -160
 	// 		int leftright_unpack; // $a2
 	// 		int topbottom_unpack; // $a3
 	// 		int num_regions_to_unpack; // $a1
@@ -737,7 +737,7 @@ void startgame(void)
 	// 		unsigned short *palette; // $a1
 	// 		int temp; // $a2
 	// 		int i; // $a0
-	// 		struct RECT dest; // stack offset -16
+	// 		RECT dest; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0007E2CC
 	// End Line: 856
@@ -790,7 +790,7 @@ void DrawCDicon(void)
 		// Start line: 861
 		// Start offset: 0x0007E2CC
 		// Variables:
-	// 		struct RECT dest; // stack offset -16
+	// 		RECT dest; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0007E35C
 	// End Line: 918
@@ -850,8 +850,8 @@ void CheckValidSpoolData(void)
 		// Start line: 927
 		// Start offset: 0x0007B6C4
 		// Variables:
-	// 		struct SPOOLQ *current; // $s0
-	// 		struct CdlLOC pos; // stack offset -16
+	// 		SPOOLQ *current; // $s0
+	// 		CdlLOC pos; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0007B87C
 	// End Line: 977
@@ -1074,7 +1074,7 @@ void UpdateSpool(void)
 		// Start line: 1105
 		// Start offset: 0x0007E36C
 		// Variables:
-	// 		struct SPOOLQ *next; // $t0
+	// 		SPOOLQ *next; // $t0
 	// 		int sector; // $v0
 	/* end block 1 */
 	// End offset: 0x0007E3E4
@@ -1132,7 +1132,7 @@ void RequestSpool(int type, int data, int offset, int loadsize, char *address, s
 		// Variables:
 	// 		int i; // $s0
 	// 		char namebuffer[128]; // stack offset -152
-	// 		struct CdlLOC pos; // stack offset -24
+	// 		CdlLOC pos; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x0007E528
 	// End Line: 1158
@@ -1204,7 +1204,7 @@ void InitSpooling(void)
 			// Start line: 1176
 			// Start offset: 0x0007B900
 			// Variables:
-		// 		struct RECT cluts; // stack offset -32
+		// 		RECT cluts; // stack offset -32
 		// 		int npalettes; // $s1
 		// 		int i; // $a3
 		// 		unsigned long *clutptr; // $a1
@@ -1566,7 +1566,7 @@ void SendSBK(void)
 	// 		int size; // $s2
 	// 		int model_number; // $a1
 	// 		char *addr; // $s0
-	// 		struct MODEL *parentmodel; // $a1
+	// 		MODEL *parentmodel; // $a1
 
 		/* begin block 1.1 */
 			// Start line: 1519
@@ -1771,7 +1771,7 @@ void LoadInAreaModels(int area)
 		// Variables:
 	// 		int i; // $a2
 	// 		int nAreas; // $t0
-	// 		struct Spool *spoolptr; // $t1
+	// 		Spool *spoolptr; // $t1
 	// 		int load; // $a3
 	// 		int force_load_boundary; // $a0
 	/* end block 1 */
@@ -1953,7 +1953,7 @@ void ClearRegion(int target_region)
 		// Variables:
 	// 		int offset; // $s0
 	// 		char *target_unpacked_data; // $t1
-	// 		struct Spool *spoolptr; // $s1
+	// 		Spool *spoolptr; // $s1
 	// 		char *roadmap_buffer; // $s6
 	// 		char *cell_buffer; // $s3
 	/* end block 1 */
@@ -2264,7 +2264,7 @@ void WaitCloseLid(void)
 		// Start line: 1947
 		// Start offset: 0x0007E6D8
 		// Variables:
-	// 		struct CdlLOC p; // stack offset -16
+	// 		CdlLOC p; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0007E724
 	// End Line: 1963
@@ -2486,7 +2486,7 @@ void data_cb_textures(void)
 			// Start line: 2050
 			// Start offset: 0x0007E0D8
 			// Variables:
-		// 		struct SPOOLQ *current; // $a2
+		// 		SPOOLQ *current; // $a2
 		/* end block 1.1 */
 		// End offset: 0x0007E188
 		// End Line: 2080
@@ -2575,7 +2575,7 @@ void ready_cb_textures(unsigned char intr, unsigned char *result)
 			// Start line: 2110
 			// Start offset: 0x0007DF08
 			// Variables:
-		// 		struct SPOOLQ *current; // $v1
+		// 		SPOOLQ *current; // $v1
 		/* end block 1.1 */
 		// End offset: 0x0007DF08
 		// End Line: 2110
@@ -2646,7 +2646,7 @@ void ready_cb_regions(unsigned char intr, unsigned char *result)
 			// Start line: 2136
 			// Start offset: 0x0007DDBC
 			// Variables:
-		// 		struct SPOOLQ *current; // $v0
+		// 		SPOOLQ *current; // $v0
 		/* end block 1.1 */
 		// End offset: 0x0007DE80
 		// End Line: 2167
@@ -2795,7 +2795,7 @@ void data_cb_soundbank(void)
 			// Start line: 2217
 			// Start offset: 0x0007DD04
 			// Variables:
-		// 		struct SPOOLQ *current; // $a0
+		// 		SPOOLQ *current; // $a0
 		/* end block 1.1 */
 		// End offset: 0x0007DD70
 		// End Line: 2237
@@ -2865,7 +2865,7 @@ void ready_cb_soundbank(unsigned char intr, unsigned char *result)
 			// Start line: 2250
 			// Start offset: 0x0007DA74
 			// Variables:
-		// 		struct SPOOLQ *current; // $v0
+		// 		SPOOLQ *current; // $v0
 		/* end block 1.1 */
 		// End offset: 0x0007DB28
 		// End Line: 2275
@@ -3212,7 +3212,7 @@ void Unpack_CellPtrs(void)
 	// 		int i; // $s1
 	// 		int j; // $s2
 	// 		int tpage; // $s0
-	// 		struct RECT specCluts; // stack offset -48
+	// 		RECT specCluts; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 2522
@@ -3583,7 +3583,7 @@ void LowModelSpooled(void)
 			// Start line: 2702
 			// Start offset: 0x0007CE8C
 			// Variables:
-		// 		struct MODEL *tempModel; // $a1
+		// 		MODEL *tempModel; // $a1
 		/* end block 1.1 */
 		// End offset: 0x0007CEE0
 		// End Line: 2713
@@ -3682,7 +3682,7 @@ void CleanSpooled(void)
 			// Start line: 2728
 			// Start offset: 0x0007E7D8
 			// Variables:
-		// 		struct MODEL *tempModel; // $a1
+		// 		MODEL *tempModel; // $a1
 		/* end block 1.1 */
 		// End offset: 0x0007E820
 		// End Line: 2737
@@ -3744,7 +3744,7 @@ void LowSpooled(void)
 			// Start line: 2751
 			// Start offset: 0x0007CF60
 			// Variables:
-		// 		struct RECT tpage; // stack offset -32
+		// 		RECT tpage; // stack offset -32
 		// 		int spec_tpage; // $a0
 		/* end block 1.1 */
 		// End offset: 0x0007D018
@@ -3754,7 +3754,7 @@ void LowSpooled(void)
 			// Start line: 2767
 			// Start offset: 0x0007D018
 			// Variables:
-		// 		struct RECT tpage; // stack offset -24
+		// 		RECT tpage; // stack offset -24
 		// 		int spec_tpage; // $a0
 		/* end block 1.2 */
 		// End offset: 0x0007D0EC
@@ -4000,7 +4000,7 @@ void SpecialStartNextBlock(void)
 		// Start line: 2958
 		// Start offset: 0x0007D4E0
 		// Variables:
-	// 		struct _CAR_DATA *lcp; // $a0
+	// 		CAR_DATA *lcp; // $a0
 	// 		int ret; // $a3
 
 		/* begin block 1.1 */
@@ -4035,7 +4035,7 @@ void CheckSpecialSpool(void)
 {
 	int ret;
 	int iVar2;
-	_CAR_DATA *lcp;
+	CAR_DATA *lcp;
 
 	if (startSpecSpool != -1 && startSpecSpool+400 < CameraCnt) 
 	{

--- a/src_rebuild/GAME/C/SYSTEM.C
+++ b/src_rebuild/GAME/C/SYSTEM.C
@@ -440,8 +440,8 @@ int Loadfile(char *name, char *addr)
 	// 		int sector; // $s2
 	// 		int nsectors; // $s5
 	// 		char sectorbuffer[2048]; // stack offset -2120
-	// 		struct CdlFILE info; // stack offset -72
-	// 		struct CdlLOC pos; // stack offset -48
+	// 		CdlFILE info; // stack offset -72
+	// 		CdlLOC pos; // stack offset -48
 	// 		int i; // $a2
 	// 		int toload; // $s4
 	// 		int first; // $a0
@@ -690,7 +690,7 @@ void data_ready(void)
 			// Start line: 1004
 			// Start offset: 0x0007FAE4
 			// Variables:
-		// 		struct CdlLOC p; // stack offset -16
+		// 		CdlLOC p; // stack offset -16
 		/* end block 1.1 */
 		// End offset: 0x0007FB34
 		// End Line: 1014
@@ -759,7 +759,7 @@ void sector_ready(unsigned char intr, unsigned char *result)
 		// Start line: 1018
 		// Start offset: 0x0007F904
 		// Variables:
-	// 		struct CdlLOC pos; // stack offset -16
+	// 		CdlLOC pos; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x0007F984
 	// End Line: 1035
@@ -1076,7 +1076,7 @@ void UpdatePadData(void)
 		// Start line: 1366
 		// Start offset: 0x0007EDDC
 		// Variables:
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 	// 		int i; // $v1
 	/* end block 1 */
 	// End offset: 0x0007EF0C
@@ -1266,7 +1266,7 @@ void SetupDrawBufferData(int num_players)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ InitaliseDrawEnv(struct DB *pBuff /*$s0*/, int x /*$s4*/, int y /*$s3*/, int w /*$s1*/, int h /*stack 16*/)
+// void /*$ra*/ InitaliseDrawEnv(DB *pBuff /*$s0*/, int x /*$s4*/, int y /*$s3*/, int w /*$s1*/, int h /*stack 16*/)
  // line 1535, offset 0x0007f7c0
 	/* begin block 1 */
 		// Start line: 4857
@@ -1325,14 +1325,14 @@ void ResetCityType(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetCityType(enum CITYTYPE type /*$a0*/)
+// void /*$ra*/ SetCityType(CITYTYPE type /*$a0*/)
  // line 1577, offset 0x0007f118
 	/* begin block 1 */
 		// Start line: 1578
 		// Start offset: 0x0007F118
 		// Variables:
-	// 		struct CdlFILE cdfile; // stack offset -120
-	// 		struct XYPAIR *info; // $s2
+	// 		CdlFILE cdfile; // stack offset -120
+	// 		XYPAIR *info; // $s2
 	// 		char namebuffer[64]; // stack offset -96
 	// 		unsigned char result[8]; // stack offset -32
 	// 		int i; // $a2
@@ -1491,7 +1491,7 @@ LAB_0007f244:
 		// Start line: 1683
 		// Start offset: 0x0007F5C8
 		// Variables:
-	// 		struct CdlFILE cdfile; // stack offset -176
+	// 		CdlFILE cdfile; // stack offset -176
 	// 		char namebuffer[128]; // stack offset -152
 	// 		unsigned char result[8]; // stack offset -24
 	// 		int retries; // $s1
@@ -1548,13 +1548,13 @@ int FileExists(char *filename)
 
 // decompiled code
 // original method signature: 
-// enum CDTYPE /*$ra*/ DiscSwapped(char *filename /*$s1*/)
+// CDTYPE /*$ra*/ DiscSwapped(char *filename /*$s1*/)
  // line 1723, offset 0x0007f640
 	/* begin block 1 */
 		// Start line: 1724
 		// Start offset: 0x0007F640
 		// Variables:
-	// 		struct CdlFILE cdfile; // stack offset -40
+	// 		CdlFILE cdfile; // stack offset -40
 	// 		int ret; // $v1
 	/* end block 1 */
 	// End offset: 0x0007F6FC

--- a/src_rebuild/GAME/C/SYSTEM.H
+++ b/src_rebuild/GAME/C/SYSTEM.H
@@ -67,14 +67,14 @@ extern int pathAILoaded;
 
 extern char* LoadingScreenNames[];
 
-struct DB // hashcode: 0xE4F25C4D (dec: -453878707)
+struct DB
 {
-	char* primptr; // size=0, offset=0
-	OTTYPE* ot; // size=0, offset=4
-	char* primtab; // size=0, offset=8
-	int id; // size=0, offset=12
-	DRAWENV draw; // size=92, offset=16
-	DISPENV disp; // size=20, offset=108
+	char* primptr;
+	OTTYPE* ot;
+	char* primtab;
+	int id;
+	DRAWENV draw;
+	DISPENV disp;
 };
 
 extern DRAW_MODE draw_mode_pal;

--- a/src_rebuild/GAME/C/SYSTEM.H
+++ b/src_rebuild/GAME/C/SYSTEM.H
@@ -149,15 +149,15 @@ extern void SetupDrawBuffers(); // 0x0007EDDC
 
 extern void SetupDrawBufferData(int num_players); // 0x0007EF0C
 
-extern void InitaliseDrawEnv(struct DB *pBuff, int x, int y, int w, int h); // 0x0007F7C0
+extern void InitaliseDrawEnv(DB *pBuff, int x, int y, int w, int h); // 0x0007F7C0
 
 extern void ResetCityType(); // 0x0007F5B4
 
-extern void SetCityType(enum CITYTYPE type); // 0x0007F118
+extern void SetCityType(CITYTYPE type); // 0x0007F118
 
 extern int FileExists(char *filename); // 0x0007F5C8
 
-extern enum CDTYPE DiscSwapped(char *filename); // 0x0007F640
+extern CDTYPE DiscSwapped(char *filename); // 0x0007F640
 
 
 #endif

--- a/src_rebuild/GAME/C/TARGETS.C
+++ b/src_rebuild/GAME/C/TARGETS.C
@@ -90,13 +90,13 @@ int gDraw3DArrowBlue = 0;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Draw3DTarget(struct VECTOR *position /*$s0*/, int flags /*$s2*/)
+// void /*$ra*/ Draw3DTarget(VECTOR *position /*$s0*/, int flags /*$s2*/)
  // line 213, offset 0x0007fb44
 	/* begin block 1 */
 		// Start line: 214
 		// Start offset: 0x0007FB44
 		// Variables:
-	// 		struct VECTOR pos; // stack offset -32
+	// 		VECTOR pos; // stack offset -32
 	// 		int shadow; // $s1
 	/* end block 1 */
 	// End offset: 0x0007FD48
@@ -181,7 +181,7 @@ void Draw3DTarget(VECTOR *position, int flags)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawTargetArrowModel(struct TARGET_ARROW_MODEL *pTargetArrowModel /*$s1*/, struct VECTOR *pPosition /*$s2*/, int shadow /*$s4*/, int invert /*$s3*/)
+// void /*$ra*/ DrawTargetArrowModel(TARGET_ARROW_MODEL *pTargetArrowModel /*$s1*/, VECTOR *pPosition /*$s2*/, int shadow /*$s4*/, int invert /*$s3*/)
  // line 267, offset 0x0007fd48
 	/* begin block 1 */
 		// Start line: 268
@@ -191,16 +191,16 @@ void Draw3DTarget(VECTOR *position, int flags)
 			// Start line: 271
 			// Start offset: 0x0007FD9C
 			// Variables:
-		// 		struct VECTOR tempVec; // stack offset -56
-		// 		struct SVECTOR *pVerts; // $s0
-		// 		struct SVECTOR temp; // stack offset -40
+		// 		VECTOR tempVec; // stack offset -56
+		// 		SVECTOR *pVerts; // $s0
+		// 		SVECTOR temp; // stack offset -40
 		// 		char *pVertIndex; // $a3
 
 			/* begin block 1.1.1 */
 				// Start line: 283
 				// Start offset: 0x0007FE2C
 				// Variables:
-			// 		struct POLY_F3 *poly; // $t0
+			// 		POLY_F3 *poly; // $t0
 			// 		int z; // stack offset -32
 			/* end block 1.1.1 */
 			// End offset: 0x00080044
@@ -320,15 +320,15 @@ void DrawTargetArrowModel(TARGET_ARROW_MODEL *pTargetArrowModel, VECTOR *pPositi
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawStopZone(struct VECTOR *pPosition /*$s5*/)
+// void /*$ra*/ DrawStopZone(VECTOR *pPosition /*$s5*/)
  // line 412, offset 0x000800f8
 	/* begin block 1 */
 		// Start line: 413
 		// Start offset: 0x000800F8
 		// Variables:
-	// 		struct VECTOR *pVector; // $s0
-	// 		struct VECTOR pStopZonePt[4]; // stack offset -128
-	// 		struct POLY_FT4 *pPoly; // $s1
+	// 		VECTOR *pVector; // $s0
+	// 		VECTOR pStopZonePt[4]; // stack offset -128
+	// 		POLY_FT4 *pPoly; // $s1
 	// 		long *pOut; // $s2
 	// 		long sz; // stack offset -48
 
@@ -336,7 +336,7 @@ void DrawTargetArrowModel(TARGET_ARROW_MODEL *pTargetArrowModel, VECTOR *pPositi
 			// Start line: 430
 			// Start offset: 0x000801FC
 			// Variables:
-		// 		struct SVECTOR temp; // stack offset -64
+		// 		SVECTOR temp; // stack offset -64
 		// 		long p; // stack offset -56
 		// 		long flag; // stack offset -52
 		/* end block 1.1 */
@@ -448,7 +448,7 @@ void DrawStopZone(VECTOR *pPosition)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ WorldToCameraPositions(struct VECTOR *pGlobalPositionIn /*$s1*/, struct VECTOR *pCameraPositionOut /*$s0*/, int count /*$s2*/)
+// void /*$ra*/ WorldToCameraPositions(VECTOR *pGlobalPositionIn /*$s1*/, VECTOR *pCameraPositionOut /*$s0*/, int count /*$s2*/)
  // line 496, offset 0x0008047c
 	/* begin block 1 */
 		// Start line: 497
@@ -458,7 +458,7 @@ void DrawStopZone(VECTOR *pPosition)
 			// Start line: 500
 			// Start offset: 0x000804B8
 			// Variables:
-		// 		struct VECTOR temp; // stack offset -48
+		// 		VECTOR temp; // stack offset -48
 		/* end block 1.1 */
 		// End offset: 0x000804B8
 		// End Line: 502

--- a/src_rebuild/GAME/C/TEXTURE.C
+++ b/src_rebuild/GAME/C/TEXTURE.C
@@ -83,7 +83,7 @@ short specialSlot;
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ IncrementClutNum(struct RECT *clut /*$a0*/)
+// void /*$ra*/ IncrementClutNum(RECT *clut /*$a0*/)
  // line 116, offset 0x00080ddc
 	/* begin block 1 */
 		// Start line: 1163
@@ -116,7 +116,7 @@ void IncrementClutNum(RECT16 *clut)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ IncrementTPageNum(struct RECT *tpage /*$t0*/)
+// void /*$ra*/ IncrementTPageNum(RECT *tpage /*$t0*/)
  // line 126, offset 0x00080528
 	/* begin block 1 */
 		// Start line: 127
@@ -175,7 +175,7 @@ void IncrementTPageNum(RECT16 *tpage)
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ LoadTPageAndCluts(struct RECT *tpage /*$s5*/, struct RECT *cluts /*$s2*/, int tpage2send /*$s6*/, char *tpageaddress /*$s0*/)
+// int /*$ra*/ LoadTPageAndCluts(RECT *tpage /*$s5*/, RECT *cluts /*$s2*/, int tpage2send /*$s6*/, char *tpageaddress /*$s0*/)
  // line 155, offset 0x00080e14
 	/* begin block 1 */
 		// Start line: 156
@@ -183,7 +183,7 @@ void IncrementTPageNum(RECT16 *tpage)
 		// Variables:
 	// 		int i; // $s3
 	// 		int npalettes; // $s4
-	// 		struct RECT temptpage; // stack offset -40
+	// 		RECT temptpage; // stack offset -40
 	/* end block 1 */
 	// End offset: 0x00080F3C
 	// End Line: 185
@@ -256,7 +256,7 @@ int LoadTPageAndCluts(RECT16 *tpage, RECT16 *cluts, int tpage2send, char *tpagea
 
 // decompiled code
 // original method signature: 
-// int /*$ra*/ Find_TexID(struct MODEL *model /*$t0*/, int t_id /*$a1*/)
+// int /*$ra*/ Find_TexID(MODEL *model /*$t0*/, int t_id /*$a1*/)
  // line 191, offset 0x000805ec
 	/* begin block 1 */
 		// Start line: 192
@@ -366,7 +366,7 @@ int Find_TexID(MODEL *model, int t_id)
 
 // decompiled code
 // original method signature: 
-// struct TEXINF * /*$ra*/ GetTEXINFName(char *name /*$fp*/, int *tpagenum /*stack 4*/, int *texturenum /*stack 8*/)
+// TEXINF * /*$ra*/ GetTEXINFName(char *name /*$fp*/, int *tpagenum /*stack 4*/, int *texturenum /*stack 8*/)
  // line 261, offset 0x00080f3c
 	/* begin block 1 */
 		// Start line: 262
@@ -375,7 +375,7 @@ int Find_TexID(MODEL *model, int t_id)
 	// 		int i; // $s4
 	// 		int j; // $s1
 	// 		int texamt; // $s2
-	// 		struct TEXINF *texinf; // $s3
+	// 		TEXINF *texinf; // $s3
 	// 		char *nametable; // $s6
 	/* end block 1 */
 	// End offset: 0x00081038
@@ -429,7 +429,7 @@ TEXINF* GetTEXINFName(char *name, int *tpagenum, int *texturenum)
 
 // decompiled code
 // original method signature: 
-// struct TEXINF * /*$ra*/ GetTextureInfoName(char *name /*$a0*/, struct TPAN *result /*$s0*/)
+// TEXINF * /*$ra*/ GetTextureInfoName(char *name /*$a0*/, TPAN *result /*$s0*/)
  // line 290, offset 0x00080da0
 	/* begin block 1 */
 		// Start line: 291
@@ -465,7 +465,7 @@ TEXINF* GetTextureInfoName(char *name, TPAN *result)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ update_slotinfo(int tpage /*$a0*/, int slot /*$a1*/, struct RECT *pos /*$a2*/)
+// void /*$ra*/ update_slotinfo(int tpage /*$a0*/, int slot /*$a1*/, RECT *pos /*$a2*/)
  // line 334, offset 0x00081038
 	/* begin block 1 */
 		// Start line: 1606
@@ -778,8 +778,8 @@ void LoadPermanentTPages(int *sector)
 		// Start line: 580
 		// Start offset: 0x00081118
 		// Variables:
-	// 		struct RECT tpage; // stack offset -88
-	// 		struct RECT clutpos; // stack offset -80
+	// 		RECT tpage; // stack offset -88
+	// 		RECT clutpos; // stack offset -80
 	// 		char name[64]; // stack offset -72
 	/* end block 1 */
 	// End offset: 0x00081140
@@ -818,7 +818,7 @@ void ReloadIcons(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetTextureDetails(char *name /*stack 0*/, struct TEXTURE_DETAILS *info /*$s3*/)
+// void /*$ra*/ GetTextureDetails(char *name /*stack 0*/, TEXTURE_DETAILS *info /*$s3*/)
  // line 602, offset 0x00080bb0
 	/* begin block 1 */
 		// Start line: 603
@@ -827,7 +827,7 @@ void ReloadIcons(void)
 	// 		int i; // $s2
 	// 		int j; // $s1
 	// 		int texamt; // $s4
-	// 		struct TEXINF *texinf; // $v1
+	// 		TEXINF *texinf; // $v1
 	// 		char *nametable; // stack offset -56
 	/* end block 1 */
 	// End offset: 0x00080D70

--- a/src_rebuild/GAME/C/TILE.C
+++ b/src_rebuild/GAME/C/TILE.C
@@ -11,7 +11,7 @@
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ Tile1x1(struct MODEL *model /*$a0*/)
+// void /*$ra*/ Tile1x1(MODEL *model /*$a0*/)
  // line 79, offset 0x00041b10
 	/* begin block 1 */
 		// Start line: 80
@@ -19,8 +19,8 @@
 		// Variables:
 	// 		int i; // $t3
 	// 		unsigned char *polys; // $t0
-	// 		struct SVECTOR *verts; // $t1
-	// 		struct POLY_FT4 *prims; // $a2
+	// 		SVECTOR *verts; // $t1
+	// 		POLY_FT4 *prims; // $a2
 	// 		unsigned long clut; // $t6
 	// 		unsigned long tpage; // $a1
 
@@ -177,7 +177,7 @@ void Tile1x1(MODEL *model)
 			// Start line: 208
 			// Start offset: 0x00041EBC
 			// Variables:
-		// 		struct PACKED_CELL_OBJECT **tilePointers; // $s3
+		// 		PACKED_CELL_OBJECT **tilePointers; // $s3
 		// 		int previous_matrix; // $s4
 
 			/* begin block 1.2.1 */
@@ -192,7 +192,7 @@ void Tile1x1(MODEL *model)
 					// Start offset: 0x00041F34
 					// Variables:
 				// 		int yang; // $a1
-				// 		struct PACKED_CELL_OBJECT *ppco; // $a0
+				// 		PACKED_CELL_OBJECT *ppco; // $a0
 				/* end block 1.2.1.1 */
 				// End offset: 0x00041FB8
 				// End Line: 241
@@ -201,7 +201,7 @@ void Tile1x1(MODEL *model)
 					// Start line: 270
 					// Start offset: 0x0004202C
 					// Variables:
-				// 		struct MODEL *model; // $a0
+				// 		MODEL *model; // $a0
 				/* end block 1.2.1.2 */
 				// End offset: 0x00042060
 				// End Line: 279
@@ -326,7 +326,7 @@ void DrawTILES(PACKED_CELL_OBJECT** tiles, int tile_amount)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ makeMesh(struct MVERTEX (*VSP)[5][5] /*$t4*/, int m /*$t2*/, int n /*$a2*/)
+// void /*$ra*/ makeMesh(MVERTEX (*VSP)[5][5] /*$t4*/, int m /*$t2*/, int n /*$a2*/)
  // line 292, offset 0x000420b0
 	/* begin block 1 */
 		// Start line: 293
@@ -646,7 +646,7 @@ void makeMesh(MVERTEX(*VSP)[5][5], int m, int n)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ drawMesh(struct MVERTEX (*VSP)[5][5] /*$s2*/, int m /*$s3*/, int n /*$s1*/, struct _pct *pc /*$a3*/)
+// void /*$ra*/ drawMesh(MVERTEX (*VSP)[5][5] /*$s2*/, int m /*$s3*/, int n /*$s1*/, plotContext *pc /*$a3*/)
  // line 359, offset 0x00042650
 	/* begin block 1 */
 		// Start line: 360
@@ -654,7 +654,7 @@ void makeMesh(MVERTEX(*VSP)[5][5], int m, int n)
 		// Variables:
 	// 		int j; // $t6
 	// 		int k; // $t9
-	// 		struct POLY_FT4 *prims; // $t1
+	// 		POLY_FT4 *prims; // $t1
 
 		/* begin block 1.1 */
 			// Start line: 370
@@ -662,7 +662,7 @@ void makeMesh(MVERTEX(*VSP)[5][5], int m, int n)
 			// Variables:
 		// 		int Z1; // stack offset -24
 		// 		int Z2; // stack offset -20
-		// 		struct MVERTEX (*VST)[5][5]; // $t2
+		// 		MVERTEX (*VST)[5][5]; // $t2
 		// 		long *ot; // $t7
 
 			/* begin block 1.1.1 */
@@ -780,17 +780,17 @@ void drawMesh(MVERTEX(*VSP)[5][5], int m, int n, _pct *pc)
 		// Start line: 490
 		// Start offset: 0x00042AEC
 		// Variables:
-	// 		struct MVERTEX (*VSP)[5][5]; // $t3
-	// 		struct _pct *pc; // $t2
+	// 		MVERTEX (*VSP)[5][5]; // $t3
+	// 		plotContext *pc; // $t2
 
 		/* begin block 1.1 */
 			// Start line: 490
 			// Start offset: 0x00042AEC
 			// Variables:
 		// 		unsigned long indices; // $a0
-		// 		struct SVECTOR *v0; // $t1
-		// 		struct SVECTOR *v1; // $a1
-		// 		struct SVECTOR *v2; // $t0
+		// 		SVECTOR *v0; // $t1
+		// 		SVECTOR *v1; // $a1
+		// 		SVECTOR *v2; // $t0
 		/* end block 1.1 */
 		// End offset: 0x00042AEC
 		// End Line: 490
@@ -879,7 +879,7 @@ void SubdivNxM(char *polys, ulong n, ulong m, int ofse)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ TileNxN(struct MODEL *model /*$s4*/, int levels /*$s2*/, int Dofse /*$s6*/)
+// void /*$ra*/ TileNxN(MODEL *model /*$s4*/, int levels /*$s2*/, int Dofse /*$s6*/)
  // line 581, offset 0x00042f40
 	/* begin block 1 */
 		// Start line: 582

--- a/src_rebuild/GAME/C/TILE.H
+++ b/src_rebuild/GAME/C/TILE.H
@@ -1,17 +1,17 @@
 #ifndef TILE_H
 #define TILE_H
 
-extern void Tile1x1(struct MODEL *model); // 0x00041B10
+extern void Tile1x1(MODEL *model); // 0x00041B10
 
 extern void DrawTILES(PACKED_CELL_OBJECT** tiles, int tile_amount); // 0x00041D7C
 
-extern void makeMesh(struct MVERTEX (*VSP)[5][5], int m, int n); // 0x000420B0
+extern void makeMesh(MVERTEX (*VSP)[5][5], int m, int n); // 0x000420B0
 
-extern void drawMesh(struct MVERTEX (*VSP)[5][5], int m, int n, struct _pct *pc); // 0x00042650
+extern void drawMesh(MVERTEX (*VSP)[5][5], int m, int n, _pct *pc); // 0x00042650
 
 extern void SubdivNxM(char *polys, unsigned long n, unsigned long m, int ofse); // 0x00042AEC
 
-extern void TileNxN(struct MODEL *model, int levels, int Dofse); // 0x00042F40
+extern void TileNxN(MODEL *model, int levels, int Dofse); // 0x00042F40
 
 extern void ProcessSubDivisionLump(char *lump_ptr, int lump_size); // 0x00042F34
 

--- a/src_rebuild/GAME/C/WHEELFORCES.C
+++ b/src_rebuild/GAME/C/WHEELFORCES.C
@@ -37,8 +37,8 @@ _HANDLING_TYPE handlingType[7] =
 		// Start line: 68
 		// Start offset: 0x00082BD0
 		// Variables:
-	// 		struct _CAR_DATA **ppCar; // $s0
-	// 		struct _CAR_DATA **end; // $s1
+	// 		CAR_DATA **ppCar; // $s0
+	// 		CAR_DATA **end; // $s1
 
 		/* begin block 1.1 */
 			// Start line: 73
@@ -82,8 +82,8 @@ _HANDLING_TYPE handlingType[7] =
 // [D] [T]
 void StepCars(void)
 {
-	_CAR_DATA** ppCar;
-	_CAR_DATA** end;
+	CAR_DATA** ppCar;
+	CAR_DATA** end;
 
 	ppCar = active_car_list;
 	end = active_car_list + num_active_cars;
@@ -100,17 +100,17 @@ void StepCars(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ StepOneCar(struct _CAR_DATA *cp /*$s1*/)
+// void /*$ra*/ StepOneCar(CAR_DATA *cp /*$s1*/)
  // line 98, offset 0x00081178
 	/* begin block 1 */
 		// Start line: 99
 		// Start offset: 0x00081178
 		// Variables:
-	// 		struct CAR_LOCALS _cl; // stack offset -248
-	// 		struct CAR_LOCALS *cl; // $s3
+	// 		CAR_LOCALS _cl; // stack offset -248
+	// 		CAR_LOCALS *cl; // $s3
 	// 		int i; // $s0
 	// 		int speed; // $v1
-	// 		struct _sdPlane *SurfacePtr; // stack offset -48
+	// 		sdPlane *SurfacePtr; // stack offset -48
 
 		/* begin block 1.1 */
 			// Start line: 122
@@ -132,7 +132,7 @@ void StepCars(void)
 		// 		int lift; // $s5
 		// 		int count; // $a0
 		// 		int friToUse; // $s6
-		// 		struct SVECTOR *carDisp; // $a1
+		// 		SVECTOR *carDisp; // $a1
 
 			/* begin block 1.2.1 */
 				// Start line: 156
@@ -187,7 +187,7 @@ void StepCars(void)
 						// Start line: 237
 						// Start offset: 0x000816CC
 						// Variables:
-					// 		struct VECTOR direction; // stack offset -80
+					// 		VECTOR direction; // stack offset -80
 					/* end block 1.2.2.3.1 */
 					// End offset: 0x000816CC
 					// End Line: 237
@@ -196,7 +196,7 @@ void StepCars(void)
 						// Start line: 242
 						// Start offset: 0x0008170C
 						// Variables:
-					// 		struct VECTOR direction; // stack offset -64
+					// 		VECTOR direction; // stack offset -64
 					/* end block 1.2.2.3.2 */
 					// End offset: 0x00081744
 					// End Line: 244
@@ -211,7 +211,7 @@ void StepCars(void)
 				// Start line: 256
 				// Start offset: 0x0008186C
 				// Variables:
-			// 		struct VECTOR offset; // stack offset -112
+			// 		VECTOR offset; // stack offset -112
 			/* end block 1.2.3 */
 			// End offset: 0x00081944
 			// End Line: 269
@@ -235,7 +235,7 @@ void StepCars(void)
 int impulse;
 
 // [D] [T]
-void StepOneCar(_CAR_DATA* cp)
+void StepOneCar(CAR_DATA* cp)
 {
 	static int frictionLimit[6] = {
 		0x3ED000, 0x178E000,
@@ -258,7 +258,7 @@ void StepOneCar(_CAR_DATA* cp)
 	long lever[4];
 	long reaction[4];
 	VECTOR direction;
-	_sdPlane* SurfacePtr;
+	sdPlane* SurfacePtr;
 
 	if (cp->controlType == CONTROL_TYPE_NONE)
 		return;
@@ -463,13 +463,13 @@ void StepOneCar(_CAR_DATA* cp)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ GetFrictionScalesDriver1(struct _CAR_DATA *cp /*$t0*/, struct CAR_LOCALS *cl /*$a1*/, int *frontFS /*$a2*/, int *rearFS /*$a3*/)
+// void /*$ra*/ GetFrictionScalesDriver1(CAR_DATA *cp /*$t0*/, CAR_LOCALS *cl /*$a1*/, int *frontFS /*$a2*/, int *rearFS /*$a3*/)
  // line 288, offset 0x0008198c
 	/* begin block 1 */
 		// Start line: 289
 		// Start offset: 0x0008198C
 		// Variables:
-	// 		struct _HANDLING_TYPE *hp; // $t2
+	// 		_HANDLING_TYPE *hp; // $t2
 
 		/* begin block 1.1 */
 			// Start line: 306
@@ -503,7 +503,7 @@ void StepOneCar(_CAR_DATA* cp)
 	// End Line: 808
 
 // [D] [T]
-void GetFrictionScalesDriver1(_CAR_DATA* cp, CAR_LOCALS* cl, int* frontFS, int* rearFS)
+void GetFrictionScalesDriver1(CAR_DATA* cp, CAR_LOCALS* cl, int* frontFS, int* rearFS)
 {
 	unsigned char bVar1;
 	int autoBrake;
@@ -625,7 +625,7 @@ void GetFrictionScalesDriver1(_CAR_DATA* cp, CAR_LOCALS* cl, int* frontFS, int* 
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ ConvertTorqueToAngularAcceleration(struct _CAR_DATA *cp /*$a0*/, struct CAR_LOCALS *cl /*$t5*/)
+// void /*$ra*/ ConvertTorqueToAngularAcceleration(CAR_DATA *cp /*$a0*/, CAR_LOCALS *cl /*$t5*/)
  // line 412, offset 0x00081e20
 	/* begin block 1 */
 		// Start line: 413
@@ -661,7 +661,7 @@ void GetFrictionScalesDriver1(_CAR_DATA* cp, CAR_LOCALS* cl, int* frontFS, int* 
 	// End Line: 1066
 
 // [D] [T]
-void ConvertTorqueToAngularAcceleration(_CAR_DATA* cp, CAR_LOCALS* cl)
+void ConvertTorqueToAngularAcceleration(CAR_DATA* cp, CAR_LOCALS* cl)
 {
 	int twistY;
 	int twistZ;
@@ -690,7 +690,7 @@ void ConvertTorqueToAngularAcceleration(_CAR_DATA* cp, CAR_LOCALS* cl)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ AddWheelForcesDriver1(struct _CAR_DATA *cp /*$s2*/, struct CAR_LOCALS *cl /*$s7*/)
+// void /*$ra*/ AddWheelForcesDriver1(CAR_DATA *cp /*$s2*/, CAR_LOCALS *cl /*$s7*/)
  // line 442, offset 0x00081f50
 	/* begin block 1 */
 		// Start line: 443
@@ -706,8 +706,8 @@ void ConvertTorqueToAngularAcceleration(_CAR_DATA* cp, CAR_LOCALS* cl)
 	// 		int sdx; // stack offset -72
 	// 		int sdz; // stack offset -68
 	// 		int friction_coef; // $s6
-	// 		struct CAR_COSMETICS *car_cos; // stack offset -64
-	// 		struct _sdPlane *SurfacePtr; // stack offset -88
+	// 		CAR_COSMETICS *car_cos; // stack offset -64
+	// 		sdPlane *SurfacePtr; // stack offset -88
 	// 		int player_id; // stack offset -60
 
 		/* begin block 1.1 */
@@ -743,7 +743,7 @@ void ConvertTorqueToAngularAcceleration(_CAR_DATA* cp, CAR_LOCALS* cl)
 				// Start line: 537
 				// Start offset: 0x00082380
 				// Variables:
-			// 		struct VECTOR force; // stack offset -128
+			// 		VECTOR force; // stack offset -128
 			// 		long pointVel[4]; // stack offset -112
 			// 		int lfx; // $a2
 			// 		int lfz; // $t2
@@ -797,7 +797,7 @@ void ConvertTorqueToAngularAcceleration(_CAR_DATA* cp, CAR_LOCALS* cl)
 	// End Line: 1173
 
 // [D] [T]
-void AddWheelForcesDriver1(_CAR_DATA* cp, CAR_LOCALS* cl)
+void AddWheelForcesDriver1(CAR_DATA* cp, CAR_LOCALS* cl)
 {
 	int oldCompression;
 	int dir;
@@ -820,7 +820,7 @@ void AddWheelForcesDriver1(_CAR_DATA* cp, CAR_LOCALS* cl)
 	long pointVel[4];
 	int frontFS;
 	int rearFS;
-	_sdPlane* SurfacePtr;
+	sdPlane* SurfacePtr;
 	int i;
 	int cdx;
 	int cdz;

--- a/src_rebuild/GAME/C/WHEELFORCES.C
+++ b/src_rebuild/GAME/C/WHEELFORCES.C
@@ -126,9 +126,9 @@ void StepCars(void)
 			// Start line: 133
 			// Start offset: 0x0008127C
 			// Variables:
-		// 		long deepestNormal[4]; // stack offset -208
-		// 		long deepestLever[4]; // stack offset -192
-		// 		long deepestPoint[4]; // stack offset -176
+		// 		LONGVECTOR deepestNormal; // stack offset -208
+		// 		LONGVECTOR deepestLever; // stack offset -192
+		// 		LONGVECTOR deepestPoint; // stack offset -176
 		// 		int lift; // $s5
 		// 		int count; // $a0
 		// 		int friToUse; // $s6
@@ -138,10 +138,10 @@ void StepCars(void)
 				// Start line: 156
 				// Start offset: 0x00081314
 				// Variables:
-			// 		long pointPos[4]; // stack offset -160
-			// 		long surfacePoint[4]; // stack offset -144
-			// 		long surfaceNormal[4]; // stack offset -128
-			// 		long lever[4]; // stack offset -112
+			// 		LONGVECTOR pointPos; // stack offset -160
+			// 		LONGVECTOR surfacePoint; // stack offset -144
+			// 		LONGVECTOR surfaceNormal; // stack offset -128
+			// 		LONGVECTOR lever; // stack offset -112
 			// 		int newLift; // $a0
 			/* end block 1.2.1 */
 			// End offset: 0x00081410
@@ -151,8 +151,8 @@ void StepCars(void)
 				// Start line: 201
 				// Start offset: 0x00081428
 				// Variables:
-			// 		long pointVel[4]; // stack offset -112
-			// 		long reaction[4]; // stack offset -96
+			// 		LONGVECTOR pointVel; // stack offset -112
+			// 		LONGVECTOR reaction; // stack offset -96
 			// 		int strikeVel; // $a2
 			// 		int componant; // $t3
 			// 		static int frictionLimit[6]; // offset 0x0
@@ -249,14 +249,14 @@ void StepOneCar(CAR_DATA* cp)
 	int a, b, speed;
 	int count, i;
 	CAR_LOCALS _cl;
-	long deepestNormal[4];
-	long deepestLever[4];
-	long deepestPoint[4];
-	long pointPos[4];
-	long surfacePoint[4];
-	long surfaceNormal[4];
-	long lever[4];
-	long reaction[4];
+	LONGVECTOR deepestNormal;
+	LONGVECTOR deepestLever;
+	LONGVECTOR deepestPoint;
+	LONGVECTOR pointPos;
+	LONGVECTOR surfacePoint;
+	LONGVECTOR surfaceNormal;
+	LONGVECTOR lever;
+	LONGVECTOR reaction;
 	VECTOR direction;
 	sdPlane* SurfacePtr;
 
@@ -631,7 +631,7 @@ void GetFrictionScalesDriver1(CAR_DATA* cp, CAR_LOCALS* cl, int* frontFS, int* r
 		// Start line: 413
 		// Start offset: 0x00081E20
 		// Variables:
-	// 		long nose[4]; // stack offset -16
+	// 		LONGVECTOR nose; // stack offset -16
 	// 		int zd; // $a3
 	// 		int i; // $t4
 	// 		int twistY; // $t0
@@ -717,9 +717,9 @@ void ConvertTorqueToAngularAcceleration(CAR_DATA* cp, CAR_LOCALS* cl)
 		// 		int oldCompression; // $s5
 		// 		int newCompression; // $s3
 		// 		int susForce; // $s0
-		// 		long wheelPos[4]; // stack offset -176
-		// 		long surfacePoint[4]; // stack offset -160
-		// 		long surfaceNormal[4]; // stack offset -144
+		// 		LONGVECTOR wheelPos; // stack offset -176
+		// 		LONGVECTOR surfacePoint; // stack offset -160
+		// 		LONGVECTOR surfaceNormal; // stack offset -144
 
 			/* begin block 1.1.1 */
 				// Start line: 488
@@ -744,7 +744,7 @@ void ConvertTorqueToAngularAcceleration(CAR_DATA* cp, CAR_LOCALS* cl)
 				// Start offset: 0x00082380
 				// Variables:
 			// 		VECTOR force; // stack offset -128
-			// 		long pointVel[4]; // stack offset -112
+			// 		LONGVECTOR pointVel; // stack offset -112
 			// 		int lfx; // $a2
 			// 		int lfz; // $t2
 			// 		int sidevel; // $t0
@@ -813,11 +813,11 @@ void AddWheelForcesDriver1(CAR_DATA* cp, CAR_LOCALS* cl)
 	int friction_coef;
 	int oldSpeed;
 	int wheelspd;
-	long wheelPos[4];
-	long surfacePoint[4];
-	long surfaceNormal[4];
+	LONGVECTOR wheelPos;
+	LONGVECTOR surfacePoint;
+	LONGVECTOR surfaceNormal;
 	VECTOR force;
-	long pointVel[4];
+	LONGVECTOR pointVel;
 	int frontFS;
 	int rearFS;
 	sdPlane* SurfacePtr;

--- a/src_rebuild/GAME/C/WHEELFORCES.H
+++ b/src_rebuild/GAME/C/WHEELFORCES.H
@@ -5,13 +5,13 @@ extern _HANDLING_TYPE handlingType[7];
 
 extern void StepCars(); // 0x00082BD0
 
-extern void StepOneCar(struct _CAR_DATA *cp); // 0x00081178
+extern void StepOneCar(CAR_DATA *cp); // 0x00081178
 
-extern void GetFrictionScalesDriver1(struct _CAR_DATA *cp, struct CAR_LOCALS *cl, int *frontFS, int *rearFS); // 0x0008198C
+extern void GetFrictionScalesDriver1(CAR_DATA *cp, CAR_LOCALS *cl, int *frontFS, int *rearFS); // 0x0008198C
 
-extern void ConvertTorqueToAngularAcceleration(struct _CAR_DATA *cp, struct CAR_LOCALS *cl); // 0x00081E20
+extern void ConvertTorqueToAngularAcceleration(CAR_DATA *cp, CAR_LOCALS *cl); // 0x00081E20
 
-extern void AddWheelForcesDriver1(struct _CAR_DATA *cp, struct CAR_LOCALS *cl); // 0x00081F50
+extern void AddWheelForcesDriver1(CAR_DATA *cp, CAR_LOCALS *cl); // 0x00081F50
 
 
 #endif

--- a/src_rebuild/GAME/C/XAPLAY.C
+++ b/src_rebuild/GAME/C/XAPLAY.C
@@ -88,7 +88,7 @@ void PrintXASubtitles()
 		// Start line: 129
 		// Start offset: 0x00082EC0
 		// Variables:
-	// 		struct CdlFILE fp; // stack offset -32
+	// 		CdlFILE fp; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x00082F18
 	// End Line: 144
@@ -123,7 +123,7 @@ void GetMissionXAData(int number)
 		// Start offset: 0x00082D60
 		// Variables:
 	// 		int i; // $s0
-	// 		struct CdlFILE fp; // stack offset -32
+	// 		CdlFILE fp; // stack offset -32
 	/* end block 1 */
 	// End offset: 0x00082DAC
 	// End Line: 167
@@ -295,8 +295,8 @@ void PrepareXA(void)
 		// Start line: 266
 		// Start offset: 0x00082C64
 		// Variables:
-	// 		struct CdlFILTER filt; // stack offset -40
-	// 		struct CdlLOC loc; // stack offset -32
+	// 		CdlFILTER filt; // stack offset -40
+	// 		CdlLOC loc; // stack offset -32
 	// 		unsigned char res[8]; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00082D48
@@ -549,7 +549,7 @@ void cbready(int intr, unsigned char *result)
 		// Start line: 388
 		// Start offset: 0x00082FC4
 		// Variables:
-	// 		struct CdlFILTER filt; // stack offset -32
+	// 		CdlFILTER filt; // stack offset -32
 	// 		unsigned char res[8]; // stack offset -24
 	/* end block 1 */
 	// End offset: 0x00083064

--- a/src_rebuild/GAME/DR2TYPES.H
+++ b/src_rebuild/GAME/DR2TYPES.H
@@ -80,23 +80,7 @@ struct GAP_INFO // hashcode: 0x468CC560 (dec: 1183630688)
 	char clear; // size=0, offset=4
 };
 
-struct PSXBUTTON // hashcode: 0x41BD456C (dec: 1102923116)
-{
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	short w; // size=0, offset=4
-	short h; // size=0, offset=6
-	unsigned char l; // size=0, offset=8
-	unsigned char r; // size=0, offset=9
-	unsigned char u; // size=0, offset=10
-	unsigned char d; // size=0, offset=11
-	int userDrawFunctionNum; // size=0, offset=12
-	short s_x; // size=0, offset=16
-	short s_y; // size=0, offset=18
-	int action; // size=0, offset=20
-	int var; // size=0, offset=24
-	char Name[32]; // size=32, offset=28
-};
+
 
 struct PADRECORD // hashcode: 0x0D20CEBD (dec: 220253885)
 {
@@ -157,14 +141,14 @@ struct DRIVER2_JUNCTION // hashcode: 0x7C27C3D0 (dec: 2082980816)
 	unsigned long flags; // size=0, offset=8
 };
 
-struct _sdPlane // hashcode: 0x873C357E (dec: -2026097282)
+typedef struct _sdPlane // hashcode: 0x873C357E (dec: -2026097282)
 {
 	short surface; // size=0, offset=0
 	short a; // size=0, offset=2
 	short b; // size=0, offset=4
 	short c; // size=0, offset=6
 	int d; // size=0, offset=8
-};
+} sdPlane;
 
 struct sdNodePACKED
 {
@@ -195,7 +179,7 @@ struct OrientedBox // hashcode: 0x8D87CFA2 (dec: -1920479326)
 	short length[3]; // size=6, offset=30
 };
 
-struct _HANDLING_DATA // hashcode: 0x9DD0BFD7 (dec: -1647263785)
+typedef struct _HANDLING_DATA // hashcode: 0x9DD0BFD7 (dec: -1647263785)
 {
 	MATRIX where; // size=32, offset=0
 	MATRIX drawCarMat; // size=32, offset=32
@@ -213,8 +197,8 @@ struct _HANDLING_DATA // hashcode: 0x9DD0BFD7 (dec: -1647263785)
 	VECTOR shadowPoints[4]; // size=64, offset=132
 	int front_vel; // size=0, offset=196
 	int rear_vel; // size=0, offset=200
-	struct OrientedBox oBox; // size=36, offset=204
-};
+	OrientedBox oBox; // size=36, offset=204
+} HANDLING_DATA;
 
 union RigidBodyState // Hashcode: 0x60B16C22 (dec: 1622240290)
 {
@@ -227,10 +211,59 @@ union RigidBodyState // Hashcode: 0x60B16C22 (dec: 1622240290)
 	} n; // size=52, offset=0, found in object files: obj\dr2roads.obj, obj\dr2roads.obj
 };
 
-struct _APPEARANCE_DATA // hashcode: 0x4A050E31 (dec: 1241845297)
+struct CAR_POLY // hashcode: 0x6DD9D398 (dec: 1842992024)
 {
-	struct SXYPAIR light_trails[4][4]; // size=64, offset=0
-	struct CAR_COSMETICS* carCos; // size=236, offset=64
+	int vindices; // size=0, offset=0
+	int nindices; // size=0, offset=4
+	int clut_uv0; // size=0, offset=8
+	int tpage_uv1; // size=0, offset=12
+	int uv3_uv2; // size=0, offset=16
+	short originalindex; // size=0, offset=20
+};
+
+struct CAR_MODEL // hashcode: 0xE3A253F1 (dec: -475900943)
+{
+	int numFT3; // size=0, offset=0
+	CAR_POLY* pFT3; // size=24, offset=4
+	int numGT3; // size=0, offset=8
+	CAR_POLY* pGT3; // size=24, offset=12
+	int numB3; // size=0, offset=16
+	CAR_POLY* pB3; // size=24, offset=20
+	SVECTOR* vlist; // size=8, offset=24
+	SVECTOR* nlist; // size=8, offset=28
+};
+
+struct CAR_COSMETICS // hashcode: 0x48DDA5C0 (dec: 1222485440)
+{
+	SVECTOR headLight; // size=8, offset=0
+	SVECTOR frontInd; // size=8, offset=8
+	SVECTOR backInd; // size=8, offset=16
+	SVECTOR brakeLight; // size=8, offset=24
+	SVECTOR revLight; // size=8, offset=32
+	SVECTOR policeLight; // size=8, offset=40
+	SVECTOR exhaust; // size=8, offset=48
+	SVECTOR smoke; // size=8, offset=56
+	SVECTOR fire; // size=8, offset=64
+	SVECTOR wheelDisp[4]; // size=32, offset=72
+	short extraInfo; // size=0, offset=104
+	short powerRatio; // size=0, offset=106
+	short cbYoffset; // size=0, offset=108
+	short susCoeff; // size=0, offset=110
+	short traction; // size=0, offset=112
+	short wheelSize; // size=0, offset=114
+	SVECTOR cPoints[12]; // size=96, offset=116
+	SVECTOR colBox; // size=8, offset=212
+	SVECTOR cog; // size=8, offset=220
+	short twistRateX; // size=0, offset=228
+	short twistRateY; // size=0, offset=230
+	short twistRateZ; // size=0, offset=232
+	short mass; // size=0, offset=234
+};
+
+typedef struct _APPEARANCE_DATA // hashcode: 0x4A050E31 (dec: 1241845297)
+{
+	SXYPAIR light_trails[4][4]; // size=64, offset=0
+	CAR_COSMETICS* carCos; // size=236, offset=64
 	short old_clock[4]; // size=8, offset=68
 	char life; // size=0, offset=76
 	char coplife; // size=0, offset=77
@@ -244,7 +277,7 @@ struct _APPEARANCE_DATA // hashcode: 0x4A050E31 (dec: 1241845297)
 	char flags : 7;			// [A] new: appearance flags, 1,2,3,4 = wheel hubcaps lost
 
 	short damage[6]; // size=12, offset=86
-};
+} APPEARANCE_DATA;
 
 struct CIV_ROUTE_ENTRY // hashcode: 0x7DE1E25F (dec: 2111955551)
 {
@@ -259,7 +292,7 @@ struct CIV_STATE // hashcode: 0x1B69CC52 (dec: 459918418)
 {
 	int currentRoad; // size=0, offset=0
 	int currentNode; // size=0, offset=4
-	struct CIV_ROUTE_ENTRY* ctrlNode; // size=16, offset=8
+	CIV_ROUTE_ENTRY* ctrlNode; // size=16, offset=8
 	unsigned char ctrlState; // size=0, offset=12
 	unsigned char trafficLightPhaseId; // size=0, offset=13
 	unsigned char changeLane; // size=0, offset=14
@@ -272,8 +305,8 @@ struct CIV_STATE // hashcode: 0x1B69CC52 (dec: 459918418)
 	int changeLaneIndicateCount; // size=0, offset=24
 	int carPauseCnt; // size=0, offset=28
 	int velRatio; // size=0, offset=32
-	struct CIV_ROUTE_ENTRY targetRoute[13]; // size=208, offset=36
-	struct CIV_ROUTE_ENTRY* pnode; // size=16, offset=244
+	CIV_ROUTE_ENTRY targetRoute[13]; // size=208, offset=36
+	CIV_ROUTE_ENTRY* pnode; // size=16, offset=244
 	unsigned char maxSpeed; // size=0, offset=248
 	unsigned char thrustState; // size=0, offset=249
 	unsigned char carMustDie; // size=0, offset=250
@@ -282,7 +315,7 @@ struct CIV_STATE // hashcode: 0x1B69CC52 (dec: 459918418)
 
 struct COP // hashcode: 0x03D1B2C7 (dec: 64074439)
 {
-	struct VECTOR2 targetHistory[2]; // size=16, offset=0
+	VECTOR2 targetHistory[2]; // size=16, offset=0
 	char routeInMemory; // size=0, offset=16
 	char justPinged; // size=0, offset=17
 	char close_pursuit; // size=0, offset=18
@@ -352,18 +385,18 @@ enum ECarControlFlags
 
 typedef struct _CAR_DATA // hashcode: 0x8D78CB99 (dec: -1921463399)
 {
-	struct _HANDLING_DATA hd; // size=240, offset=0
-	union RigidBodyState st; // size=52, offset=240
-	struct _APPEARANCE_DATA ap; // size=100, offset=292
+	HANDLING_DATA hd; // size=240, offset=0
+	RigidBodyState st; // size=52, offset=240
+	APPEARANCE_DATA ap; // size=100, offset=292
 	unsigned char hndType; // size=0, offset=392
 	unsigned char controlType; // size=0, offset=393
 	unsigned char controlFlags; // size=0, offset=394
 	char id; // size=0, offset=395
 	union {
 		char* padid; // size=0, offset=0
-		struct CIV_STATE c; // size=252, offset=0
-		struct COP p; // size=40, offset=0
-		struct LEAD_CAR l; // size=104, offset=0
+		CIV_STATE c; // size=252, offset=0
+		COP p; // size=40, offset=0
+		LEAD_CAR l; // size=104, offset=0
 	} ai; // size=252, offset=396, found in object files: obj\dr2roads.obj, obj\dr2roads.obj
 	int* inform; // size=0, offset=648
 	short thrust; // size=0, offset=652
@@ -375,42 +408,15 @@ typedef struct _CAR_DATA // hashcode: 0x8D78CB99 (dec: -1921463399)
 	short wheel_angle; // size=0, offset=660
 	unsigned short totalDamage; // size=0, offset=662
 	long lastPad; // size=0, offset=664
-} _CAR_DATA;
+} CAR_DATA;
 
-struct CAR_COSMETICS // hashcode: 0x48DDA5C0 (dec: 1222485440)
-{
-	struct SVECTOR headLight; // size=8, offset=0
-	struct SVECTOR frontInd; // size=8, offset=8
-	struct SVECTOR backInd; // size=8, offset=16
-	struct SVECTOR brakeLight; // size=8, offset=24
-	struct SVECTOR revLight; // size=8, offset=32
-	struct SVECTOR policeLight; // size=8, offset=40
-	struct SVECTOR exhaust; // size=8, offset=48
-	struct SVECTOR smoke; // size=8, offset=56
-	struct SVECTOR fire; // size=8, offset=64
-	struct SVECTOR wheelDisp[4]; // size=32, offset=72
-	short extraInfo; // size=0, offset=104
-	short powerRatio; // size=0, offset=106
-	short cbYoffset; // size=0, offset=108
-	short susCoeff; // size=0, offset=110
-	short traction; // size=0, offset=112
-	short wheelSize; // size=0, offset=114
-	struct SVECTOR cPoints[12]; // size=96, offset=116
-	struct SVECTOR colBox; // size=8, offset=212
-	struct SVECTOR cog; // size=8, offset=220
-	short twistRateX; // size=0, offset=228
-	short twistRateY; // size=0, offset=230
-	short twistRateZ; // size=0, offset=232
-	short mass; // size=0, offset=234
-};
-
-struct _COP_DATA // hashcode: 0xDE3D2698 (dec: -566417768)
+typedef struct _COP_DATA // hashcode: 0xDE3D2698 (dec: -566417768)
 {
 	int speed; // size=0, offset=0
 	int power; // size=0, offset=4
 	int min; // size=0, offset=8
 	int max; // size=0, offset=12
-};
+} MS_COP_DATA;
 
 struct LEAD_PARAMETERS // hashcode: 0x5849B382 (dec: 1481225090)
 {
@@ -432,7 +438,7 @@ struct LEAD_PARAMETERS // hashcode: 0x5849B382 (dec: 1481225090)
 	int hWidth80Mul; // size=0, offset=60
 };
 
-struct _EVENT // hashcode: 0xDD197EB3 (dec: -585531725)
+typedef struct _EVENT // hashcode: 0xDD197EB3 (dec: -585531725)
 {
 	VECTOR position; // size=16, offset=0
 	short rotation; // size=0, offset=16
@@ -442,8 +448,8 @@ struct _EVENT // hashcode: 0xDD197EB3 (dec: -585531725)
 	short flags; // size=0, offset=28
 	short radius; // size=0, offset=30
 	int model; // size=0, offset=32
-	struct _EVENT* next; // size=40, offset=36
-};
+	_EVENT* next; // size=40, offset=36
+} EVENT;
 
 struct FixedEvent // hashcode: 0xF758406C (dec: -145211284)
 {
@@ -457,16 +463,16 @@ struct FixedEvent // hashcode: 0xF758406C (dec: -145211284)
 	short flags; // size=0, offset=28
 	short radius; // size=0, offset=30
 	int model; // size=0, offset=32
-	_EVENT* next; // size=40, offset=36
+	EVENT* next; // size=40, offset=36
 	char* modelName; // size=0, offset=40
 };
 
-struct MAPPING // hashcode: 0x46E5EAED (dec: 1189473005)
+typedef struct MAPPING // hashcode: 0x46E5EAED (dec: 1189473005)
 {
 	unsigned short button_lookup[16]; // size=32, offset=0
 	unsigned short swap_analog; // size=0, offset=32
 	unsigned short reserved1; // size=0, offset=34
-};
+} *LPMAPPING;
 
 struct SAVED_PLAYER_POS // hashcode: 0x3269504F (dec: 845762639)
 {
@@ -495,8 +501,8 @@ struct SAVED_CAR_POS // hashcode: 0x02E940CC (dec: 48840908)
 
 struct MISSION_DATA // hashcode: 0x2CE3A08C (dec: 753115276)
 {
-	struct SAVED_PLAYER_POS PlayerPos; // size=36, offset=0
-	struct SAVED_CAR_POS CarPos[6]; // size=192, offset=36
+	SAVED_PLAYER_POS PlayerPos; // size=36, offset=0
+	SAVED_CAR_POS CarPos[6]; // size=192, offset=36
 };
 
 struct SCORE_ENTRY // hashcode: 0xD0B3A6C6 (dec: -793532730)
@@ -508,11 +514,11 @@ struct SCORE_ENTRY // hashcode: 0xD0B3A6C6 (dec: -793532730)
 
 struct SCORE_TABLES // hashcode: 0xDB95702F (dec: -610963409)
 {
-	struct SCORE_ENTRY GetawayTable[4][2][5]; // size=480, offset=0
-	struct SCORE_ENTRY GateRaceTable[4][2][5]; // size=480, offset=480
-	struct SCORE_ENTRY CheckpointTable[4][2][5]; // size=480, offset=960
-	struct SCORE_ENTRY TrailblazerTable[4][2][5]; // size=480, offset=1440
-	struct SCORE_ENTRY SurvivalTable[4][1][5]; // size=240, offset=1920
+	SCORE_ENTRY GetawayTable[4][2][5]; // size=480, offset=0
+	SCORE_ENTRY GateRaceTable[4][2][5]; // size=480, offset=480
+	SCORE_ENTRY CheckpointTable[4][2][5]; // size=480, offset=960
+	SCORE_ENTRY TrailblazerTable[4][2][5]; // size=480, offset=1440
+	SCORE_ENTRY SurvivalTable[4][1][5]; // size=240, offset=1920
 };
 
 struct ACTIVE_CHEATS // hashcode: 0x2127EFE8 (dec: 556265448)
@@ -545,122 +551,21 @@ struct STREAM_SOURCE // hashcode: 0x81E93B6E (dec: -2115421330)
 	char controlType; // size=0, offset=3
 	unsigned short flags; // size=0, offset=4
 	unsigned short rotation; // size=0, offset=6
-	struct VECTOR_NOPAD position; // size=12, offset=8
+	VECTOR_NOPAD position; // size=12, offset=8
 	int totaldamage; // size=0, offset=20
 	int damage[6]; // size=24, offset=24
 };
 
-typedef struct RVECTOR RVECTOR;
-
-typedef struct CRVECTOR3 CRVECTOR3;
-
-typedef struct CRVECTOR4 CRVECTOR4;
-
-typedef struct SndVolume2 SndVolume2;
-
-typedef struct VECTOR_NOPAD VECTOR_NOPAD;
-
-typedef struct SVECTOR_NOPAD SVECTOR_NOPAD;
-
-typedef struct BOX BOX;
-
-typedef struct BSPHERE BSPHERE;
-
-typedef struct RGB RGB;
-
-typedef struct UV_INFO UV_INFO;
-
-typedef struct XYPAIR XYPAIR;
-
-typedef struct SXYPAIR SXYPAIR;
-
-typedef struct GAP_INFO GAP_INFO;
-
-typedef struct PSXBUTTON PSXBUTTON;
-
-typedef struct PADRECORD PADRECORD;
-
-typedef struct ARC_ENTRY ARC_ENTRY;
-
-typedef struct USVECTOR_NOPAD USVECTOR_NOPAD;
-
-typedef struct DRIVER2_STRAIGHT DRIVER2_STRAIGHT;
-
-typedef struct OLD_DRIVER2_JUNCTION OLD_DRIVER2_JUNCTION;
-
-typedef struct DRIVER2_JUNCTION DRIVER2_JUNCTION;
-
-typedef struct DRIVER2_CURVE DRIVER2_CURVE;
-
-typedef struct _sdPlane sdPlane;
-
-typedef struct CIV_ROUTE_ENTRY CIV_ROUTE_ENTRY;
-
-typedef struct CIV_STATE CIV_STATE;
-
-typedef struct CAR_COSMETICS CAR_COSMETICS;
-
-typedef struct VECTOR2 VECTOR2;
-
-typedef struct COP COP;
-
-typedef struct LEAD_CAR LEAD_CAR;
-
-typedef union RigidBodyState RigidBodyState;
-
-typedef struct WHEEL WHEEL;
-
-typedef struct OrientedBox OrientedBox;
-
-typedef struct _HANDLING_DATA HANDLING_DATA;
-
-typedef struct _APPEARANCE_DATA APPEARANCE_DATA;
-
-typedef struct _COP_DATA MS_COP_DATA;
-
-typedef struct LEAD_PARAMETERS LEAD_PARAMETERS;
-
-typedef struct _EVENT EVENT;
-
-typedef struct MAPPING MAPPING;
-
-typedef struct SAVED_PLAYER_POS SAVED_PLAYER_POS;
-
-typedef struct SAVED_CAR_POS SAVED_CAR_POS;
-
-typedef struct MISSION_DATA MISSION_DATA;
-
-typedef struct SCORE_ENTRY SCORE_ENTRY;
-
-typedef struct SCORE_TABLES SCORE_TABLES;
-
-typedef struct ACTIVE_CHEATS ACTIVE_CHEATS;
-
-typedef struct STREAM_SOURCE STREAM_SOURCE;
-
 typedef unsigned char u_char;
-
 typedef unsigned short u_short;
-
 typedef unsigned int u_int;
-
 typedef unsigned long u_long;
 
+typedef char schar;
+typedef unsigned char uchar;
 typedef unsigned short ushort;
-
-typedef struct _physadr* physadr;
-
-// typedef long daddr_t;
-
-typedef char* caddr_t;
-
-typedef long* qaddr_t;
-
-typedef long swblk_t;
-
-// typedef unsigned int size_t;
-
-typedef long off_t;
+typedef unsigned int uint;
+typedef unsigned long ulong;
 
 #ifndef __GNUC__
 typedef unsigned short uid_t;
@@ -670,20 +575,12 @@ typedef unsigned short gid_t;
 
 typedef void (*SsMarkCallbackProc)();
 
-typedef long LONGVECTOR[4];
-
 typedef short SHORTVECTOR[4];
 
+typedef long LONGVECTOR[4];
 typedef long LONGQUATERNION[4];
 
-typedef unsigned long ulong;
 
-
-typedef struct PADRAW* LPPADRAW;
-
-typedef struct MAPPING* LPMAPPING;
-
-typedef struct PAD* LPPAD;
 
 struct MODEL // hashcode: 0x3A42A4FE (dec: 977446142)
 {
@@ -727,7 +624,7 @@ struct UV // hashcode: 0xB11A813B (dec: -1323663045)
 
 struct TEXTURE_DETAILS // hashcode: 0xBFBD097F (dec: -1078130305)
 {
-	struct UV coords; // size=8, offset=0
+	UV coords; // size=8, offset=0
 	unsigned short tpageid; // size=0, offset=8
 	unsigned short clutid; // size=0, offset=10
 	char texture_number; // size=0, offset=12
@@ -736,7 +633,7 @@ struct TEXTURE_DETAILS // hashcode: 0xBFBD097F (dec: -1078130305)
 
 struct CELL_OBJECT // hashcode: 0xD26720D4 (dec: -764993324)
 {
-	struct VECTOR_NOPAD pos; // size=12, offset=0
+	VECTOR_NOPAD pos; // size=12, offset=0
 	unsigned char pad; // size=0, offset=12
 	unsigned char yang; // size=0, offset=13
 	unsigned short type; // size=0, offset=14
@@ -761,9 +658,9 @@ struct SMASHABLE_OBJECT // hashcode: 0x15B5F719 (dec: 364246809)
 
 struct GARAGE_DOOR // hashcode: 0x830EFAED (dec: -2096170259)
 {
-	struct CELL_OBJECT* cop; // size=16, offset=0
-	struct VECTOR_NOPAD old_pos; // size=12, offset=4
-	struct VECTOR_NOPAD pos; // size=12, offset=16
+	CELL_OBJECT* cop; // size=16, offset=0
+	VECTOR_NOPAD old_pos; // size=12, offset=4
+	VECTOR_NOPAD pos; // size=12, offset=16
 	short rotation; // size=0, offset=28
 	char yang; // size=0, offset=30
 };
@@ -886,7 +783,7 @@ struct MS_TARGET_EVENT
 	int loseMessage;	// data 14
 };
 
-struct _TARGET// hashcode: 0xB3C67F7D (dec: -1278836867)
+typedef struct _TARGET// hashcode: 0xB3C67F7D (dec: -1278836867)
 {
 	union
 	{
@@ -896,7 +793,7 @@ struct _TARGET// hashcode: 0xB3C67F7D (dec: -1278836867)
 		MS_TARGET_CAR car;
 		MS_TARGET_EVENT event;
 	};
-};
+} MS_TARGET;
 
 struct MR_TIMER // hashcode: 0xEA39F36E (dec: -365300882)
 {
@@ -937,17 +834,16 @@ enum PED_MODEL_TYPES : char // Hashcode: 0x2858A7E3 (dec: 676898787)
 	CIVILIAN = 3,
 };
 
-struct PEDESTRIAN;
-typedef void(*pedFunc)(PEDESTRIAN* pPed);
+typedef void(*pedFunc)(struct PEDESTRIAN* pPed);
 
-struct PEDESTRIAN // hashcode: 0xF569ED7C (dec: -177607300)
+typedef struct PEDESTRIAN // hashcode: 0xF569ED7C (dec: -177607300)
 {
 	PEDESTRIAN* pNext; // size=92, offset=0
 	PEDESTRIAN* pPrev; // size=92, offset=4
 	pedFunc fpRestState; // size=0, offset=8
 	pedFunc fpAgitatedState; // size=0, offset=12
 	char padId; // size=0, offset=16
-	enum PED_MODEL_TYPES pedType; // size=1, offset=17
+	PED_MODEL_TYPES pedType; // size=1, offset=17
 	VECTOR_NOPAD position; // size=12, offset=20
 	SVECTOR dir; // size=8, offset=32
 	SVECTOR velocity; // size=8, offset=40
@@ -965,21 +861,21 @@ struct PEDESTRIAN // hashcode: 0xF569ED7C (dec: -177607300)
 	char finished_turn; // size=0, offset=86
 	char seat_index; // size=0, offset=87
 	unsigned char pallet; // size=0, offset=88
-	enum PED_ACTION_TYPE type; // size=1, offset=89
-};
+	PED_ACTION_TYPE type; // size=1, offset=89
+} *LPPEDESTRIAN;
 
-struct __skidinfo // hashcode: 0x807ED49D (dec: -2139171683)
+typedef struct __skidinfo // hashcode: 0x807ED49D (dec: -2139171683)
 {
 	char chan; // size=0, offset=0
 	char sound; // size=0, offset=1
-};
+} skidinfo;
 
-struct __horninfo // hashcode: 0x09E3B159 (dec: 165917017)
+typedef struct __horninfo // hashcode: 0x09E3B159 (dec: 165917017)
 {
 	char on; // size=0, offset=0
 	char time; // size=0, offset=1
 	char request; // size=0, offset=2
-};
+} horninfo;
 
 struct CYCLE_OBJECT // hashcode: 0x61BB6061 (dec: 1639669857)
 {
@@ -993,106 +889,15 @@ struct CYCLE_OBJECT // hashcode: 0x61BB6061 (dec: 1639669857)
 	short stop2; // size=0, offset=16
 	short speed2; // size=0, offset=18
 };
-/*
-typedef struct DRAWENV DRAWENV;
-
-typedef struct DISPENV DISPENV;
-
-typedef struct DR_LOAD DR_LOAD;
-
-typedef struct MODEL MODEL;
-
-typedef enum PAUSEMODE PAUSEMODE;
-
-typedef struct UV UV;
-
-typedef struct TEXTURE_DETAILS TEXTURE_DETAILS;
-
-typedef struct CELL_OBJECT CELL_OBJECT;
-
-typedef struct ANIMATED_OBJECT ANIMATED_OBJECT;
-
-typedef struct SMASHABLE_OBJECT SMASHABLE_OBJECT;
-
-typedef struct GARAGE_DOOR GARAGE_DOOR;
-
-typedef struct RGB16 RGB16;
-
-typedef struct BVECTOR BVECTOR;
-
-typedef struct ADJACENT_ROAD_INFO ADJACENT_ROAD_INFO;
-
-typedef struct SpuVolume SpuVolume;
-
-typedef struct SpuVoiceAttr SpuVoiceAttr;
-
-typedef struct SpuExtAttr SpuExtAttr;
-
-typedef struct SpuStVoiceAttr SpuStVoiceAttr;
-
-typedef struct FELONY_DELAY FELONY_DELAY;
-
-typedef struct FELONY_VALUE FELONY_VALUE;
-*/
-
-/*
-typedef struct _TARGET MS_TARGET;
-
-typedef struct MR_TIMER MR_TIMER;
-
-typedef struct PEDESTRIAN PEDESTRIAN;
-
-typedef enum PED_ACTION_TYPE PED_ACTION_TYPE;
-
-typedef enum PED_MODEL_TYPES PED_MODEL_TYPES;
-
-typedef struct __skidinfo skidinfo;
-
-typedef struct __horninfo horninfo;
-
-typedef struct CYCLE_OBJECT CYCLE_OBJECT;
-
-typedef void (*SpuIRQCallbackProc)();
-
-typedef void (*SpuTransferCallbackProc)();
-
-typedef void (*SpuStCallbackProc)();
-
-typedef unsigned char uchar;
-
-typedef char schar;
-
-typedef unsigned int uint;
-
-typedef void envsoundfunc();
-
-typedef struct MVERTEX SV5x5[5][5];
-
-typedef struct PEDESTRIAN *LPPEDESTRIAN;
-
-typedef struct SEATED_PEDESTRIANS *SEATEDPTR;
-
-typedef struct PEDESTRIAN_ROADS *LPPEDESTRIAN_ROADS;
-*/
-
-struct CAR_POLY // hashcode: 0x6DD9D398 (dec: 1842992024)
-{
-	int vindices; // size=0, offset=0
-	int nindices; // size=0, offset=4
-	int clut_uv0; // size=0, offset=8
-	int tpage_uv1; // size=0, offset=12
-	int uv3_uv2; // size=0, offset=16
-	short originalindex; // size=0, offset=20
-};
 
 struct COLOUR_BAND // hashcode: 0x1D8D5AB8 (dec: 495803064)
 {
-	struct CVECTOR colour; // size=4, offset=0
+	CVECTOR colour; // size=4, offset=0
 	int value; // size=0, offset=4
 	int flags; // size=0, offset=8
 };
 
-struct _PERCENTAGE_BAR // hashcode: 0x56E8855E (dec: 1458079070)
+typedef struct _PERCENTAGE_BAR // hashcode: 0x56E8855E (dec: 1458079070)
 {
 	char* tag; // size=0, offset=0
 	short xpos; // size=0, offset=4
@@ -1101,25 +906,10 @@ struct _PERCENTAGE_BAR // hashcode: 0x56E8855E (dec: 1458079070)
 	short height; // size=0, offset=10
 	unsigned short position; // size=0, offset=12
 	unsigned short max; // size=0, offset=14
-	struct COLOUR_BAND* pColourBand; // size=12, offset=16
+	COLOUR_BAND* pColourBand; // size=12, offset=16
 	int flags; // size=0, offset=20
 	int active; // size=0, offset=24
-};
-/*
-typedef struct POLY_G4 POLY_G4;
-
-typedef struct TILE TILE;
-
-typedef struct DR_TPAGE DR_TPAGE;
-
-typedef struct CAR_POLY CAR_POLY;
-
-typedef struct COLOUR_BAND COLOUR_BAND;
-
-typedef struct _PERCENTAGE_BAR PERCENTAGE_BAR;
-
-typedef struct _PERCENTAGE_BAR *LPPERCENTAGE_BAR;
-*/
+} PERCENTAGE_BAR, *LPPERCENTAGE_BAR;
 
 struct COP_SIGHT_DATA // hashcode: 0x4400B303 (dec: 1140896515)
 {
@@ -1146,37 +936,11 @@ struct OVERMAP // hashcode: 0x34D52BCC (dec: 886385612)
 	unsigned char dummy; // size=0, offset=17
 	int scale; // size=0, offset=20
 };
-/*
-typedef struct POLY_F3 POLY_F3;
 
-typedef struct POLY_F4 POLY_F4;
-
-typedef struct POLY_FT3 POLY_FT3;
-
-typedef struct POLY_FT4 POLY_FT4;
-
-typedef struct POLY_G3 POLY_G3;
-
-typedef struct LINE_F2 LINE_F2;
-
-typedef struct LINE_G2 LINE_G2;
-
-typedef struct LINE_F4 LINE_F4;
-
-typedef struct TILE_1 TILE_1;
-
-typedef struct DR_AREA DR_AREA;
-
-typedef struct COP_SIGHT_DATA COP_SIGHT_DATA;
-
-typedef struct MAPTEX MAPTEX;
-
-typedef struct OVERMAP OVERMAP;
-*/
 struct REPLAY_PARAMETER_BLOCK // hashcode: 0xA8ABCA42 (dec: -1465136574)
 {
 	int RecordingEnd; // size=0, offset=0
-	struct VECTOR_NOPAD lead_car_start; // size=12, offset=4
+	VECTOR_NOPAD lead_car_start; // size=12, offset=4
 	short Lead_car_dir; // size=0, offset=16
 	unsigned char timeofday; // size=0, offset=18
 	unsigned char weather; // size=0, offset=19
@@ -1193,8 +957,8 @@ struct REPLAY_SAVE_HEADER // hashcode: 0x7B872BEC (dec: 2072456172)
 	unsigned char RandomChase; // size=0, offset=9
 	unsigned char CutsceneEvent; // size=0, offset=10
 	unsigned char gCopDifficultyLevel; // size=0, offset=11
-	struct MISSION_DATA SavedData; // size=228, offset=12
-	struct ACTIVE_CHEATS ActiveCheats; // size=4, offset=240
+	MISSION_DATA SavedData; // size=228, offset=12
+	ACTIVE_CHEATS ActiveCheats; // size=4, offset=240
 	int wantedCar[2]; // size=8, offset=244
 	int MissionNumber; // size=0, offset=252
 	int HaveStoredData; // size=0, offset=256
@@ -1203,39 +967,29 @@ struct REPLAY_SAVE_HEADER // hashcode: 0x7B872BEC (dec: 2072456172)
 
 struct REPLAY_STREAM_HEADER // hashcode: 0x7D77518E (dec: 2104971662)
 {
-	struct STREAM_SOURCE SourceType; // size=48, offset=0
+	STREAM_SOURCE SourceType; // size=48, offset=0
 	int Size; // size=0, offset=48
 	int Length; // size=0, offset=52
 };
 
 struct REPLAY_STREAM // hashcode: 0xC894D541 (dec: -929770175)
 {
-	struct STREAM_SOURCE SourceType; // size=48, offset=0
-	struct PADRECORD* InitialPadRecordBuffer; // size=3, offset=48
-	struct PADRECORD* PadRecordBuffer; // size=3, offset=52
-	struct PADRECORD* PadRecordBufferEnd; // size=3, offset=56
+	STREAM_SOURCE SourceType; // size=48, offset=0
+	PADRECORD* InitialPadRecordBuffer; // size=3, offset=48
+	PADRECORD* PadRecordBuffer; // size=3, offset=52
+	PADRECORD* PadRecordBufferEnd; // size=3, offset=56
 	unsigned char playbackrun; // size=0, offset=60
 	int length; // size=0, offset=64
 	int padCount;
 };
 
-struct _PING_PACKET // hashcode: 0x9E8E7C27 (dec: -1634829273)
+typedef struct _PING_PACKET // hashcode: 0x9E8E7C27 (dec: -1634829273)
 {
 	unsigned short frame; // size=0, offset=0
 	char carId; // size=0, offset=2
 	char cookieCount; // size=0, offset=3
-};
-/*
-typedef struct REPLAY_PARAMETER_BLOCK REPLAY_PARAMETER_BLOCK;
+} PING_PACKET;
 
-typedef struct REPLAY_SAVE_HEADER REPLAY_SAVE_HEADER;
-
-typedef struct REPLAY_STREAM_HEADER REPLAY_STREAM_HEADER;
-
-typedef struct REPLAY_STREAM REPLAY_STREAM;
-
-typedef struct _PING_PACKET PING_PACKET;
-*/
 struct ROADBLOCK // hashcode: 0x006C3CDD (dec: 7093469)
 {
 	VECTOR position; // size=16, offset=0
@@ -1252,16 +1006,12 @@ struct ROADBLOCK // hashcode: 0x006C3CDD (dec: 7093469)
 	char AI_Slot[13]; // size=13, offset=41
 };
 
-//typedef struct ROADBLOCK ROADBLOCK;
-
 struct TestResult // hashcode: 0x105A4D3D (dec: 274353469)
 {
 	int depth; // size=0, offset=0
 	VECTOR location; // size=16, offset=4
 	VECTOR normal; // size=16, offset=20
 };
-
-//typedef struct TestResult TestResult;
 
 struct BUILDING_BOX // hashcode: 0x6B53A728 (dec: 1800644392)
 {
@@ -1293,20 +1043,19 @@ struct CRET2D // hashcode: 0x0DF86D8D (dec: 234384781)
 	int neverfree; // size=0, offset=36
 };
 
-struct __tunnelcoords // hashcode: 0x7711175C (dec: 1997608796)
+typedef struct __tunnelcoords // hashcode: 0x7711175C (dec: 1997608796)
 {
 	VECTOR p1; // size=16, offset=0
 	VECTOR p2; // size=16, offset=16
-};
-/*
-typedef struct BUILDING_BOX BUILDING_BOX;
+} tunnelcoords;
 
-typedef struct CDATA2D CDATA2D;
+typedef struct __tunnelinfo // hashcode: 0xC172C5A2 (dec: -1049442910)
+{
+	char num_tunnels; // size=0, offset=0
+	char tunnel_cnt; // size=0, offset=1
+	tunnelcoords coords[29]; // size=928, offset=4
+} tunnelinfo;
 
-typedef struct CRET2D CRET2D;
-
-typedef struct __tunnelcoords tunnelcoords;
-*/
 enum ExplosionType // Hashcode: 0xD0FDC1E0 (dec: -788676128)
 {
 	BIG_BANG = 0,
@@ -1315,7 +1064,7 @@ enum ExplosionType // Hashcode: 0xD0FDC1E0 (dec: -788676128)
 	BANG_USED = 999,
 };
 
-struct _ExOBJECT // hashcode: 0x1D4ED61D (dec: 491705885)
+typedef struct _ExOBJECT // hashcode: 0x1D4ED61D (dec: 491705885)
 {
 	int time; // size=0, offset=0
 	int speed; // size=0, offset=4
@@ -1323,7 +1072,7 @@ struct _ExOBJECT // hashcode: 0x1D4ED61D (dec: 491705885)
 	int rscale; // size=0, offset=12
 	ExplosionType type; // size=2, offset=16
 	VECTOR pos; // size=16, offset=20
-};
+} EXOBJECT;
 
 struct BOMB // hashcode: 0x9EA608A2 (dec: -1633285982)
 {
@@ -1333,11 +1082,7 @@ struct BOMB // hashcode: 0x9EA608A2 (dec: -1633285982)
 	VECTOR position; // size=16, offset=4
 	VECTOR velocity; // size=16, offset=20
 };
-/*
-typedef struct _ExOBJECT EXOBJECT;
 
-typedef struct BOMB BOMB;
-*/
 struct COLLISION_PACKET // hashcode: 0x404603E7 (dec: 1078330343)
 {
 	short type; // size=0, offset=0
@@ -1352,7 +1097,7 @@ struct COLLISION_PACKET // hashcode: 0x404603E7 (dec: 1078330343)
 	short zsize; // size=0, offset=18
 };
 
-struct _PLAYER // hashcode: 0x8C0D3284 (dec: -1945292156)
+typedef struct _PLAYER // hashcode: 0x8C0D3284 (dec: -1945292156)
 {
 	long pos[4]; // size=16, offset=0
 	int dir; // size=0, offset=16
@@ -1378,15 +1123,15 @@ struct _PLAYER // hashcode: 0x8C0D3284 (dec: -1945292156)
 	char car_is_sounding; // size=0, offset=75
 	long camera_vel[3]; // size=12, offset=76
 	int snd_cam_ang; // size=0, offset=88
-	__skidinfo skidding; // size=2, offset=92
-	__skidinfo wheelnoise; // size=2, offset=94
-	__horninfo horn; // size=3, offset=96
+	skidinfo skidding; // size=2, offset=92
+	skidinfo wheelnoise; // size=2, offset=94
+	horninfo horn; // size=3, offset=96
 	int car_sound_timer; // size=0, offset=100
 	short revsvol; // size=0, offset=104
 	short idlevol; // size=0, offset=106
-	PEDESTRIAN* pPed; // size=92, offset=108
+	LPPEDESTRIAN pPed; // size=92, offset=108
 	int crash_timer; // size=0, offset=112
-};
+} PLAYER;
 
 struct XZPAIR // hashcode: 0x0F1AD091 (dec: 253415569)
 {
@@ -1401,11 +1146,11 @@ struct CELL_DATA // hashcode: 0x016E4A08 (dec: 24005128)
 
 struct PACKED_CELL_OBJECT // hashcode: 0x4109E18D (dec: 1091166605)
 {
-	struct USVECTOR_NOPAD pos; // size=6, offset=0
+	USVECTOR_NOPAD pos; // size=6, offset=0
 	unsigned short value; // size=0, offset=6
 };
 
-struct PAD // hashcode: 0x3E7349EB (dec: 1047742955)
+typedef struct PAD // hashcode: 0x3E7349EB (dec: 1047742955)
 {
 	unsigned char active; // size=0, offset=0
 	unsigned char type; // size=0, offset=1
@@ -1417,7 +1162,7 @@ struct PAD // hashcode: 0x3E7349EB (dec: 1047742955)
 	unsigned short mapped; // size=0, offset=12
 	unsigned short mapnew; // size=0, offset=14
 	char mapanalog[4]; // size=4, offset=16
-	struct MAPPING mappings; // size=36, offset=20
+	MAPPING mappings; // size=36, offset=20
 	unsigned char alarmShakeCounter; // size=0, offset=56
 	unsigned char asd; // size=0, offset=57
 	unsigned char sdf; // size=0, offset=58
@@ -1430,13 +1175,13 @@ struct PAD // hashcode: 0x3E7349EB (dec: 1047742955)
 	unsigned char motors[2]; // size=2, offset=68
 	unsigned char shake_type; // size=0, offset=70
 	unsigned char vibrate; // size=0, offset=71
-};
+} *LPPAD;
 
 struct CELL_ITERATOR // hashcode: 0x4C2A91BE (dec: 1277858238)
 {
-	struct CELL_DATA* pcd; // size=2, offset=0
-	struct PACKED_CELL_OBJECT* ppco; // size=8, offset=4
-	struct XZPAIR nearCell; // size=8, offset=8
+	CELL_DATA* pcd; // size=2, offset=0
+	PACKED_CELL_OBJECT* ppco; // size=8, offset=4
+	XZPAIR nearCell; // size=8, offset=8
 	int use_computed; // size=0, offset=16
 };
 
@@ -1452,19 +1197,7 @@ struct TEX_INFO // hashcode: 0x7C1A76C5 (dec: 2082109125)
 
 struct TEXTURE_LOOKUP // hashcode: 0x531E7A41 (dec: 1394506305)
 {
-	struct TEX_INFO(*Damage[6]); // size=24, offset=0
-};
-
-struct CAR_MODEL // hashcode: 0xE3A253F1 (dec: -475900943)
-{
-	int numFT3; // size=0, offset=0
-	struct CAR_POLY* pFT3; // size=24, offset=4
-	int numGT3; // size=0, offset=8
-	struct CAR_POLY* pGT3; // size=24, offset=12
-	int numB3; // size=0, offset=16
-	struct CAR_POLY* pB3; // size=24, offset=20
-	struct SVECTOR* vlist; // size=8, offset=24
-	struct SVECTOR* nlist; // size=8, offset=28
+	TEX_INFO(*Damage[6]); // size=24, offset=0
 };
 
 struct plotCarGlobals // hashcode: 0xED466FF8 (dec: -314150920)
@@ -1480,7 +1213,7 @@ struct plotCarGlobals // hashcode: 0xED466FF8 (dec: -314150920)
 	int ghost; // size=0, offset=32
 };
 
-struct _EXTRA_CIV_DATA // hashcode: 0x98F5BF74 (dec: -1728725132)
+typedef struct _EXTRA_CIV_DATA // hashcode: 0x98F5BF74 (dec: -1728725132)
 {
 	int surfInd; // size=0, offset=0
 	int distAlongSegment; // size=0, offset=4
@@ -1489,23 +1222,7 @@ struct _EXTRA_CIV_DATA // hashcode: 0x98F5BF74 (dec: -1728725132)
 	int thrustState; // size=0, offset=12
 	unsigned char palette; // size=0, offset=16
 	unsigned char controlFlags; // size=0, offset=17
-};
-
-struct CIV_AI_234fake // hashcode: 0xF56A6FC4 (dec: -177573948)
-{
-	int NumPingedIn; // size=0, offset=0
-	int OffRoad; // size=0, offset=4
-	int NotDrivable; // size=0, offset=8
-	int TooShortStr; // size=0, offset=12
-	int NearEndStr; // size=0, offset=16
-	int TooShortCrv; // size=0, offset=20
-	int NearEndCrv; // size=0, offset=24
-	int TooCloseNuddaCar; // size=0, offset=28
-	int TooClosePlayer; // size=0, offset=32
-	int InvalidRegion; // size=0, offset=36
-};
-
-typedef struct _EXTRA_CIV_DATA EXTRA_CIV_DATA;
+} EXTRA_CIV_DATA;
 
 struct COP_DATA // hashcode: 0x2EAA754B (dec: 782923083)
 {
@@ -1522,9 +1239,9 @@ struct COP_DATA // hashcode: 0x2EAA754B (dec: 782923083)
 
 struct FELONY_DATA // hashcode: 0x2264AF24 (dec: 577023780)
 {
-	struct FELONY_DELAY occurrenceDelay[12]; // size=48, offset=0
-	struct FELONY_DELAY reoccurrenceDelay[12]; // size=48, offset=48
-	struct FELONY_VALUE value[12]; // size=48, offset=96
+	FELONY_DELAY occurrenceDelay[12]; // size=48, offset=0
+	FELONY_DELAY reoccurrenceDelay[12]; // size=48, offset=48
+	FELONY_VALUE value[12]; // size=48, offset=96
 	int pursuitFelonyScale; // size=0, offset=144
 };
 
@@ -1544,8 +1261,8 @@ struct iVectNT // hashcode: 0x3D8D0417 (dec: 1032651799)
 
 struct PLAYBACKCAMERA // hashcode: 0xF83C80A8 (dec: -130252632)
 {
-	struct VECTOR_NOPAD position; // size=12, offset=0
-	struct SVECTOR angle; // size=8, offset=12
+	VECTOR_NOPAD position; // size=12, offset=0
+	SVECTOR angle; // size=8, offset=12
 	int FrameCnt; // size=0, offset=20
 	short CameraPosvy; // size=0, offset=24
 	short scr_z; // size=0, offset=26
@@ -1576,7 +1293,7 @@ struct CUTSCENE_INFO // hashcode: 0x57BD570A (dec: 1472026378)
 struct CUTSCENE_HEADER // hashcode: 0xAC6560B4 (dec: -1402642252)
 {
 	int maxsize; // size=0, offset=0
-	struct CUTSCENE_INFO data[15]; // size=60, offset=4
+	CUTSCENE_INFO data[15]; // size=60, offset=4
 };
 
 struct TPAN // hashcode: 0x984DCD6C (dec: -1739731604)
@@ -1595,11 +1312,11 @@ struct POLYFT4 // hashcode: 0x0B933067 (dec: 194195559)
 	unsigned char v1; // size=0, offset=5
 	unsigned char v2; // size=0, offset=6
 	unsigned char v3; // size=0, offset=7
-	struct UV_INFO uv0; // size=2, offset=8
-	struct UV_INFO uv1; // size=2, offset=10
-	struct UV_INFO uv2; // size=2, offset=12
-	struct UV_INFO uv3; // size=2, offset=14
-	struct RGB color; // size=4, offset=16
+	UV_INFO uv0; // size=2, offset=8
+	UV_INFO uv1; // size=2, offset=10
+	UV_INFO uv2; // size=2, offset=12
+	UV_INFO uv3; // size=2, offset=14
+	RGB color; // size=4, offset=16
 };
 
 struct POLYGT4 // hashcode: 0x9BF00654 (dec: -1678768556)
@@ -1616,11 +1333,11 @@ struct POLYGT4 // hashcode: 0x9BF00654 (dec: -1678768556)
 	unsigned char n1; // size=0, offset=9
 	unsigned char n2; // size=0, offset=10
 	unsigned char n3; // size=0, offset=11
-	struct UV_INFO uv0; // size=2, offset=12
-	struct UV_INFO uv1; // size=2, offset=14
-	struct UV_INFO uv2; // size=2, offset=16
-	struct UV_INFO uv3; // size=2, offset=18
-	struct RGB color; // size=4, offset=20
+	UV_INFO uv0; // size=2, offset=12
+	UV_INFO uv1; // size=2, offset=14
+	UV_INFO uv2; // size=2, offset=16
+	UV_INFO uv3; // size=2, offset=18
+	RGB color; // size=4, offset=20
 };
 
 
@@ -1650,7 +1367,7 @@ struct DEBRIS // hashcode: 0x7F875F65 (dec: 2139578213)
 	unsigned short flags; // size=0, offset=26
 	unsigned short num; // size=0, offset=28
 	unsigned short pos; // size=0, offset=30
-	struct RGB rgb; // size=4, offset=32
+	RGB rgb; // size=4, offset=32
 	char step; // size=0, offset=36
 	char type; // size=0, offset=37
 };
@@ -1663,7 +1380,7 @@ struct LEAF // hashcode: 0x8E232930 (dec: -1910298320)
 	unsigned short flags; // size=0, offset=26
 	unsigned short num; // size=0, offset=28
 	unsigned short pos; // size=0, offset=30
-	struct RGB rgb; // size=4, offset=32
+	RGB rgb; // size=4, offset=32
 	char step; // size=0, offset=36
 	char type; // size=0, offset=37
 	short sin_index1; // size=0, offset=38
@@ -1674,43 +1391,43 @@ struct LEAF // hashcode: 0x8E232930 (dec: -1910298320)
 
 struct DAMAGED_LAMP // hashcode: 0x1240B5B5 (dec: 306230709)
 {
-	struct CELL_OBJECT* cop; // size=16, offset=0
+	CELL_OBJECT* cop; // size=16, offset=0
 	char damage; // size=0, offset=4
 };
 
 struct DAMAGED_OBJECT // hashcode: 0xC8C77ECE (dec: -926449970)
 {
-	struct CELL_OBJECT cop; // size=16, offset=0
+	CELL_OBJECT cop; // size=16, offset=0
 	char active; // size=0, offset=16
 	char damage; // size=0, offset=17
 	int rot_speed; // size=0, offset=20
-	struct SVECTOR velocity; // size=8, offset=24
+	SVECTOR velocity; // size=8, offset=24
 	int vx; // size=0, offset=32
 };
 
 struct TRI_POINT // hashcode: 0x50D0CFA0 (dec: 1355861920)
 {
-	struct BVECTOR v0; // size=4, offset=0
-	struct BVECTOR v1; // size=4, offset=4
-	struct BVECTOR v2; // size=4, offset=8
+	BVECTOR v0; // size=4, offset=0
+	BVECTOR v1; // size=4, offset=4
+	BVECTOR v2; // size=4, offset=8
 };
 
 struct TRI_POINT_LONG // hashcode: 0xAFB61D06 (dec: -1347019514)
 {
-	struct VECTOR_NOPAD v0; // size=12, offset=0
-	struct VECTOR_NOPAD v1; // size=12, offset=12
-	struct VECTOR_NOPAD v2; // size=12, offset=24
+	VECTOR_NOPAD v0; // size=12, offset=0
+	VECTOR_NOPAD v1; // size=12, offset=12
+	VECTOR_NOPAD v2; // size=12, offset=24
 };
 
 struct RAIN_TYPE // hashcode: 0x4B9D35B0 (dec: 1268594096)
 {
-	struct VECTOR_NOPAD position; // size=12, offset=0
-	struct SVECTOR oldposition; // size=8, offset=12
+	VECTOR_NOPAD position; // size=12, offset=0
+	SVECTOR oldposition; // size=8, offset=12
 };
 
 struct LAMP_STREAK // hashcode: 0xB0E3FA15 (dec: -1327236587)
 {
-	struct SXYPAIR light_trails[4]; // size=16, offset=0
+	SXYPAIR light_trails[4]; // size=16, offset=0
 	int id; // size=0, offset=16
 	short clock; // size=0, offset=20
 	char set; // size=0, offset=22
@@ -1740,15 +1457,11 @@ struct HUBCAP // hashcode: 0x8B4D12CD (dec: -1957883187)
 	int Duration; // size=0, offset=180
 };
 
-typedef struct DENTUVS DENTUVS;
-
-typedef struct HUBCAP HUBCAP;
-
 struct REPLAY_ICON // hashcode: 0x6B6009DA (dec: 1801456090)
 {
 	short x; // size=0, offset=0
 	short y; // size=0, offset=2
-	struct TEXTURE_DETAILS* texture; // size=14, offset=4
+	TEXTURE_DETAILS* texture; // size=14, offset=4
 	char* TextPtr; // size=0, offset=8
 	short tx; // size=0, offset=12
 	short ty; // size=0, offset=14
@@ -1767,7 +1480,7 @@ struct _pct // hashcode: 0x3CC33EEE (dec: 1019428590)
 	unsigned long tpage; // size=0, offset=156
 	unsigned long colour; // size=0, offset=160
 	int flags; // size=0, offset=164
-	struct SVECTOR* verts; // size=8, offset=168
+	SVECTOR* verts; // size=8, offset=168
 	unsigned long lastTexInfo; // size=0, offset=172
 	int scribble[8]; // size=32, offset=176
 	int model; // size=0, offset=208
@@ -1813,10 +1526,10 @@ struct PL_POLYFT4 // hashcode: 0x851A459F (dec: -2061875809)
 	unsigned char v1; // size=0, offset=5
 	unsigned char v2; // size=0, offset=6
 	unsigned char v3; // size=0, offset=7
-	struct UV_INFO uv0; // size=2, offset=8
-	struct UV_INFO uv1; // size=2, offset=10
-	struct UV_INFO uv2; // size=2, offset=12
-	struct UV_INFO uv3; // size=2, offset=14
+	UV_INFO uv0; // size=2, offset=8
+	UV_INFO uv1; // size=2, offset=10
+	UV_INFO uv2; // size=2, offset=12
+	UV_INFO uv3; // size=2, offset=14
 };
 
 struct MVERTEX // hashcode: 0xCC5E5250 (dec: -866233776)
@@ -1871,8 +1584,8 @@ struct EventGlobal // hashcode: 0xF4852999 (dec: -192599655)
 {
 	int camera; // size=0, offset=0
 	int draw; // size=0, offset=4
-	struct _EVENT** track; // size=40, offset=8
-	struct _EVENT* cameraEvent; // size=40, offset=12
+	EVENT** track; // size=40, offset=8
+	EVENT* cameraEvent; // size=40, offset=12
 };
 
 enum SpecialCamera // Hashcode: 0xB5557F2F (dec: -1252688081)
@@ -1885,7 +1598,7 @@ enum SpecialCamera // Hashcode: 0xB5557F2F (dec: -1252688081)
 
 struct MissionTrain // hashcode: 0x1C680836 (dec: 476579894)
 {
-	struct _EVENT* engine; // size=40, offset=0
+	EVENT* engine; // size=40, offset=0
 	int* node; // size=0, offset=4
 	int cornerSpeed; // size=0, offset=8
 	int initialStraightSpeed; // size=0, offset=12
@@ -1896,7 +1609,7 @@ struct MissionTrain // hashcode: 0x1C680836 (dec: 476579894)
 
 struct Foam // hashcode: 0xFD0C756C (dec: -49515156)
 {
-	struct MODEL* model; // size=36, offset=0
+	MODEL* model; // size=36, offset=0
 	int rotate; // size=0, offset=4
 };
 
@@ -1908,7 +1621,7 @@ struct EventCarriage // hashcode: 0xA136BEAC (dec: -1590247764)
 
 struct MultiCar // hashcode: 0x862F8E20 (dec: -2043703776)
 {
-	struct _EVENT* event; // size=40, offset=0
+	EVENT* event; // size=40, offset=0
 	int count; // size=0, offset=4
 };
 
@@ -1921,7 +1634,7 @@ struct Helicopter // hashcode: 0xE626A675 (dec: -433674635)
 	short dr; // size=0, offset=10
 	int lastX; // size=0, offset=12
 	int lastZ; // size=0, offset=16
-	struct TEXTURE_DETAILS rotorTexture; // size=14, offset=20
+	TEXTURE_DETAILS rotorTexture; // size=14, offset=20
 	short rotorrot; // size=0, offset=34
 	short rotorvel; // size=0, offset=36
 	int cleanModel; // size=0, offset=40
@@ -1985,7 +1698,7 @@ struct RENDER_ARGS // hashcode: 0x9CEEC3A3 (dec: -1662073949)
 	unsigned char subtitle; // size=0, offset=1
 	char screenx; // size=0, offset=2
 	char screeny; // size=0, offset=3
-	struct RENDER_ARG Args[4]; // size=16, offset=4
+	RENDER_ARG Args[4]; // size=16, offset=4
 };
 
 typedef struct __envsound // hashcode: 0x7218E697 (dec: 1914234519)
@@ -1997,15 +1710,15 @@ typedef struct __envsound // hashcode: 0x7218E697 (dec: 1914234519)
 	int bank; // size=0, offset=36
 	int sample; // size=0, offset=40
 	int vol; // size=0, offset=44
-} __envsound;
+} envsound;
 
-struct __envsoundtags // hashcode: 0x8645A61D (dec: -2042255843)
+typedef struct __envsoundtags // hashcode: 0x8645A61D (dec: -2042255843)
 {
 	int frame_cnt; // size=0, offset=0
 	int func_cnt; // size=0, offset=4
 	int num_envsnds; // size=0, offset=8
 	int envsnd_cnt; // size=0, offset=12
-};
+} envsoundtags;
 
 typedef struct __envsoundinfo // hashcode: 0x45AC9536 (dec: 1168938294)
 {
@@ -2016,7 +1729,7 @@ typedef struct __envsoundinfo // hashcode: 0x45AC9536 (dec: 1168938294)
 	int playing_sound[4]; // size=16, offset=112
 	int chan[4]; // size=16, offset=128
 	unsigned long flags; // size=0, offset=144
-} __envsoundinfo;
+} envsoundinfo;
 
 struct SPEECH_QUEUE // hashcode: 0xF7AB07B1 (dec: -139786319)
 {
@@ -2028,27 +1741,20 @@ struct SPEECH_QUEUE // hashcode: 0xF7AB07B1 (dec: -139786319)
 	int slot[7]; // size=28, offset=12
 };
 
-struct __othercarsound // hashcode: 0x88F0C520 (dec: -1997486816)
+typedef struct __othercarsound // hashcode: 0x88F0C520 (dec: -1997486816)
 {
 	int car; // size=0, offset=0
 	int chan; // size=0, offset=4
 	char in_use; // size=0, offset=8
 	char stopped; // size=0, offset=9
 	char idle; // size=0, offset=10
-};
+} othercarsound;
 
-typedef struct __tunnelinfo // hashcode: 0xC172C5A2 (dec: -1049442910)
-{
-	char num_tunnels; // size=0, offset=0
-	char tunnel_cnt; // size=0, offset=1
-	struct __tunnelcoords coords[29]; // size=928, offset=4
-} __tunnelinfo;
-
-struct __bitfield64 // hashcode: 0x2A3F54F0 (dec: 708793584)
+typedef struct __bitfield64 // hashcode: 0x2A3F54F0 (dec: 708793584)
 {
 	long h; // size=0, offset=0
 	long l; // size=0, offset=4
-};
+} bitfield64;
 
 struct GEAR_DESC // hashcode: 0xE4380123 (dec: -466091741)
 {
@@ -2057,14 +1763,6 @@ struct GEAR_DESC // hashcode: 0xE4380123 (dec: -466091741)
 	int hi_ws; // size=0, offset=8
 	int ratio_ac; // size=0, offset=12
 	int ratio_id; // size=0, offset=16
-};
-
-struct PSXSCREEN // hashcode: 0x9E392939 (dec: -1640421063)
-{
-	unsigned char index; // size=0, offset=0
-	unsigned char numButtons; // size=0, offset=1
-	unsigned char userFunctionNum; // size=0, offset=2
-	struct PSXBUTTON buttons[8]; // size=480, offset=4
 };
 
 enum GAMEMODE // Hashcode: 0xA71425E4 (dec: -1491851804)
@@ -2129,7 +1827,7 @@ struct BOXINFO // hashcode: 0x0A20DC94 (dec: 169925780)
 
 struct MAP_DATA // hashcode: 0x83C30077 (dec: -2084372361)
 {
-	_CAR_DATA* cp; // size=0, offset=0
+	CAR_DATA* cp; // size=0, offset=0
 	VECTOR* base; // size=16, offset=4
 	VECTOR* pos; // size=16, offset=8
 	VECTOR* vel; // size=16, offset=12
@@ -2146,7 +1844,7 @@ struct GAME_SAVE_HEADER // hashcode: 0xB1E0BE5E (dec: -1310671266)
 	unsigned char pad1; // size=0, offset=5
 	unsigned char pad2; // size=0, offset=6
 	unsigned char pad3; // size=0, offset=7
-	struct MISSION_DATA SavedData; // size=228, offset=8
+	MISSION_DATA SavedData; // size=228, offset=8
 	int reserved[8]; // size=32, offset=236
 };
 
@@ -2159,14 +1857,14 @@ struct CONFIG_SAVE_HEADER // hashcode: 0x6370AFC2 (dec: 1668329410)
 	int gVibration; // size=0, offset=16
 	int gCopDifficultyLevel; // size=0, offset=20
 	int gFurthestMission; // size=0, offset=24
-	struct MAPPING PadMapping[2]; // size=72, offset=28
-	struct SCORE_TABLES ScoreTables; // size=2160, offset=100
+	MAPPING PadMapping[2]; // size=72, offset=28
+	SCORE_TABLES ScoreTables; // size=2160, offset=100
 	int PALAdjustX; // size=0, offset=2260
 	int PALAdjustY; // size=0, offset=2264
 	int NTSCAdjustX; // size=0, offset=2268
 	int NTSCAdjustY; // size=0, offset=2272
 	int gSubtitles; // size=0, offset=2276
-	struct ACTIVE_CHEATS AvailableCheats; // size=4, offset=2280
+	ACTIVE_CHEATS AvailableCheats; // size=4, offset=2280
 	int reserved[6]; // size=24, offset=2284
 };
 
@@ -2200,7 +1898,7 @@ struct OUT_CELL_FILE_HEADER // hashcode: 0x5665F7D5 (dec: 1449523157)
 	int num_cell_objects; // size=0, offset=20
 	int num_cell_data; // size=0, offset=24
 	int ambient_light_level; // size=0, offset=28
-	struct VECTOR_NOPAD light_source; // size=12, offset=32
+	VECTOR_NOPAD light_source; // size=12, offset=32
 };
 
 enum EXIT_VALUE // Hashcode: 0x3F23BCE8 (dec: 1059306728)
@@ -2223,15 +1921,10 @@ struct XYWH // hashcode: 0x1C1E57F6 (dec: 471750646)
 	short h; // size=0, offset=6
 };
 
-struct MENU_HEADER // hashcode: 0x0BDA3805 (dec: 198850565)
-{
-	char* Title; // size=0, offset=0
-	struct XYWH Bound; // size=8, offset=4
-	unsigned char NumItems; // size=0, offset=12
-	struct MENU_ITEM* MenuItems; // size=20, offset=16
-};
-
 typedef void(*pauseFunc)(int dir);
+
+struct MENU_ITEM;
+struct MENU_HEADER;
 
 struct MENU_ITEM // hashcode: 0x9519D4FB (dec: -1793469189)
 {
@@ -2239,9 +1932,19 @@ struct MENU_ITEM // hashcode: 0x9519D4FB (dec: -1793469189)
 	unsigned char Type; // size=0, offset=4
 	unsigned char Justify; // size=0, offset=5
 	pauseFunc func; // size=0, offset=8
-	enum EXIT_VALUE ExitValue; // size=1, offset=12
-	struct MENU_HEADER* SubMenu; // size=0, offset=16
+	EXIT_VALUE ExitValue; // size=1, offset=12
+	MENU_HEADER* SubMenu; // size=0, offset=16
 };
+
+struct MENU_HEADER // hashcode: 0x0BDA3805 (dec: 198850565)
+{
+	char* Title; // size=0, offset=0
+	XYWH Bound; // size=8, offset=4
+	unsigned char NumItems; // size=0, offset=12
+	MENU_ITEM* MenuItems; // size=20, offset=16
+};
+
+
 
 struct AREA_LOAD_INFO // hashcode: 0xC55B5A7D (dec: -983868803)
 {
@@ -2279,13 +1982,13 @@ struct _MISSION // hashcode: 0x85F0EB6C (dec: -2047808660)
 	int city; // size=0, offset=8
 	int time; // size=0, offset=12
 	int weather; // size=0, offset=16
-	struct XYPAIR playerStartPosition; // size=8, offset=20
+	XYPAIR playerStartPosition; // size=8, offset=20
 	int playerStartRotation; // size=0, offset=28
 	int type; // size=0, offset=32
 	short timer; // size=0, offset=36
 	short timerFlags; // size=0, offset=38
 	int strings; // size=0, offset=40
-	struct _COP_DATA cops; // size=16, offset=44
+	MS_COP_DATA cops; // size=16, offset=44
 	int msgCarWrecked; // size=0, offset=60
 	int msgOutOfTime; // size=0, offset=64
 	int msgComplete; // size=0, offset=68
@@ -2306,18 +2009,18 @@ struct _ROUTE_INFO // hashcode: 0x5A21DB68 (dec: 1512168296)
 {
 	int nJunctions; // size=0, offset=0
 	char data[1000][4]; // size=4000, offset=4
-	struct LEAD_PARAMETERS parameters; // size=64, offset=4004
+	LEAD_PARAMETERS parameters; // size=64, offset=4004
 };
 
 struct MR_MISSION // hashcode: 0xF240F754 (dec: -230623404)
 {
 	int active; // size=0, offset=0
 	int gameover_delay; // size=0, offset=4
-	enum PAUSEMODE gameover_mode; // size=1, offset=8
+	PAUSEMODE gameover_mode; // size=1, offset=8
 	short message_timer[2]; // size=4, offset=10
 	short message_priority[2]; // size=4, offset=14
 	char(*message_string[2]); // size=8, offset=20
-	struct MR_TIMER timer[2]; // size=24, offset=28
+	MR_TIMER timer[2]; // size=24, offset=28
 	_TARGET* CarTarget; // size=64, offset=52
 	_TARGET* ChaseTarget; // size=64, offset=56
 	int PhantomCarId; // size=0, offset=60
@@ -2327,7 +2030,7 @@ struct MR_MISSION // hashcode: 0xF240F754 (dec: -230623404)
 
 struct STOPCOPS // hashcode: 0x145E8976 (dec: 341739894)
 {
-	struct VECTOR_NOPAD pos; // size=12, offset=0
+	VECTOR_NOPAD pos; // size=12, offset=0
 	int radius; // size=0, offset=12
 };
 
@@ -2357,11 +2060,11 @@ struct POLYFT3 // hashcode: 0xF42A702D (dec: -198545363)
 	unsigned char v1; // size=0, offset=5
 	unsigned char v2; // size=0, offset=6
 	unsigned char pad; // size=0, offset=7
-	struct UV_INFO uv0; // size=2, offset=8
-	struct UV_INFO uv1; // size=2, offset=10
-	struct UV_INFO uv2; // size=2, offset=12
-	struct UV_INFO pad2; // size=2, offset=14
-	struct RGB color; // size=4, offset=16
+	UV_INFO uv0; // size=2, offset=8
+	UV_INFO uv1; // size=2, offset=10
+	UV_INFO uv2; // size=2, offset=12
+	UV_INFO pad2; // size=2, offset=14
+	RGB color; // size=4, offset=16
 };
 
 struct POLYGT3
@@ -2378,11 +2081,11 @@ struct POLYGT3
 	unsigned char n1; // size=0, offset=9
 	unsigned char n2; // size=0, offset=10
 	unsigned char pad2; // size=0, offset=11
-	struct UV_INFO uv0; // size=2, offset=12
-	struct UV_INFO uv1; // size=2, offset=14
-	struct UV_INFO uv2; // size=2, offset=16
-	struct UV_INFO pad3; // size=2, offset=18
-	struct RGB color; // size=4, offset=20
+	UV_INFO uv0; // size=2, offset=12
+	UV_INFO uv1; // size=2, offset=14
+	UV_INFO uv2; // size=2, offset=16
+	UV_INFO pad3; // size=2, offset=18
+	RGB color; // size=4, offset=20
 };
 
 enum LIMBS // Hashcode: 0x200BA5A5 (dec: 537634213)
@@ -2414,8 +2117,8 @@ enum LIMBS // Hashcode: 0x200BA5A5 (dec: 537634213)
 
 struct BONE // hashcode: 0xC453A1B7 (dec: -1001152073)
 {
-	enum LIMBS id; // size=1, offset=0
-	struct BONE* pParent; // size=68, offset=4
+	LIMBS id; // size=1, offset=0
+	BONE* pParent; // size=68, offset=4
 	char numChildren; // size=0, offset=8
 	BONE(*pChildren[3]); // size=12, offset=12
 	SVECTOR_NOPAD* pvOrigPos; // size=6, offset=24
@@ -2437,8 +2140,8 @@ struct PED_DATA // hashcode: 0xF0838D4B (dec: -259814069)
 {
 	char cWidth; // size=0, offset=0
 	unsigned char cAdj; // size=0, offset=1
-	struct TEXTURE_DETAILS* ptd; // size=14, offset=4
-	enum TEXTURE_PALS texPal; // size=1, offset=8
+	TEXTURE_DETAILS* ptd; // size=14, offset=4
+	TEXTURE_PALS texPal; // size=1, offset=8
 };
 
 struct tRay // hashcode: 0x9D13B2B7 (dec: -1659653449)
@@ -2455,7 +2158,7 @@ struct tRange // hashcode: 0x2599E03D (dec: 630841405)
 
 struct tAABB // hashcode: 0x67B18B0E (dec: 1739688718)
 {
-	struct tRange slab[3]; // size=24, offset=0
+	tRange slab[3]; // size=24, offset=0
 };
 
 struct DUPLICATION // hashcode: 0x6B8217F0 (dec: 1803687920)
@@ -2494,14 +2197,14 @@ struct PLAYER_SCORE // hashcode: 0x4C80DCD4 (dec: 1283513556)
 	char name[6]; // size=6, offset=12
 };
 
-struct SEATED_PEDESTRIANS // hashcode: 0x75CFA44E (dec: 1976542286)
+typedef struct SEATED_PEDESTRIANS // hashcode: 0x75CFA44E (dec: 1976542286)
 {
 	int x; // size=0, offset=0
 	int z; // size=0, offset=4
 	short rotation; // size=0, offset=8
 	char index; // size=0, offset=10
 	char pad; // size=0, offset=11
-};
+} *SEATEDPTR;
 
 struct CAR_COLLISION_BOX // hashcode: 0xE148B668 (dec: -515328408)
 {
@@ -2511,14 +2214,14 @@ struct CAR_COLLISION_BOX // hashcode: 0xE148B668 (dec: -515328408)
 	int max_z; // size=0, offset=12
 };
 
-struct PEDESTRIAN_ROADS // hashcode: 0xC3763082 (dec: -1015664510)
+typedef struct PEDESTRIAN_ROADS // hashcode: 0xC3763082 (dec: -1015664510)
 {
 	short pos; // size=0, offset=0
 	short north; // size=0, offset=2
 	short south; // size=0, offset=4
 	short east; // size=0, offset=6
 	short west; // size=0, offset=8
-};
+} *LPPEDESTRIAN_ROADS;
 
 struct OUT_FONTINFO // hashcode: 0x22390EDA (dec: 574164698)
 {
@@ -2556,7 +2259,7 @@ struct SHADOWHDR // hashcode: 0x4ED3B57A (dec: 1322497402)
 	unsigned short nverts[4]; // size=8, offset=16
 	unsigned short npolys[4]; // size=8, offset=24
 	unsigned long(*poly_block[4]); // size=16, offset=32
-	struct SVECTOR* vertices; // size=8, offset=48
+	SVECTOR* vertices; // size=8, offset=48
 };
 
 struct TYRE_TRACK // hashcode: 0xF19415A8 (dec: -241953368)
@@ -2565,10 +2268,10 @@ struct TYRE_TRACK // hashcode: 0xF19415A8 (dec: -241953368)
 	char shade; // size=0, offset=1
 	char shade_type; // size=0, offset=2
 	char surface; // size=0, offset=3
-	struct SVECTOR_NOPAD p1; // size=6, offset=4
-	struct SVECTOR_NOPAD p2; // size=6, offset=10
-	struct SVECTOR_NOPAD p3; // size=6, offset=16
-	struct SVECTOR_NOPAD p4; // size=6, offset=22
+	SVECTOR_NOPAD p1; // size=6, offset=4
+	SVECTOR_NOPAD p2; // size=6, offset=10
+	SVECTOR_NOPAD p3; // size=6, offset=16
+	SVECTOR_NOPAD p4; // size=6, offset=22
 };
 
 struct S_XYZ // hashcode: 0x44EE024B (dec: 1156448843)
@@ -2580,7 +2283,7 @@ struct S_XYZ // hashcode: 0x44EE024B (dec: 1156448843)
 
 struct FLAREREC // hashcode: 0x61D9DD50 (dec: 1641667920)
 {
-	struct RGB16 transparency; // size=8, offset=0
+	RGB16 transparency; // size=8, offset=0
 	char size; // size=0, offset=8
 	short gapmod; // size=0, offset=10
 };
@@ -2700,7 +2403,7 @@ enum CITYTYPE // Hashcode: 0x89BC71DE (dec: -1984138786)
 
 struct TARGET_ARROW_MODEL // hashcode: 0x49188CA9 (dec: 1226345641)
 {
-	struct SVECTOR* pVerts; // size=8, offset=0
+	SVECTOR* pVerts; // size=8, offset=0
 	char* pTris; // size=0, offset=4
 	char numTris; // size=0, offset=8
 };
@@ -2736,7 +2439,7 @@ struct FE_CHARDATA // hashcode: 0x3BD93806 (dec: 1004091398)
 struct FE_FONT // hashcode: 0x602743A1 (dec: 1613185953)
 {
 	int NumFonts; // size=0, offset=0
-	struct FE_CHARDATA CharInfo[256]; // size=1024, offset=4
+	FE_CHARDATA CharInfo[256]; // size=1024, offset=4
 };
 
 struct SCREEN_LIMITS // hashcode: 0x445BA46E (dec: 1146856558)

--- a/src_rebuild/GAME/DR2TYPES.H
+++ b/src_rebuild/GAME/DR2TYPES.H
@@ -443,7 +443,9 @@ struct LEAD_PARAMETERS
 	int hWidth80Mul;
 };
 
-typedef struct _EVENT
+typedef struct _EVENT EVENT;
+
+struct _EVENT
 {
 	VECTOR position;
 	short rotation;
@@ -453,8 +455,8 @@ typedef struct _EVENT
 	short flags;
 	short radius;
 	int model;
-	_EVENT* next;
-} EVENT;
+	EVENT* next;
+};
 
 struct FixedEvent
 {

--- a/src_rebuild/GAME/DR2TYPES.H
+++ b/src_rebuild/GAME/DR2TYPES.H
@@ -3,6 +3,11 @@
 
 // Driver 2 system types
 
+typedef short SHORTVECTOR[4];
+
+typedef long LONGVECTOR[4];
+typedef long LONGQUATERNION[4];
+
 struct VECTOR2 // hashcode: 0x7572A047 (dec: 1970446407)
 {
 	int vx; // size=0, offset=0
@@ -205,7 +210,7 @@ union RigidBodyState // Hashcode: 0x60B16C22 (dec: 1622240290)
 	long v[13]; // size=52, offset=0
 	struct {
 		long fposition[3]; // size=12, offset=0
-		long orientation[4]; // size=16, offset=12
+		LONGQUATERNION orientation; // size=16, offset=12
 		long linearVelocity[3]; // size=12, offset=28
 		long angularVelocity[3]; // size=12, offset=40
 	} n; // size=52, offset=0, found in object files: obj\dr2roads.obj, obj\dr2roads.obj
@@ -574,13 +579,6 @@ typedef unsigned short gid_t;
 #endif
 
 typedef void (*SsMarkCallbackProc)();
-
-typedef short SHORTVECTOR[4];
-
-typedef long LONGVECTOR[4];
-typedef long LONGQUATERNION[4];
-
-
 
 struct MODEL // hashcode: 0x3A42A4FE (dec: 977446142)
 {

--- a/src_rebuild/GAME/DR2TYPES.H
+++ b/src_rebuild/GAME/DR2TYPES.H
@@ -8,364 +8,364 @@ typedef short SHORTVECTOR[4];
 typedef long LONGVECTOR[4];
 typedef long LONGQUATERNION[4];
 
-struct VECTOR2 // hashcode: 0x7572A047 (dec: 1970446407)
+struct VECTOR2
 {
-	int vx; // size=0, offset=0
-	int vz; // size=0, offset=4
+	int vx;
+	int vz;
 };
 
-struct USVECTOR_NOPAD // hashcode: 0xA2EACE82 (dec: -1561670014)
+struct USVECTOR_NOPAD
 {
-	unsigned short vx; // size=0, offset=0
-	unsigned short vy; // size=0, offset=2
-	unsigned short vz; // size=0, offset=4
+	unsigned short vx;
+	unsigned short vy;
+	unsigned short vz;
 };
 
-struct VECTOR_NOPAD // hashcode: 0x32909951 (dec: 848337233)
+struct VECTOR_NOPAD
 {
-	long vx; // size=0, offset=0
-	long vy; // size=0, offset=4
-	long vz; // size=0, offset=8
+	long vx;
+	long vy;
+	long vz;
 };
 
-struct SVECTOR_NOPAD // hashcode: 0xBEBBA7F1 (dec: -1094998031)
+struct SVECTOR_NOPAD
 {
-	short vx; // size=0, offset=0
-	short vy; // size=0, offset=2
-	short vz; // size=0, offset=4
+	short vx;
+	short vy;
+	short vz;
 };
 
 // TODO: DR2TYPES
 
-struct BOX // hashcode: 0xC47BB3B2 (dec: -998526030)
+struct BOX
 {
-	float xmin; // size=0, offset=0
-	float ymin; // size=0, offset=4
-	float zmin; // size=0, offset=8
-	float xmax; // size=0, offset=12
-	float ymax; // size=0, offset=16
-	float zmax; // size=0, offset=20
+	float xmin;
+	float ymin;
+	float zmin;
+	float xmax;
+	float ymax;
+	float zmax;
 };
 
-struct BSPHERE // hashcode: 0x117AEF65 (dec: 293269349)
+struct BSPHERE
 {
-	VECTOR bounding_sphere_mid; // size=16, offset=0
-	float bounding_sphere; // size=0, offset=16
+	VECTOR bounding_sphere_mid;
+	float bounding_sphere;
 };
 
-struct RGB // hashcode: 0xDDB9C681 (dec: -575027583)
+struct RGB
 {
-	unsigned char r; // size=0, offset=0
-	unsigned char g; // size=0, offset=1
-	unsigned char b; // size=0, offset=2
-	unsigned char pad; // size=0, offset=3
+	unsigned char r;
+	unsigned char g;
+	unsigned char b;
+	unsigned char pad;
 };
 
-struct UV_INFO // hashcode: 0x23373190 (dec: 590819728)
+struct UV_INFO
 {
-	unsigned char u; // size=0, offset=0
-	unsigned char v; // size=0, offset=1
+	unsigned char u;
+	unsigned char v;
 };
 
-struct XYPAIR // hashcode: 0x26B42A1B (dec: 649341467)
+struct XYPAIR
 {
-	int x; // size=0, offset=0
-	int y; // size=0, offset=4
+	int x;
+	int y;
 };
 
-struct SXYPAIR // hashcode: 0xC24DE5F5 (dec: -1035082251)
+struct SXYPAIR
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
+	short x;
+	short y;
 };
 
-struct GAP_INFO // hashcode: 0x468CC560 (dec: 1183630688)
+struct GAP_INFO
 {
-	DVECTOR offset; // size=4, offset=0
-	char clear; // size=0, offset=4
+	DVECTOR offset;
+	char clear;
 };
 
 
 
-struct PADRECORD // hashcode: 0x0D20CEBD (dec: 220253885)
+struct PADRECORD
 {
-	unsigned char pad; // size=0, offset=0
-	unsigned char analogue; // size=0, offset=1
-	unsigned char run; // size=0, offset=2
+	unsigned char pad;
+	unsigned char analogue;
+	unsigned char run;
 };
 
-struct ARC_ENTRY // hashcode: 0x4C376F3B (dec: 1278701371)
+struct ARC_ENTRY
 {
-	short offset; // size=0, offset=0
-	short length; // size=0, offset=2
+	short offset;
+	short length;
 };
 
-struct DRIVER2_CURVE // hashcode: 0xB805ADA3 (dec: -1207587421)
+struct DRIVER2_CURVE
 {
-	int Midx; // size=0, offset=0
-	int Midz; // size=0, offset=4
-	short start; // size=0, offset=8
-	short end; // size=0, offset=10
-	short ConnectIdx[4]; // size=8, offset=12
-	short gradient; // size=0, offset=20
-	short height; // size=0, offset=22
-	char NumLanes; // size=0, offset=24
-	char LaneDirs; // size=0, offset=25
-	char inside; // size=0, offset=26
-	char AILanes; // size=0, offset=27
+	int Midx;
+	int Midz;
+	short start;
+	short end;
+	short ConnectIdx[4];
+	short gradient;
+	short height;
+	char NumLanes;
+	char LaneDirs;
+	char inside;
+	char AILanes;
 };
 
-struct DRIVER2_STRAIGHT // hashcode: 0xCF738039 (dec: -814514119)
+struct DRIVER2_STRAIGHT
 {
-	int Midx; // size=0, offset=0
-	int Midz; // size=0, offset=4
-	unsigned short length; // size=0, offset=8
-	short bing; // size=0, offset=10
-	short angle; // size=0, offset=12
-	short ConnectIdx[4]; // size=8, offset=14
-	char NumLanes; // size=0, offset=22				// masked: 0xF - lane count, flags: 0x40 - allow non-drivable parked cars, 0x80: allow parked cars
-	char LaneDirs; // size=0, offset=23				// bit field of lanes 
-	char AILanes; // size=0, offset=24				// bit field of lanes which allows spawning active cars. LaneDirs >> (LANE_NUMBER / 2 & 0x1fU)
-	char packing; // size=0, offset=25
+	int Midx;
+	int Midz;
+	unsigned short length;
+	short bing;
+	short angle;
+	short ConnectIdx[4];
+	char NumLanes;
+	char LaneDirs;
+	char AILanes;
+	char packing;
 };
 
-struct OLD_DRIVER2_JUNCTION // hashcode: 0x42D65B1B (dec: 1121344283)
+struct OLD_DRIVER2_JUNCTION
 {
-	int Midx; // size=0, offset=0
-	int Midz; // size=0, offset=4
-	short length; // size=0, offset=8
-	short width; // size=0, offset=10
-	short angle; // size=0, offset=12
-	short ExitIdx[4]; // size=8, offset=14
-	unsigned short flags; // size=0, offset=22
+	int Midx;
+	int Midz;
+	short length;
+	short width;
+	short angle;
+	short ExitIdx[4];
+	unsigned short flags;
 };
 
-struct DRIVER2_JUNCTION // hashcode: 0x7C27C3D0 (dec: 2082980816)
+struct DRIVER2_JUNCTION
 {
-	short ExitIdx[4]; // size=8, offset=0
-	unsigned long flags; // size=0, offset=8
+	short ExitIdx[4];
+	unsigned long flags;
 };
 
-typedef struct _sdPlane // hashcode: 0x873C357E (dec: -2026097282)
+typedef struct _sdPlane
 {
-	short surface; // size=0, offset=0
-	short a; // size=0, offset=2
-	short b; // size=0, offset=4
-	short c; // size=0, offset=6
-	int d; // size=0, offset=8
+	short surface;
+	short a;
+	short b;
+	short c;
+	int d;
 } sdPlane;
 
 struct sdNodePACKED
 {
-	int angle : 11; // offset=0 bit
-	int dist : 12; // offset=11 bit
-	int offset : 8; // offset=23 bit
-	int node : 1; // offset=31 bit
+	int angle : 11;
+	int dist : 12;
+	int offset : 8;
+	int node : 1;
 };
 
-union _sdNode // hashcode: 0xD508740E (dec: -720866290)
+union _sdNode
 {
 	int value;
 	sdNodePACKED n;
 };
 
-struct WHEEL // hashcode: 0x76B6CC6D (dec: 1991691373)
+struct WHEEL
 {
-	char susCompression; // size=0, offset=0
-	char locked; // size=0, offset=1
-	char onGrass; // size=0, offset=2
-	unsigned char surface; // size=0, offset=3
+	char susCompression;
+	char locked;
+	char onGrass;
+	unsigned char surface;
 };
 
-struct OrientedBox // hashcode: 0x8D87CFA2 (dec: -1920479326)
+struct OrientedBox
 {
-	VECTOR_NOPAD location; // size=12, offset=0
-	SVECTOR_NOPAD radii[3]; // size=18, offset=12
-	short length[3]; // size=6, offset=30
+	VECTOR_NOPAD location;
+	SVECTOR_NOPAD radii[3];
+	short length[3];
 };
 
-typedef struct _HANDLING_DATA // hashcode: 0x9DD0BFD7 (dec: -1647263785)
+typedef struct _HANDLING_DATA
 {
-	MATRIX where; // size=32, offset=0
-	MATRIX drawCarMat; // size=32, offset=32
-	long acc[4]; // size=16, offset=64
-	long aacc[4]; // size=16, offset=80
-	int wheel_speed; // size=0, offset=96
-	int speed; // size=0, offset=100
-	int direction; // size=0, offset=104
-	char gear; // size=0, offset=108
-	char changingGear; // size=0, offset=109
-	char mayBeColliding; // size=0, offset=110
-	char autoBrake; // size=0, offset=111
-	WHEEL wheel[4]; // size=16, offset=112
-	short revs; // size=0, offset=128
-	VECTOR shadowPoints[4]; // size=64, offset=132
-	int front_vel; // size=0, offset=196
-	int rear_vel; // size=0, offset=200
-	OrientedBox oBox; // size=36, offset=204
+	MATRIX where;
+	MATRIX drawCarMat;
+	long acc[4];
+	long aacc[4];
+	int wheel_speed;
+	int speed;
+	int direction;
+	char gear;
+	char changingGear;
+	char mayBeColliding;
+	char autoBrake;
+	WHEEL wheel[4];
+	short revs;
+	VECTOR shadowPoints[4];
+	int front_vel;
+	int rear_vel;
+	OrientedBox oBox;
 } HANDLING_DATA;
 
-union RigidBodyState // Hashcode: 0x60B16C22 (dec: 1622240290)
+union RigidBodyState
 {
-	long v[13]; // size=52, offset=0
+	long v[13];
 	struct {
-		long fposition[3]; // size=12, offset=0
-		LONGQUATERNION orientation; // size=16, offset=12
-		long linearVelocity[3]; // size=12, offset=28
-		long angularVelocity[3]; // size=12, offset=40
-	} n; // size=52, offset=0, found in object files: obj\dr2roads.obj, obj\dr2roads.obj
+		long fposition[3];
+		LONGQUATERNION orientation;
+		long linearVelocity[3];
+		long angularVelocity[3];
+	} n;
 };
 
-struct CAR_POLY // hashcode: 0x6DD9D398 (dec: 1842992024)
+struct CAR_POLY
 {
-	int vindices; // size=0, offset=0
-	int nindices; // size=0, offset=4
-	int clut_uv0; // size=0, offset=8
-	int tpage_uv1; // size=0, offset=12
-	int uv3_uv2; // size=0, offset=16
-	short originalindex; // size=0, offset=20
+	int vindices;
+	int nindices;
+	int clut_uv0;
+	int tpage_uv1;
+	int uv3_uv2;
+	short originalindex;
 };
 
-struct CAR_MODEL // hashcode: 0xE3A253F1 (dec: -475900943)
+struct CAR_MODEL
 {
-	int numFT3; // size=0, offset=0
-	CAR_POLY* pFT3; // size=24, offset=4
-	int numGT3; // size=0, offset=8
-	CAR_POLY* pGT3; // size=24, offset=12
-	int numB3; // size=0, offset=16
-	CAR_POLY* pB3; // size=24, offset=20
-	SVECTOR* vlist; // size=8, offset=24
-	SVECTOR* nlist; // size=8, offset=28
+	int numFT3;
+	CAR_POLY* pFT3;
+	int numGT3;
+	CAR_POLY* pGT3;
+	int numB3;
+	CAR_POLY* pB3;
+	SVECTOR* vlist;
+	SVECTOR* nlist;
 };
 
-struct CAR_COSMETICS // hashcode: 0x48DDA5C0 (dec: 1222485440)
+struct CAR_COSMETICS
 {
-	SVECTOR headLight; // size=8, offset=0
-	SVECTOR frontInd; // size=8, offset=8
-	SVECTOR backInd; // size=8, offset=16
-	SVECTOR brakeLight; // size=8, offset=24
-	SVECTOR revLight; // size=8, offset=32
-	SVECTOR policeLight; // size=8, offset=40
-	SVECTOR exhaust; // size=8, offset=48
-	SVECTOR smoke; // size=8, offset=56
-	SVECTOR fire; // size=8, offset=64
-	SVECTOR wheelDisp[4]; // size=32, offset=72
-	short extraInfo; // size=0, offset=104
-	short powerRatio; // size=0, offset=106
-	short cbYoffset; // size=0, offset=108
-	short susCoeff; // size=0, offset=110
-	short traction; // size=0, offset=112
-	short wheelSize; // size=0, offset=114
-	SVECTOR cPoints[12]; // size=96, offset=116
-	SVECTOR colBox; // size=8, offset=212
-	SVECTOR cog; // size=8, offset=220
-	short twistRateX; // size=0, offset=228
-	short twistRateY; // size=0, offset=230
-	short twistRateZ; // size=0, offset=232
-	short mass; // size=0, offset=234
+	SVECTOR headLight;
+	SVECTOR frontInd;
+	SVECTOR backInd;
+	SVECTOR brakeLight;
+	SVECTOR revLight;
+	SVECTOR policeLight;
+	SVECTOR exhaust;
+	SVECTOR smoke;
+	SVECTOR fire;
+	SVECTOR wheelDisp[4];
+	short extraInfo;
+	short powerRatio;
+	short cbYoffset;
+	short susCoeff;
+	short traction;
+	short wheelSize;
+	SVECTOR cPoints[12];
+	SVECTOR colBox;
+	SVECTOR cog;
+	short twistRateX;
+	short twistRateY;
+	short twistRateZ;
+	short mass;
 };
 
-typedef struct _APPEARANCE_DATA // hashcode: 0x4A050E31 (dec: 1241845297)
+typedef struct _APPEARANCE_DATA
 {
-	SXYPAIR light_trails[4][4]; // size=64, offset=0
-	CAR_COSMETICS* carCos; // size=236, offset=64
-	short old_clock[4]; // size=8, offset=68
-	char life; // size=0, offset=76
-	char coplife; // size=0, offset=77
-	short qy; // size=0, offset=78
-	short qw; // size=0, offset=80
-	char life2; // size=0, offset=82
-	char model; // size=0, offset=83
-	char palette; // size=0, offset=84
+	SXYPAIR light_trails[4][4];
+	CAR_COSMETICS* carCos;
+	short old_clock[4];
+	char life;
+	char coplife;
+	short qy;
+	short qw;
+	char life2;
+	char model;
+	char palette;
 
-	char needsDenting : 1; // size=0, offset=85
+	char needsDenting : 1;
 	char flags : 7;			// [A] new: appearance flags, 1,2,3,4 = wheel hubcaps lost
 
-	short damage[6]; // size=12, offset=86
+	short damage[6];
 } APPEARANCE_DATA;
 
-struct CIV_ROUTE_ENTRY // hashcode: 0x7DE1E25F (dec: 2111955551)
+struct CIV_ROUTE_ENTRY
 {
-	short dir; // size=0, offset=0
-	unsigned short pathType; // size=0, offset=2
-	int distAlongSegment; // size=0, offset=4
-	int x; // size=0, offset=8
-	int z; // size=0, offset=12
+	short dir;
+	unsigned short pathType;
+	int distAlongSegment;
+	int x;
+	int z;
 };
 
-struct CIV_STATE // hashcode: 0x1B69CC52 (dec: 459918418)
+struct CIV_STATE
 {
-	int currentRoad; // size=0, offset=0
-	int currentNode; // size=0, offset=4
-	CIV_ROUTE_ENTRY* ctrlNode; // size=16, offset=8
-	unsigned char ctrlState; // size=0, offset=12
-	unsigned char trafficLightPhaseId; // size=0, offset=13
-	unsigned char changeLane; // size=0, offset=14
-	unsigned char turnDir; // size=0, offset=15
-	char brakeLight; // size=0, offset=16
-	unsigned char oldLane; // size=0, offset=17
-	unsigned char changeLaneCount; // size=0, offset=18
-	unsigned char pad3; // size=0, offset=19
-	int turnNode; // size=0, offset=20
-	int changeLaneIndicateCount; // size=0, offset=24
-	int carPauseCnt; // size=0, offset=28
-	int velRatio; // size=0, offset=32
-	CIV_ROUTE_ENTRY targetRoute[13]; // size=208, offset=36
-	CIV_ROUTE_ENTRY* pnode; // size=16, offset=244
-	unsigned char maxSpeed; // size=0, offset=248
-	unsigned char thrustState; // size=0, offset=249
-	unsigned char carMustDie; // size=0, offset=250
-	unsigned char currentLane; // size=0, offset=251
+	int currentRoad;
+	int currentNode;
+	CIV_ROUTE_ENTRY* ctrlNode;
+	unsigned char ctrlState;
+	unsigned char trafficLightPhaseId;
+	unsigned char changeLane;
+	unsigned char turnDir;
+	char brakeLight;
+	unsigned char oldLane;
+	unsigned char changeLaneCount;
+	unsigned char pad3;
+	int turnNode;
+	int changeLaneIndicateCount;
+	int carPauseCnt;
+	int velRatio;
+	CIV_ROUTE_ENTRY targetRoute[13];
+	CIV_ROUTE_ENTRY* pnode;
+	unsigned char maxSpeed;
+	unsigned char thrustState;
+	unsigned char carMustDie;
+	unsigned char currentLane;
 };
 
-struct COP // hashcode: 0x03D1B2C7 (dec: 64074439)
+struct COP
 {
-	VECTOR2 targetHistory[2]; // size=16, offset=0
-	char routeInMemory; // size=0, offset=16
-	char justPinged; // size=0, offset=17
-	char close_pursuit; // size=0, offset=18
-	char dying; // size=0, offset=19
-	unsigned short DistanceToPlayer; // size=0, offset=20
-	short desiredSpeed; // size=0, offset=22
-	short recalcTimer; // size=0, offset=24
-	short stuckTimer; // size=0, offset=26
-	short lastRecoverStrategy; // size=0, offset=28
-	short recoveryTimer; // size=0, offset=30
-	short hiddenTimer; // size=0, offset=32
-	short frontLClear; // size=0, offset=34
-	short frontRClear; // size=0, offset=36
+	VECTOR2 targetHistory[2];
+	char routeInMemory;
+	char justPinged;
+	char close_pursuit;
+	char dying;
+	unsigned short DistanceToPlayer;
+	short desiredSpeed;
+	short recalcTimer;
+	short stuckTimer;
+	short lastRecoverStrategy;
+	short recoveryTimer;
+	short hiddenTimer;
+	short frontLClear;
+	short frontRClear;
 };
 
-struct LEAD_CAR // hashcode: 0x44C76F5F (dec: 1153920863)
+struct LEAD_CAR
 {
-	char dstate; // size=0, offset=0
-	char ctt; // size=0, offset=1
-	short targetDir; // size=0, offset=2
-	int targetX; // size=0, offset=4
-	int targetZ; // size=0, offset=8
-	int currentRoad; // size=0, offset=12
-	int lastRoad; // size=0, offset=16
-	int nextJunction; // size=0, offset=20
-	int nextTurn; // size=0, offset=24
-	int nextExit; // size=0, offset=28
-	int stuckCount; // size=0, offset=32
-	int panicCount; // size=0, offset=36
-	int recoverTime; // size=0, offset=40
-	int roadPosition; // size=0, offset=44
-	int roadForward; // size=0, offset=48
-	int boringness; // size=0, offset=52
-	int avoid; // size=0, offset=56
-	int lastTarget; // size=0, offset=60
-	int offRoad; // size=0, offset=64
-	int width; // size=0, offset=68
-	int d; // size=0, offset=72
-	int base_Normal; // size=0, offset=76
-	int base_Angle; // size=0, offset=80
-	int base_Dir; // size=0, offset=84
-	int outsideSpoolRegion; // size=0, offset=88
-	int direction; // size=0, offset=92
-	int lastDirection; // size=0, offset=96
-	char takeDamage; // size=0, offset=100
+	char dstate;
+	char ctt;
+	short targetDir;
+	int targetX;
+	int targetZ;
+	int currentRoad;
+	int lastRoad;
+	int nextJunction;
+	int nextTurn;
+	int nextExit;
+	int stuckCount;
+	int panicCount;
+	int recoverTime;
+	int roadPosition;
+	int roadForward;
+	int boringness;
+	int avoid;
+	int lastTarget;
+	int offRoad;
+	int width;
+	int d;
+	int base_Normal;
+	int base_Angle;
+	int base_Dir;
+	int outsideSpoolRegion;
+	int direction;
+	int lastDirection;
+	char takeDamage;
 };
 
 enum ECarControlType
@@ -388,177 +388,177 @@ enum ECarControlFlags
 	CONTROL_FLAG_WAS_PARKED = (1 << 2)		// car pinged in as parked. Really nothing to do with it
 };
 
-typedef struct _CAR_DATA // hashcode: 0x8D78CB99 (dec: -1921463399)
+typedef struct _CAR_DATA
 {
-	HANDLING_DATA hd; // size=240, offset=0
-	RigidBodyState st; // size=52, offset=240
-	APPEARANCE_DATA ap; // size=100, offset=292
-	unsigned char hndType; // size=0, offset=392
-	unsigned char controlType; // size=0, offset=393
-	unsigned char controlFlags; // size=0, offset=394
-	char id; // size=0, offset=395
+	HANDLING_DATA hd;
+	RigidBodyState st;
+	APPEARANCE_DATA ap;
+	unsigned char hndType;
+	unsigned char controlType;
+	unsigned char controlFlags;
+	char id;
 	union {
-		char* padid; // size=0, offset=0
-		CIV_STATE c; // size=252, offset=0
-		COP p; // size=40, offset=0
-		LEAD_CAR l; // size=104, offset=0
-	} ai; // size=252, offset=396, found in object files: obj\dr2roads.obj, obj\dr2roads.obj
-	int* inform; // size=0, offset=648
-	short thrust; // size=0, offset=652
-	short felonyRating; // size=0, offset=654
-	char handbrake; // size=0, offset=656
-	char wheelspin; // size=0, offset=657
-	char wasOnGround; // size=0, offset=658
-	char lowDetail; // size=0, offset=659
-	short wheel_angle; // size=0, offset=660
-	unsigned short totalDamage; // size=0, offset=662
-	long lastPad; // size=0, offset=664
+		char* padid;
+		CIV_STATE c;
+		COP p;
+		LEAD_CAR l;
+	} ai;
+	int* inform;
+	short thrust;
+	short felonyRating;
+	char handbrake;
+	char wheelspin;
+	char wasOnGround;
+	char lowDetail;
+	short wheel_angle;
+	unsigned short totalDamage;
+	long lastPad;
 } CAR_DATA;
 
-typedef struct _COP_DATA // hashcode: 0xDE3D2698 (dec: -566417768)
+typedef struct _COP_DATA
 {
-	int speed; // size=0, offset=0
-	int power; // size=0, offset=4
-	int min; // size=0, offset=8
-	int max; // size=0, offset=12
+	int speed;
+	int power;
+	int min;
+	int max;
 } MS_COP_DATA;
 
-struct LEAD_PARAMETERS // hashcode: 0x5849B382 (dec: 1481225090)
+struct LEAD_PARAMETERS
 {
-	int tEnd; // size=0, offset=0
-	int tAvelLimit; // size=0, offset=4
-	int tDist; // size=0, offset=8
-	int tDistMul; // size=0, offset=12
-	int tWidth; // size=0, offset=16
-	int tWidthMul; // size=0, offset=20
-	int tWidth80; // size=0, offset=24
-	int tWidth80Mul; // size=0, offset=28
-	int hEnd; // size=0, offset=32
-	int dEnd; // size=0, offset=36
-	int hDist; // size=0, offset=40
-	int hDistMul; // size=0, offset=44
-	int hWidth; // size=0, offset=48
-	int hWidthMul; // size=0, offset=52
-	int hWidth80; // size=0, offset=56
-	int hWidth80Mul; // size=0, offset=60
+	int tEnd;
+	int tAvelLimit;
+	int tDist;
+	int tDistMul;
+	int tWidth;
+	int tWidthMul;
+	int tWidth80;
+	int tWidth80Mul;
+	int hEnd;
+	int dEnd;
+	int hDist;
+	int hDistMul;
+	int hWidth;
+	int hWidthMul;
+	int hWidth80;
+	int hWidth80Mul;
 };
 
-typedef struct _EVENT // hashcode: 0xDD197EB3 (dec: -585531725)
+typedef struct _EVENT
 {
-	VECTOR position; // size=16, offset=0
-	short rotation; // size=0, offset=16
-	short timer; // size=0, offset=18
-	int* data; // size=0, offset=20
-	int* node; // size=0, offset=24
-	short flags; // size=0, offset=28
-	short radius; // size=0, offset=30
-	int model; // size=0, offset=32
-	_EVENT* next; // size=40, offset=36
+	VECTOR position;
+	short rotation;
+	short timer;
+	int* data;
+	int* node;
+	short flags;
+	short radius;
+	int model;
+	_EVENT* next;
 } EVENT;
 
-struct FixedEvent // hashcode: 0xF758406C (dec: -145211284)
+struct FixedEvent
 {
-	VECTOR position; // size=16, offset=0
-	short rotation; // size=0, offset=16
-	short active; // size=0, offset=18
-	unsigned short initialRotation; // size=0, offset=20
-	unsigned short finalRotation; // size=0, offset=22
-	unsigned short minSpeed; // size=0, offset=24
-	unsigned short maxSpeed; // size=0, offset=26
-	short flags; // size=0, offset=28
-	short radius; // size=0, offset=30
-	int model; // size=0, offset=32
-	EVENT* next; // size=40, offset=36
-	char* modelName; // size=0, offset=40
+	VECTOR position;
+	short rotation;
+	short active;
+	unsigned short initialRotation;
+	unsigned short finalRotation;
+	unsigned short minSpeed;
+	unsigned short maxSpeed;
+	short flags;
+	short radius;
+	int model;
+	EVENT* next;
+	char* modelName;
 };
 
-typedef struct MAPPING // hashcode: 0x46E5EAED (dec: 1189473005)
+typedef struct MAPPING
 {
-	unsigned short button_lookup[16]; // size=32, offset=0
-	unsigned short swap_analog; // size=0, offset=32
-	unsigned short reserved1; // size=0, offset=34
+	unsigned short button_lookup[16];
+	unsigned short swap_analog;
+	unsigned short reserved1;
 } *LPMAPPING;
 
-struct SAVED_PLAYER_POS // hashcode: 0x3269504F (dec: 845762639)
+struct SAVED_PLAYER_POS
 {
-	unsigned short type; // size=0, offset=0
-	short direction; // size=0, offset=2
-	long vx; // size=0, offset=4
-	long vy; // size=0, offset=8
-	long vz; // size=0, offset=12
-	unsigned long felony; // size=0, offset=16
-	unsigned short totaldamage; // size=0, offset=20
-	short damage[6]; // size=12, offset=22
+	unsigned short type;
+	short direction;
+	long vx;
+	long vy;
+	long vz;
+	unsigned long felony;
+	unsigned short totaldamage;
+	short damage[6];
 };
 
-struct SAVED_CAR_POS // hashcode: 0x02E940CC (dec: 48840908)
+struct SAVED_CAR_POS
 {
-	char active; // size=0, offset=0
-	unsigned char model; // size=0, offset=1
-	unsigned char palette; // size=0, offset=2
-	unsigned short totaldamage; // size=0, offset=4
-	unsigned short damage[6]; // size=12, offset=6
-	short direction; // size=0, offset=18
-	long vx; // size=0, offset=20
-	long vy; // size=0, offset=24
-	long vz; // size=0, offset=28
+	char active;
+	unsigned char model;
+	unsigned char palette;
+	unsigned short totaldamage;
+	unsigned short damage[6];
+	short direction;
+	long vx;
+	long vy;
+	long vz;
 };
 
-struct MISSION_DATA // hashcode: 0x2CE3A08C (dec: 753115276)
+struct MISSION_DATA
 {
-	SAVED_PLAYER_POS PlayerPos; // size=36, offset=0
-	SAVED_CAR_POS CarPos[6]; // size=192, offset=36
+	SAVED_PLAYER_POS PlayerPos;
+	SAVED_CAR_POS CarPos[6];
 };
 
-struct SCORE_ENTRY // hashcode: 0xD0B3A6C6 (dec: -793532730)
+struct SCORE_ENTRY
 {
-	int time; // size=0, offset=0
-	short items; // size=0, offset=4
-	char name[6]; // size=6, offset=6
+	int time;
+	short items;
+	char name[6];
 };
 
-struct SCORE_TABLES // hashcode: 0xDB95702F (dec: -610963409)
+struct SCORE_TABLES
 {
-	SCORE_ENTRY GetawayTable[4][2][5]; // size=480, offset=0
-	SCORE_ENTRY GateRaceTable[4][2][5]; // size=480, offset=480
-	SCORE_ENTRY CheckpointTable[4][2][5]; // size=480, offset=960
-	SCORE_ENTRY TrailblazerTable[4][2][5]; // size=480, offset=1440
-	SCORE_ENTRY SurvivalTable[4][1][5]; // size=240, offset=1920
+	SCORE_ENTRY GetawayTable[4][2][5];
+	SCORE_ENTRY GateRaceTable[4][2][5];
+	SCORE_ENTRY CheckpointTable[4][2][5];
+	SCORE_ENTRY TrailblazerTable[4][2][5];
+	SCORE_ENTRY SurvivalTable[4][1][5];
 };
 
-struct ACTIVE_CHEATS // hashcode: 0x2127EFE8 (dec: 556265448)
+struct ACTIVE_CHEATS
 {
-	unsigned char cheat1 : 1; // size=1, offset=0
-	unsigned char cheat2 : 1; // size=1, offset=1
-	unsigned char cheat3 : 1; // size=1, offset=2
-	unsigned char cheat4 : 1; // size=1, offset=3
-	unsigned char cheat5 : 1; // size=1, offset=4
-	unsigned char cheat6 : 1; // size=1, offset=5
-	unsigned char cheat7 : 1; // size=1, offset=6
-	unsigned char cheat8 : 1; // size=1, offset=7
-	unsigned char cheat9 : 1; // size=1, offset=8
-	unsigned char cheat10 : 1; // size=1, offset=9
-	unsigned char cheat11 : 1; // size=1, offset=10
-	unsigned char cheat12 : 1; // size=1, offset=11
-	unsigned char cheat13 : 1; // size=1, offset=12
-	unsigned char cheat14 : 1; // size=1, offset=13
-	unsigned char cheat15 : 1; // size=1, offset=14
-	unsigned char cheat16 : 1; // size=1, offset=15
-	unsigned char reserved1; // size=0, offset=2
-	unsigned char reserved2; // size=0, offset=3
+	unsigned char cheat1 : 1;
+	unsigned char cheat2 : 1;
+	unsigned char cheat3 : 1;
+	unsigned char cheat4 : 1;
+	unsigned char cheat5 : 1;
+	unsigned char cheat6 : 1;
+	unsigned char cheat7 : 1;
+	unsigned char cheat8 : 1;
+	unsigned char cheat9 : 1;
+	unsigned char cheat10 : 1;
+	unsigned char cheat11 : 1;
+	unsigned char cheat12 : 1;
+	unsigned char cheat13 : 1;
+	unsigned char cheat14 : 1;
+	unsigned char cheat15 : 1;
+	unsigned char cheat16 : 1;
+	unsigned char reserved1;
+	unsigned char reserved2;
 };
 
-struct STREAM_SOURCE // hashcode: 0x81E93B6E (dec: -2115421330)
+struct STREAM_SOURCE
 {
-	unsigned char type; // size=0, offset=0
-	unsigned char model; // size=0, offset=1
-	unsigned char palette; // size=0, offset=2
-	char controlType; // size=0, offset=3
-	unsigned short flags; // size=0, offset=4
-	unsigned short rotation; // size=0, offset=6
-	VECTOR_NOPAD position; // size=12, offset=8
-	int totaldamage; // size=0, offset=20
-	int damage[6]; // size=24, offset=24
+	unsigned char type;
+	unsigned char model;
+	unsigned char palette;
+	char controlType;
+	unsigned short flags;
+	unsigned short rotation;
+	VECTOR_NOPAD position;
+	int totaldamage;
+	int damage[6];
 };
 
 typedef unsigned char u_char;
@@ -580,25 +580,25 @@ typedef unsigned short gid_t;
 
 typedef void (*SsMarkCallbackProc)();
 
-struct MODEL // hashcode: 0x3A42A4FE (dec: 977446142)
+struct MODEL
 {
-	unsigned short shape_flags; // size=0, offset=0
-	unsigned short flags2; // size=0, offset=2
-	short instance_number; // size=0, offset=4
-	unsigned char tri_verts; // size=0, offset=6
-	unsigned char zBias; // size=0, offset=7
-	short bounding_sphere; // size=0, offset=8
-	unsigned short num_point_normals; // size=0, offset=10
-	unsigned short num_vertices; // size=0, offset=12
-	unsigned short num_polys; // size=0, offset=14
-	int vertices; // size=0, offset=16				SVECTOR list
-	int poly_block; // size=0, offset=20			POLY* list
-	int normals; // size=0, offset=24				SVECTOR list
-	int point_normals; // size=0, offset=28			SVECTOR list
-	int collision_block; // size=0, offset=32		COLLISION_PACKET list
+	unsigned short shape_flags;
+	unsigned short flags2;
+	short instance_number;
+	unsigned char tri_verts;
+	unsigned char zBias;
+	short bounding_sphere;
+	unsigned short num_point_normals;
+	unsigned short num_vertices;
+	unsigned short num_polys;
+	int vertices;
+	int poly_block;
+	int normals;
+	int point_normals;
+	int collision_block;
 };
 
-typedef enum PAUSEMODE // Hashcode: 0x086AB147 (dec: 141209927)
+typedef enum PAUSEMODE
 {
 	PAUSEMODE_PAUSE = 0,
 	PAUSEMODE_PAUSEP1 = 1,
@@ -608,107 +608,107 @@ typedef enum PAUSEMODE // Hashcode: 0x086AB147 (dec: 141209927)
 	PAUSEMODE_PADERROR = 5,
 } PAUSEMODE;
 
-struct UV // hashcode: 0xB11A813B (dec: -1323663045)
+struct UV
 {
-	unsigned char u0; // size=0, offset=0
-	unsigned char v0; // size=0, offset=1
-	unsigned char u1; // size=0, offset=2
-	unsigned char v1; // size=0, offset=3
-	unsigned char u2; // size=0, offset=4
-	unsigned char v2; // size=0, offset=5
-	unsigned char u3; // size=0, offset=6
-	unsigned char v3; // size=0, offset=7
+	unsigned char u0;
+	unsigned char v0;
+	unsigned char u1;
+	unsigned char v1;
+	unsigned char u2;
+	unsigned char v2;
+	unsigned char u3;
+	unsigned char v3;
 };
 
-struct TEXTURE_DETAILS // hashcode: 0xBFBD097F (dec: -1078130305)
+struct TEXTURE_DETAILS
 {
-	UV coords; // size=8, offset=0
-	unsigned short tpageid; // size=0, offset=8
-	unsigned short clutid; // size=0, offset=10
-	char texture_number; // size=0, offset=12
-	char texture_page; // size=0, offset=13
+	UV coords;
+	unsigned short tpageid;
+	unsigned short clutid;
+	char texture_number;
+	char texture_page;
 };
 
-struct CELL_OBJECT // hashcode: 0xD26720D4 (dec: -764993324)
+struct CELL_OBJECT
 {
-	VECTOR_NOPAD pos; // size=12, offset=0
-	unsigned char pad; // size=0, offset=12
-	unsigned char yang; // size=0, offset=13
-	unsigned short type; // size=0, offset=14
+	VECTOR_NOPAD pos;
+	unsigned char pad;
+	unsigned char yang;
+	unsigned short type;
 };
 
-struct ANIMATED_OBJECT // hashcode: 0xBC1CAB6E (dec: -1138971794)
+struct ANIMATED_OBJECT
 {
-	int internal_id; // size=0, offset=0
-	int model_num; // size=0, offset=4
-	char* name; // size=0, offset=8
-	char LitPoly; // size=0, offset=12
+	int internal_id;
+	int model_num;
+	char* name;
+	char LitPoly;
 };
 
-struct SMASHABLE_OBJECT // hashcode: 0x15B5F719 (dec: 364246809)
+struct SMASHABLE_OBJECT
 {
-	int modelIdx; // size=0, offset=0
-	char* name; // size=0, offset=4
-	int sound; // size=0, offset=8
-	int volume; // size=0, offset=12
-	int pitch; // size=0, offset=16
+	int modelIdx;
+	char* name;
+	int sound;
+	int volume;
+	int pitch;
 };
 
-struct GARAGE_DOOR // hashcode: 0x830EFAED (dec: -2096170259)
+struct GARAGE_DOOR
 {
-	CELL_OBJECT* cop; // size=16, offset=0
-	VECTOR_NOPAD old_pos; // size=12, offset=4
-	VECTOR_NOPAD pos; // size=12, offset=16
-	short rotation; // size=0, offset=28
-	char yang; // size=0, offset=30
+	CELL_OBJECT* cop;
+	VECTOR_NOPAD old_pos;
+	VECTOR_NOPAD pos;
+	short rotation;
+	char yang;
 };
 
-struct RGB16 // hashcode: 0xDC722146 (dec: -596500154)
+struct RGB16
 {
-	short r; // size=0, offset=0
-	short g; // size=0, offset=2
-	short b; // size=0, offset=4
-	short pad; // size=0, offset=6
+	short r;
+	short g;
+	short b;
+	short pad;
 };
 
-struct UnpaddedHackVector // hashcode: 0x83568E05 (dec: -2091479547)
+struct UnpaddedHackVector
 {
-	int vx; // size=0, offset=0
-	int vz; // size=0, offset=4
-	short vy; // size=0, offset=8
+	int vx;
+	int vz;
+	short vy;
 };
 
-struct UnpaddedCharVector // hashcode: 0xCF0188EA (dec: -821982998)
+struct UnpaddedCharVector
 {
-	char vx; // size=0, offset=0
-	char vy; // size=0, offset=1
-	char vz; // size=0, offset=2
+	char vx;
+	char vy;
+	char vz;
 };
 
-struct BVECTOR // hashcode: 0xD3E280B3 (dec: -740130637)
+struct BVECTOR
 {
-	char vx; // size=0, offset=0
-	char vy; // size=0, offset=1
-	char vz; // size=0, offset=2
-	char pad; // size=0, offset=3
+	char vx;
+	char vy;
+	char vz;
+	char pad;
 };
 
-struct ADJACENT_ROAD_INFO // hashcode: 0xB24A0A42 (dec: -1303770558)
+struct ADJACENT_ROAD_INFO
 {
-	DVECTOR offset; // size=4, offset=0
-	GAP_INFO gap; // size=6, offset=4
+	DVECTOR offset;
+	GAP_INFO gap;
 };
 
-struct FELONY_DELAY // hashcode: 0x62906D28 (dec: 1653632296)
+struct FELONY_DELAY
 {
-	short current; // size=0, offset=0
-	short maximum; // size=0, offset=2
+	short current;
+	short maximum;
 };
 
-struct FELONY_VALUE // hashcode: 0x8F078047 (dec: -1895333817)
+struct FELONY_VALUE
 {
-	short placid; // size=0, offset=0
-	short angry; // size=0, offset=2
+	short placid;
+	short angry;
 };
 
 enum TARGET_TYPE
@@ -781,11 +781,11 @@ struct MS_TARGET_EVENT
 	int loseMessage;	// data 14
 };
 
-typedef struct _TARGET// hashcode: 0xB3C67F7D (dec: -1278836867)
+typedef struct _TARGET
 {
 	union
 	{
-		int data[16]; // size=64, offset=0
+		int data[16];
 		MS_TARGET_BASE base;
 		MS_TARGET_POINT point;
 		MS_TARGET_CAR car;
@@ -793,18 +793,18 @@ typedef struct _TARGET// hashcode: 0xB3C67F7D (dec: -1278836867)
 	};
 } MS_TARGET;
 
-struct MR_TIMER // hashcode: 0xEA39F36E (dec: -365300882)
+struct MR_TIMER
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	unsigned char flags; // size=0, offset=4
-	unsigned char min; // size=0, offset=5
-	unsigned char sec; // size=0, offset=6
-	unsigned char frac; // size=0, offset=7
-	long count; // size=0, offset=8
+	short x;
+	short y;
+	unsigned char flags;
+	unsigned char min;
+	unsigned char sec;
+	unsigned char frac;
+	long count;
 };
 
-enum PED_ACTION_TYPE : char // Hashcode: 0x3531DCAF (dec: 892460207)
+enum PED_ACTION_TYPE : char
 {
 	PED_ACTION_WALK = 0,
 	PED_ACTION_RUN = 1,
@@ -824,7 +824,7 @@ enum PED_ACTION_TYPE : char // Hashcode: 0x3531DCAF (dec: 892460207)
 	PED_ACTION_STOPPING = 15,
 };
 
-enum PED_MODEL_TYPES : char // Hashcode: 0x2858A7E3 (dec: 676898787)
+enum PED_MODEL_TYPES : char
 {
 	TANNER_MODEL = 0,
 	OTHER_MODEL = 1,
@@ -834,227 +834,227 @@ enum PED_MODEL_TYPES : char // Hashcode: 0x2858A7E3 (dec: 676898787)
 
 typedef void(*pedFunc)(struct PEDESTRIAN* pPed);
 
-typedef struct PEDESTRIAN // hashcode: 0xF569ED7C (dec: -177607300)
+typedef struct PEDESTRIAN
 {
-	PEDESTRIAN* pNext; // size=92, offset=0
-	PEDESTRIAN* pPrev; // size=92, offset=4
-	pedFunc fpRestState; // size=0, offset=8
-	pedFunc fpAgitatedState; // size=0, offset=12
-	char padId; // size=0, offset=16
-	PED_MODEL_TYPES pedType; // size=1, offset=17
-	VECTOR_NOPAD position; // size=12, offset=20
-	SVECTOR dir; // size=8, offset=32
-	SVECTOR velocity; // size=8, offset=40
-	VECTOR target; // size=16, offset=48
-	int flags; // size=0, offset=64
-	short head_pos; // size=0, offset=68
-	short head_rot; // size=0, offset=70
-	short index; // size=0, offset=72
-	short last_dir; // size=0, offset=74
-	short interest; // size=0, offset=76
-	char frame1; // size=0, offset=78
-	char* motion; // size=0, offset=80
-	char speed; // size=0, offset=84
-	char doing_turn; // size=0, offset=85
-	char finished_turn; // size=0, offset=86
-	char seat_index; // size=0, offset=87
-	unsigned char pallet; // size=0, offset=88
-	PED_ACTION_TYPE type; // size=1, offset=89
+	PEDESTRIAN* pNext;
+	PEDESTRIAN* pPrev;
+	pedFunc fpRestState;
+	pedFunc fpAgitatedState;
+	char padId;
+	PED_MODEL_TYPES pedType;
+	VECTOR_NOPAD position;
+	SVECTOR dir;
+	SVECTOR velocity;
+	VECTOR target;
+	int flags;
+	short head_pos;
+	short head_rot;
+	short index;
+	short last_dir;
+	short interest;
+	char frame1;
+	char* motion;
+	char speed;
+	char doing_turn;
+	char finished_turn;
+	char seat_index;
+	unsigned char pallet;
+	PED_ACTION_TYPE type;
 } *LPPEDESTRIAN;
 
-typedef struct __skidinfo // hashcode: 0x807ED49D (dec: -2139171683)
+typedef struct __skidinfo
 {
-	char chan; // size=0, offset=0
-	char sound; // size=0, offset=1
+	char chan;
+	char sound;
 } skidinfo;
 
-typedef struct __horninfo // hashcode: 0x09E3B159 (dec: 165917017)
+typedef struct __horninfo
 {
-	char on; // size=0, offset=0
-	char time; // size=0, offset=1
-	char request; // size=0, offset=2
+	char on;
+	char time;
+	char request;
 } horninfo;
 
-struct CYCLE_OBJECT // hashcode: 0x61BB6061 (dec: 1639669857)
+struct CYCLE_OBJECT
 {
-	char* name; // size=0, offset=0
-	short vx; // size=0, offset=4
-	short vy; // size=0, offset=6
-	short start1; // size=0, offset=8
-	short stop1; // size=0, offset=10
-	short speed1; // size=0, offset=12
-	short start2; // size=0, offset=14
-	short stop2; // size=0, offset=16
-	short speed2; // size=0, offset=18
+	char* name;
+	short vx;
+	short vy;
+	short start1;
+	short stop1;
+	short speed1;
+	short start2;
+	short stop2;
+	short speed2;
 };
 
-struct COLOUR_BAND // hashcode: 0x1D8D5AB8 (dec: 495803064)
+struct COLOUR_BAND
 {
-	CVECTOR colour; // size=4, offset=0
-	int value; // size=0, offset=4
-	int flags; // size=0, offset=8
+	CVECTOR colour;
+	int value;
+	int flags;
 };
 
-typedef struct _PERCENTAGE_BAR // hashcode: 0x56E8855E (dec: 1458079070)
+typedef struct _PERCENTAGE_BAR
 {
-	char* tag; // size=0, offset=0
-	short xpos; // size=0, offset=4
-	short ypos; // size=0, offset=6
-	short width; // size=0, offset=8
-	short height; // size=0, offset=10
-	unsigned short position; // size=0, offset=12
-	unsigned short max; // size=0, offset=14
-	COLOUR_BAND* pColourBand; // size=12, offset=16
-	int flags; // size=0, offset=20
-	int active; // size=0, offset=24
+	char* tag;
+	short xpos;
+	short ypos;
+	short width;
+	short height;
+	unsigned short position;
+	unsigned short max;
+	COLOUR_BAND* pColourBand;
+	int flags;
+	int active;
 } PERCENTAGE_BAR, *LPPERCENTAGE_BAR;
 
-struct COP_SIGHT_DATA // hashcode: 0x4400B303 (dec: 1140896515)
+struct COP_SIGHT_DATA
 {
-	short surroundViewDistance; // size=0, offset=0
-	short frontViewDistance; // size=0, offset=2
-	short frontViewAngle; // size=0, offset=4
+	short surroundViewDistance;
+	short frontViewDistance;
+	short frontViewAngle;
 };
 
-struct MAPTEX // hashcode: 0x0693A802 (dec: 110340098)
+struct MAPTEX
 {
-	short u; // size=0, offset=0
-	short w; // size=0, offset=2
-	short v; // size=0, offset=4
-	short h; // size=0, offset=6
+	short u;
+	short w;
+	short v;
+	short h;
 };
 
-struct OVERMAP // hashcode: 0x34D52BCC (dec: 886385612)
+struct OVERMAP
 {
-	int x_offset; // size=0, offset=0
-	int y_offset; // size=0, offset=4
-	int width; // size=0, offset=8
-	int height; // size=0, offset=12
-	unsigned char toptile; // size=0, offset=16
-	unsigned char dummy; // size=0, offset=17
-	int scale; // size=0, offset=20
+	int x_offset;
+	int y_offset;
+	int width;
+	int height;
+	unsigned char toptile;
+	unsigned char dummy;
+	int scale;
 };
 
-struct REPLAY_PARAMETER_BLOCK // hashcode: 0xA8ABCA42 (dec: -1465136574)
+struct REPLAY_PARAMETER_BLOCK
 {
-	int RecordingEnd; // size=0, offset=0
-	VECTOR_NOPAD lead_car_start; // size=12, offset=4
-	short Lead_car_dir; // size=0, offset=16
-	unsigned char timeofday; // size=0, offset=18
-	unsigned char weather; // size=0, offset=19
+	int RecordingEnd;
+	VECTOR_NOPAD lead_car_start;
+	short Lead_car_dir;
+	unsigned char timeofday;
+	unsigned char weather;
 };
 
-struct REPLAY_SAVE_HEADER // hashcode: 0x7B872BEC (dec: 2072456172)
+struct REPLAY_SAVE_HEADER
 {
-	unsigned long magic; // size=0, offset=0
-	unsigned char GameLevel; // size=0, offset=4
-	unsigned char GameType; // size=0, offset=5
-	unsigned char reserved1; // size=0, offset=6
-	unsigned char NumReplayStreams; // size=0, offset=7
-	unsigned char NumPlayers; // size=0, offset=8
-	unsigned char RandomChase; // size=0, offset=9
-	unsigned char CutsceneEvent; // size=0, offset=10
-	unsigned char gCopDifficultyLevel; // size=0, offset=11
-	MISSION_DATA SavedData; // size=228, offset=12
-	ACTIVE_CHEATS ActiveCheats; // size=4, offset=240
-	int wantedCar[2]; // size=8, offset=244
-	int MissionNumber; // size=0, offset=252
-	int HaveStoredData; // size=0, offset=256
-	int reserved2[6]; // size=24, offset=260
+	unsigned long magic;
+	unsigned char GameLevel;
+	unsigned char GameType;
+	unsigned char reserved1;
+	unsigned char NumReplayStreams;
+	unsigned char NumPlayers;
+	unsigned char RandomChase;
+	unsigned char CutsceneEvent;
+	unsigned char gCopDifficultyLevel;
+	MISSION_DATA SavedData;
+	ACTIVE_CHEATS ActiveCheats;
+	int wantedCar[2];
+	int MissionNumber;
+	int HaveStoredData;
+	int reserved2[6];
 };
 
-struct REPLAY_STREAM_HEADER // hashcode: 0x7D77518E (dec: 2104971662)
+struct REPLAY_STREAM_HEADER
 {
-	STREAM_SOURCE SourceType; // size=48, offset=0
-	int Size; // size=0, offset=48
-	int Length; // size=0, offset=52
+	STREAM_SOURCE SourceType;
+	int Size;
+	int Length;
 };
 
-struct REPLAY_STREAM // hashcode: 0xC894D541 (dec: -929770175)
+struct REPLAY_STREAM
 {
-	STREAM_SOURCE SourceType; // size=48, offset=0
-	PADRECORD* InitialPadRecordBuffer; // size=3, offset=48
-	PADRECORD* PadRecordBuffer; // size=3, offset=52
-	PADRECORD* PadRecordBufferEnd; // size=3, offset=56
-	unsigned char playbackrun; // size=0, offset=60
-	int length; // size=0, offset=64
+	STREAM_SOURCE SourceType;
+	PADRECORD* InitialPadRecordBuffer;
+	PADRECORD* PadRecordBuffer;
+	PADRECORD* PadRecordBufferEnd;
+	unsigned char playbackrun;
+	int length;
 	int padCount;
 };
 
-typedef struct _PING_PACKET // hashcode: 0x9E8E7C27 (dec: -1634829273)
+typedef struct _PING_PACKET
 {
-	unsigned short frame; // size=0, offset=0
-	char carId; // size=0, offset=2
-	char cookieCount; // size=0, offset=3
+	unsigned short frame;
+	char carId;
+	char cookieCount;
 } PING_PACKET;
 
-struct ROADBLOCK // hashcode: 0x006C3CDD (dec: 7093469)
+struct ROADBLOCK
 {
-	VECTOR position; // size=16, offset=0
-	ADJACENT_ROAD_INFO adjacentRoadInfo; // size=10, offset=16
-	short RoadToBlock; // size=0, offset=26
-	short AdjacentRoad; // size=0, offset=28
-	short RoadblockTimer; // size=0, offset=30
-	int copRespawnTime; // size=0, offset=32
-	char NumCarsNeededForRoad; // size=0, offset=36
-	char NumCarsNeededForAdjacentRoad; // size=0, offset=37
-	char NumCarsSavedForBlock; // size=0, offset=38
-	char DirectionToRoadblock; // size=0, offset=39
-	char status; // size=0, offset=40
-	char AI_Slot[13]; // size=13, offset=41
+	VECTOR position;
+	ADJACENT_ROAD_INFO adjacentRoadInfo;
+	short RoadToBlock;
+	short AdjacentRoad;
+	short RoadblockTimer;
+	int copRespawnTime;
+	char NumCarsNeededForRoad;
+	char NumCarsNeededForAdjacentRoad;
+	char NumCarsSavedForBlock;
+	char DirectionToRoadblock;
+	char status;
+	char AI_Slot[13];
 };
 
-struct TestResult // hashcode: 0x105A4D3D (dec: 274353469)
+struct TestResult
 {
-	int depth; // size=0, offset=0
-	VECTOR location; // size=16, offset=4
-	VECTOR normal; // size=16, offset=20
+	int depth;
+	VECTOR location;
+	VECTOR normal;
 };
 
-struct BUILDING_BOX // hashcode: 0x6B53A728 (dec: 1800644392)
+struct BUILDING_BOX
 {
-	VECTOR pos; // size=16, offset=0
-	int xsize; // size=0, offset=16
-	int zsize; // size=0, offset=20
-	int theta; // size=0, offset=24
-	int height; // size=0, offset=28
+	VECTOR pos;
+	int xsize;
+	int zsize;
+	int theta;
+	int height;
 };
 
-struct CDATA2D // hashcode: 0x077C224E (dec: 125575758)
+struct CDATA2D
 {
-	VECTOR x; // size=16, offset=0
-	VECTOR axis[2]; // size=32, offset=16
-	VECTOR vel; // size=16, offset=48
-	int theta; // size=0, offset=64
-	int length[2]; // size=8, offset=68
-	int dist[2]; // size=8, offset=76
-	int limit[2]; // size=8, offset=84
-	int avel; // size=0, offset=92
-	int isCameraOrTanner; // size=0, offset=96
+	VECTOR x;
+	VECTOR axis[2];
+	VECTOR vel;
+	int theta;
+	int length[2];
+	int dist[2];
+	int limit[2];
+	int avel;
+	int isCameraOrTanner;
 };
 
-struct CRET2D // hashcode: 0x0DF86D8D (dec: 234384781)
+struct CRET2D
 {
-	VECTOR hit; // size=16, offset=0
-	VECTOR surfNormal; // size=16, offset=16
-	int penetration; // size=0, offset=32
-	int neverfree; // size=0, offset=36
+	VECTOR hit;
+	VECTOR surfNormal;
+	int penetration;
+	int neverfree;
 };
 
-typedef struct __tunnelcoords // hashcode: 0x7711175C (dec: 1997608796)
+typedef struct __tunnelcoords
 {
-	VECTOR p1; // size=16, offset=0
-	VECTOR p2; // size=16, offset=16
+	VECTOR p1;
+	VECTOR p2;
 } tunnelcoords;
 
-typedef struct __tunnelinfo // hashcode: 0xC172C5A2 (dec: -1049442910)
+typedef struct __tunnelinfo
 {
-	char num_tunnels; // size=0, offset=0
-	char tunnel_cnt; // size=0, offset=1
-	tunnelcoords coords[29]; // size=928, offset=4
+	char num_tunnels;
+	char tunnel_cnt;
+	tunnelcoords coords[29];
 } tunnelinfo;
 
-enum ExplosionType // Hashcode: 0xD0FDC1E0 (dec: -788676128)
+enum ExplosionType
 {
 	BIG_BANG = 0,
 	LITTLE_BANG = 1,
@@ -1062,188 +1062,188 @@ enum ExplosionType // Hashcode: 0xD0FDC1E0 (dec: -788676128)
 	BANG_USED = 999,
 };
 
-typedef struct _ExOBJECT // hashcode: 0x1D4ED61D (dec: 491705885)
+typedef struct _ExOBJECT
 {
-	int time; // size=0, offset=0
-	int speed; // size=0, offset=4
-	int hscale; // size=0, offset=8
-	int rscale; // size=0, offset=12
-	ExplosionType type; // size=2, offset=16
-	VECTOR pos; // size=16, offset=20
+	int time;
+	int speed;
+	int hscale;
+	int rscale;
+	ExplosionType type;
+	VECTOR pos;
 } EXOBJECT;
 
-struct BOMB // hashcode: 0x9EA608A2 (dec: -1633285982)
+struct BOMB
 {
-	unsigned char flags; // size=0, offset=0
-	unsigned char active; // size=0, offset=1
-	short rot_speed; // size=0, offset=2
-	VECTOR position; // size=16, offset=4
-	VECTOR velocity; // size=16, offset=20
+	unsigned char flags;
+	unsigned char active;
+	short rot_speed;
+	VECTOR position;
+	VECTOR velocity;
 };
 
-struct COLLISION_PACKET // hashcode: 0x404603E7 (dec: 1078330343)
+struct COLLISION_PACKET
 {
-	short type; // size=0, offset=0
-	short xpos; // size=0, offset=2
-	short ypos; // size=0, offset=4
-	short zpos; // size=0, offset=6
-	short flags; // size=0, offset=8
-	short yang; // size=0, offset=10
-	short empty; // size=0, offset=12
-	short xsize; // size=0, offset=14
-	short ysize; // size=0, offset=16
-	short zsize; // size=0, offset=18
+	short type;
+	short xpos;
+	short ypos;
+	short zpos;
+	short flags;
+	short yang;
+	short empty;
+	short xsize;
+	short ysize;
+	short zsize;
 };
 
-typedef struct _PLAYER // hashcode: 0x8C0D3284 (dec: -1945292156)
+typedef struct _PLAYER
 {
-	long pos[4]; // size=16, offset=0
-	int dir; // size=0, offset=16
-	VECTOR* spoolXZ; // size=16, offset=20
-	VECTOR cameraPos; // size=16, offset=24
-	int cameraDist; // size=0, offset=40
-	int maxCameraDist; // size=0, offset=44
-	int cameraAngle; // size=0, offset=48
-	int headPos; // size=0, offset=52
-	int headTarget; // size=0, offset=56
-	int viewChange; // size=0, offset=60
-	unsigned char dying; // size=0, offset=64
-	unsigned char upsideDown; // size=0, offset=65
-	char onGrass; // size=0, offset=66
-	char targetCarId; // size=0, offset=67
-	char cameraView; // size=0, offset=68
-	unsigned char headTimer; // size=0, offset=69
-	char playerType; // size=0, offset=70
-	char worldCentreCarId; // size=0, offset=71
-	char playerCarId; // size=0, offset=72
-	char cameraCarId; // size=0, offset=73
-	char padid; // size=0, offset=74
-	char car_is_sounding; // size=0, offset=75
-	long camera_vel[3]; // size=12, offset=76
-	int snd_cam_ang; // size=0, offset=88
-	skidinfo skidding; // size=2, offset=92
-	skidinfo wheelnoise; // size=2, offset=94
-	horninfo horn; // size=3, offset=96
-	int car_sound_timer; // size=0, offset=100
-	short revsvol; // size=0, offset=104
-	short idlevol; // size=0, offset=106
-	LPPEDESTRIAN pPed; // size=92, offset=108
-	int crash_timer; // size=0, offset=112
+	long pos[4];
+	int dir;
+	VECTOR* spoolXZ;
+	VECTOR cameraPos;
+	int cameraDist;
+	int maxCameraDist;
+	int cameraAngle;
+	int headPos;
+	int headTarget;
+	int viewChange;
+	unsigned char dying;
+	unsigned char upsideDown;
+	char onGrass;
+	char targetCarId;
+	char cameraView;
+	unsigned char headTimer;
+	char playerType;
+	char worldCentreCarId;
+	char playerCarId;
+	char cameraCarId;
+	char padid;
+	char car_is_sounding;
+	long camera_vel[3];
+	int snd_cam_ang;
+	skidinfo skidding;
+	skidinfo wheelnoise;
+	horninfo horn;
+	int car_sound_timer;
+	short revsvol;
+	short idlevol;
+	LPPEDESTRIAN pPed;
+	int crash_timer;
 } PLAYER;
 
-struct XZPAIR // hashcode: 0x0F1AD091 (dec: 253415569)
+struct XZPAIR
 {
-	int x; // size=0, offset=0
-	int z; // size=0, offset=4
+	int x;
+	int z;
 };
 
-struct CELL_DATA // hashcode: 0x016E4A08 (dec: 24005128)
+struct CELL_DATA
 {
-	unsigned short num; // size=0, offset=0
+	unsigned short num;
 };
 
-struct PACKED_CELL_OBJECT // hashcode: 0x4109E18D (dec: 1091166605)
+struct PACKED_CELL_OBJECT
 {
-	USVECTOR_NOPAD pos; // size=6, offset=0
-	unsigned short value; // size=0, offset=6
+	USVECTOR_NOPAD pos;
+	unsigned short value;
 };
 
-typedef struct PAD // hashcode: 0x3E7349EB (dec: 1047742955)
+typedef struct PAD
 {
-	unsigned char active; // size=0, offset=0
-	unsigned char type; // size=0, offset=1
-	unsigned char dualshock; // size=0, offset=2
-	unsigned char reserved1; // size=0, offset=3
-	unsigned short direct; // size=0, offset=4
-	unsigned short dirnew; // size=0, offset=6
-	char diranalog[4]; // size=4, offset=8
-	unsigned short mapped; // size=0, offset=12
-	unsigned short mapnew; // size=0, offset=14
-	char mapanalog[4]; // size=4, offset=16
-	MAPPING mappings; // size=36, offset=20
-	unsigned char alarmShakeCounter; // size=0, offset=56
-	unsigned char asd; // size=0, offset=57
-	unsigned char sdf; // size=0, offset=58
-	unsigned char dfg; // size=0, offset=59
-	unsigned char delay; // size=0, offset=60
-	unsigned char port; // size=0, offset=61
-	unsigned char state; // size=0, offset=62
-	unsigned char dsactive; // size=0, offset=63
-	unsigned char* shakeptr; // size=0, offset=64
-	unsigned char motors[2]; // size=2, offset=68
-	unsigned char shake_type; // size=0, offset=70
-	unsigned char vibrate; // size=0, offset=71
+	unsigned char active;
+	unsigned char type;
+	unsigned char dualshock;
+	unsigned char reserved1;
+	unsigned short direct;
+	unsigned short dirnew;
+	char diranalog[4];
+	unsigned short mapped;
+	unsigned short mapnew;
+	char mapanalog[4];
+	MAPPING mappings;
+	unsigned char alarmShakeCounter;
+	unsigned char asd;
+	unsigned char sdf;
+	unsigned char dfg;
+	unsigned char delay;
+	unsigned char port;
+	unsigned char state;
+	unsigned char dsactive;
+	unsigned char* shakeptr;
+	unsigned char motors[2];
+	unsigned char shake_type;
+	unsigned char vibrate;
 } *LPPAD;
 
-struct CELL_ITERATOR // hashcode: 0x4C2A91BE (dec: 1277858238)
+struct CELL_ITERATOR
 {
-	CELL_DATA* pcd; // size=2, offset=0
-	PACKED_CELL_OBJECT* ppco; // size=8, offset=4
-	XZPAIR nearCell; // size=8, offset=8
-	int use_computed; // size=0, offset=16
+	CELL_DATA* pcd;
+	PACKED_CELL_OBJECT* ppco;
+	XZPAIR nearCell;
+	int use_computed;
 };
 
-struct TEX_INFO // hashcode: 0x7C1A76C5 (dec: 2082109125)
+struct TEX_INFO
 {
-	char name[8]; // size=8, offset=0
-	char tset; // size=0, offset=8
-	char u; // size=0, offset=9
-	char v; // size=0, offset=10
-	char w; // size=0, offset=11
-	char h; // size=0, offset=12
+	char name[8];
+	char tset;
+	char u;
+	char v;
+	char w;
+	char h;
 };
 
-struct TEXTURE_LOOKUP // hashcode: 0x531E7A41 (dec: 1394506305)
+struct TEXTURE_LOOKUP
 {
-	TEX_INFO(*Damage[6]); // size=24, offset=0
+	TEX_INFO(*Damage[6]);
 };
 
-struct plotCarGlobals // hashcode: 0xED466FF8 (dec: -314150920)
+struct plotCarGlobals
 {
-	unsigned char* primptr; // size=0, offset=0
-	OTTYPE* ot; // size=0, offset=4
-	unsigned long intensity; // size=0, offset=8
-	unsigned short* pciv_clut; // size=0, offset=12
-	unsigned long ShineyTPageASL16; // size=0, offset=16
-	unsigned long ShineyClutASL16; // size=0, offset=20
-	unsigned char* damageLevel; // size=0, offset=24
-	unsigned char* shineyTable; // size=0, offset=28
-	int ghost; // size=0, offset=32
+	unsigned char* primptr;
+	OTTYPE* ot;
+	unsigned long intensity;
+	unsigned short* pciv_clut;
+	unsigned long ShineyTPageASL16;
+	unsigned long ShineyClutASL16;
+	unsigned char* damageLevel;
+	unsigned char* shineyTable;
+	int ghost;
 };
 
-typedef struct _EXTRA_CIV_DATA // hashcode: 0x98F5BF74 (dec: -1728725132)
+typedef struct _EXTRA_CIV_DATA
 {
-	int surfInd; // size=0, offset=0
-	int distAlongSegment; // size=0, offset=4
-	short angle; // size=0, offset=8
-	unsigned short ctrlState; // size=0, offset=10
-	int thrustState; // size=0, offset=12
-	unsigned char palette; // size=0, offset=16
-	unsigned char controlFlags; // size=0, offset=17
+	int surfInd;
+	int distAlongSegment;
+	short angle;
+	unsigned short ctrlState;
+	int thrustState;
+	unsigned char palette;
+	unsigned char controlFlags;
 } EXTRA_CIV_DATA;
 
-struct COP_DATA // hashcode: 0x2EAA754B (dec: 782923083)
+struct COP_DATA
 {
-	int autoMaxPowerScaleLimit; // size=0, offset=0
-	int autoDesiredSpeedScaleLimit; // size=0, offset=4
-	int autoRespawnScaleLimit; // size=0, offset=8
-	int autoBatterPlayerTrigger; // size=0, offset=12
-	int immortal; // size=0, offset=16
-	int roadblockTrigger; // size=0, offset=20
-	int cutOffPowerScale; // size=0, offset=24
-	int cutOffDistance; // size=0, offset=28
-	short trigger[5]; // size=10, offset=32
+	int autoMaxPowerScaleLimit;
+	int autoDesiredSpeedScaleLimit;
+	int autoRespawnScaleLimit;
+	int autoBatterPlayerTrigger;
+	int immortal;
+	int roadblockTrigger;
+	int cutOffPowerScale;
+	int cutOffDistance;
+	short trigger[5];
 };
 
-struct FELONY_DATA // hashcode: 0x2264AF24 (dec: 577023780)
+struct FELONY_DATA
 {
-	FELONY_DELAY occurrenceDelay[12]; // size=48, offset=0
-	FELONY_DELAY reoccurrenceDelay[12]; // size=48, offset=48
-	FELONY_VALUE value[12]; // size=48, offset=96
-	int pursuitFelonyScale; // size=0, offset=144
+	FELONY_DELAY occurrenceDelay[12];
+	FELONY_DELAY reoccurrenceDelay[12];
+	FELONY_VALUE value[12];
+	int pursuitFelonyScale;
 };
 
-enum AIZone // Hashcode: 0x51DDC1C4 (dec: 1373487556)
+enum AIZone
 {
 	zoneFrnt = 0,
 	zoneBack = 1,
@@ -1251,342 +1251,342 @@ enum AIZone // Hashcode: 0x51DDC1C4 (dec: 1373487556)
 	zoneRght = 3,
 };
 
-struct iVectNT // hashcode: 0x3D8D0417 (dec: 1032651799)
+struct iVectNT
 {
-	int n; // size=0, offset=0
-	int t; // size=0, offset=4
+	int n;
+	int t;
 };
 
-struct PLAYBACKCAMERA // hashcode: 0xF83C80A8 (dec: -130252632)
+struct PLAYBACKCAMERA
 {
-	VECTOR_NOPAD position; // size=12, offset=0
-	SVECTOR angle; // size=8, offset=12
-	int FrameCnt; // size=0, offset=20
-	short CameraPosvy; // size=0, offset=24
-	short scr_z; // size=0, offset=26
-	short gCameraMaxDistance; // size=0, offset=28
-	short gCameraAngle; // size=0, offset=30
-	unsigned char cameraview; // size=0, offset=32
-	unsigned char next; // size=0, offset=33
-	unsigned char prev; // size=0, offset=34
-	unsigned char idx; // size=0, offset=35
+	VECTOR_NOPAD position;
+	SVECTOR angle;
+	int FrameCnt;
+	short CameraPosvy;
+	short scr_z;
+	short gCameraMaxDistance;
+	short gCameraAngle;
+	unsigned char cameraview;
+	unsigned char next;
+	unsigned char prev;
+	unsigned char idx;
 };
 
-struct CUTSCENE_BUFFER // hashcode: 0x4B940558 (dec: 1267991896)
+struct CUTSCENE_BUFFER
 {
-	int numResident; // size=0, offset=0
-	unsigned char residentCutscenes[4]; // size=4, offset=4
-	char(*residentPointers[4]); // size=16, offset=8
-	char* currentPointer; // size=0, offset=24
-	int bytesFree; // size=0, offset=28
-	char buffer[8192]; // size=8192, offset=32
+	int numResident;
+	unsigned char residentCutscenes[4];
+	char(*residentPointers[4]);
+	char* currentPointer;
+	int bytesFree;
+	char buffer[8192];
 };
 
-struct CUTSCENE_INFO // hashcode: 0x57BD570A (dec: 1472026378)
+struct CUTSCENE_INFO
 {
-	unsigned short offset; // size=0, offset=0
-	unsigned short size; // size=0, offset=2
+	unsigned short offset;
+	unsigned short size;
 };
 
-struct CUTSCENE_HEADER // hashcode: 0xAC6560B4 (dec: -1402642252)
+struct CUTSCENE_HEADER
 {
-	int maxsize; // size=0, offset=0
-	CUTSCENE_INFO data[15]; // size=60, offset=4
+	int maxsize;
+	CUTSCENE_INFO data[15];
 };
 
-struct TPAN // hashcode: 0x984DCD6C (dec: -1739731604)
+struct TPAN
 {
-	unsigned char texture_page; // size=0, offset=0
-	unsigned char texture_number; // size=0, offset=1
+	unsigned char texture_page;
+	unsigned char texture_number;
 };
 
-struct POLYFT4 // hashcode: 0x0B933067 (dec: 194195559)
+struct POLYFT4
 {
-	unsigned char id; // size=0, offset=0
-	unsigned char texture_set; // size=0, offset=1
-	unsigned char texture_id; // size=0, offset=2
-	unsigned char spare; // size=0, offset=3
-	unsigned char v0; // size=0, offset=4
-	unsigned char v1; // size=0, offset=5
-	unsigned char v2; // size=0, offset=6
-	unsigned char v3; // size=0, offset=7
-	UV_INFO uv0; // size=2, offset=8
-	UV_INFO uv1; // size=2, offset=10
-	UV_INFO uv2; // size=2, offset=12
-	UV_INFO uv3; // size=2, offset=14
-	RGB color; // size=4, offset=16
+	unsigned char id;
+	unsigned char texture_set;
+	unsigned char texture_id;
+	unsigned char spare;
+	unsigned char v0;
+	unsigned char v1;
+	unsigned char v2;
+	unsigned char v3;
+	UV_INFO uv0;
+	UV_INFO uv1;
+	UV_INFO uv2;
+	UV_INFO uv3;
+	RGB color;
 };
 
-struct POLYGT4 // hashcode: 0x9BF00654 (dec: -1678768556)
+struct POLYGT4
 {
-	unsigned char id; // size=0, offset=0
-	unsigned char texture_set; // size=0, offset=1
-	unsigned char texture_id; // size=0, offset=2
-	unsigned char spare; // size=0, offset=3
-	unsigned char v0; // size=0, offset=4
-	unsigned char v1; // size=0, offset=5
-	unsigned char v2; // size=0, offset=6
-	unsigned char v3; // size=0, offset=7
-	unsigned char n0; // size=0, offset=8
-	unsigned char n1; // size=0, offset=9
-	unsigned char n2; // size=0, offset=10
-	unsigned char n3; // size=0, offset=11
-	UV_INFO uv0; // size=2, offset=12
-	UV_INFO uv1; // size=2, offset=14
-	UV_INFO uv2; // size=2, offset=16
-	UV_INFO uv3; // size=2, offset=18
-	RGB color; // size=4, offset=20
+	unsigned char id;
+	unsigned char texture_set;
+	unsigned char texture_id;
+	unsigned char spare;
+	unsigned char v0;
+	unsigned char v1;
+	unsigned char v2;
+	unsigned char v3;
+	unsigned char n0;
+	unsigned char n1;
+	unsigned char n2;
+	unsigned char n3;
+	UV_INFO uv0;
+	UV_INFO uv1;
+	UV_INFO uv2;
+	UV_INFO uv3;
+	RGB color;
 };
 
 
-struct SMOKE // hashcode: 0x9F745C35 (dec: -1619764171)
+struct SMOKE
 {
-	UnpaddedHackVector position; // size=12, offset=0
-	UnpaddedCharVector drift; // size=3, offset=12
-	UnpaddedCharVector drift_change; // size=3, offset=15
-	UnpaddedHackVector final_tail_pos; // size=12, offset=20
-	unsigned char step; // size=0, offset=32
-	unsigned char pos; // size=0, offset=33
-	short start_w; // size=0, offset=34
-	short final_w; // size=0, offset=36
-	char life; // size=0, offset=38
-	char halflife; // size=0, offset=39
-	unsigned short flags; // size=0, offset=40
-	unsigned char num; // size=0, offset=42
-	unsigned char t_step; // size=0, offset=43
-	short transparency; // size=0, offset=44
+	UnpaddedHackVector position;
+	UnpaddedCharVector drift;
+	UnpaddedCharVector drift_change;
+	UnpaddedHackVector final_tail_pos;
+	unsigned char step;
+	unsigned char pos;
+	short start_w;
+	short final_w;
+	char life;
+	char halflife;
+	unsigned short flags;
+	unsigned char num;
+	unsigned char t_step;
+	short transparency;
 };
 
-struct DEBRIS // hashcode: 0x7F875F65 (dec: 2139578213)
+struct DEBRIS
 {
-	VECTOR position; // size=16, offset=0
-	SVECTOR direction; // size=8, offset=16
-	unsigned short life; // size=0, offset=24
-	unsigned short flags; // size=0, offset=26
-	unsigned short num; // size=0, offset=28
-	unsigned short pos; // size=0, offset=30
-	RGB rgb; // size=4, offset=32
-	char step; // size=0, offset=36
-	char type; // size=0, offset=37
+	VECTOR position;
+	SVECTOR direction;
+	unsigned short life;
+	unsigned short flags;
+	unsigned short num;
+	unsigned short pos;
+	RGB rgb;
+	char step;
+	char type;
 };
 
-struct LEAF // hashcode: 0x8E232930 (dec: -1910298320)
+struct LEAF
 {
-	VECTOR position; // size=16, offset=0
-	SVECTOR direction; // size=8, offset=16
-	unsigned short life; // size=0, offset=24
-	unsigned short flags; // size=0, offset=26
-	unsigned short num; // size=0, offset=28
-	unsigned short pos; // size=0, offset=30
-	RGB rgb; // size=4, offset=32
-	char step; // size=0, offset=36
-	char type; // size=0, offset=37
-	short sin_index1; // size=0, offset=38
-	short sin_index2; // size=0, offset=40
-	char sin_addition1; // size=0, offset=42
-	char sin_addition2; // size=0, offset=43
+	VECTOR position;
+	SVECTOR direction;
+	unsigned short life;
+	unsigned short flags;
+	unsigned short num;
+	unsigned short pos;
+	RGB rgb;
+	char step;
+	char type;
+	short sin_index1;
+	short sin_index2;
+	char sin_addition1;
+	char sin_addition2;
 };
 
-struct DAMAGED_LAMP // hashcode: 0x1240B5B5 (dec: 306230709)
+struct DAMAGED_LAMP
 {
-	CELL_OBJECT* cop; // size=16, offset=0
-	char damage; // size=0, offset=4
+	CELL_OBJECT* cop;
+	char damage;
 };
 
-struct DAMAGED_OBJECT // hashcode: 0xC8C77ECE (dec: -926449970)
+struct DAMAGED_OBJECT
 {
-	CELL_OBJECT cop; // size=16, offset=0
-	char active; // size=0, offset=16
-	char damage; // size=0, offset=17
-	int rot_speed; // size=0, offset=20
-	SVECTOR velocity; // size=8, offset=24
-	int vx; // size=0, offset=32
+	CELL_OBJECT cop;
+	char active;
+	char damage;
+	int rot_speed;
+	SVECTOR velocity;
+	int vx;
 };
 
-struct TRI_POINT // hashcode: 0x50D0CFA0 (dec: 1355861920)
+struct TRI_POINT
 {
-	BVECTOR v0; // size=4, offset=0
-	BVECTOR v1; // size=4, offset=4
-	BVECTOR v2; // size=4, offset=8
+	BVECTOR v0;
+	BVECTOR v1;
+	BVECTOR v2;
 };
 
-struct TRI_POINT_LONG // hashcode: 0xAFB61D06 (dec: -1347019514)
+struct TRI_POINT_LONG
 {
-	VECTOR_NOPAD v0; // size=12, offset=0
-	VECTOR_NOPAD v1; // size=12, offset=12
-	VECTOR_NOPAD v2; // size=12, offset=24
+	VECTOR_NOPAD v0;
+	VECTOR_NOPAD v1;
+	VECTOR_NOPAD v2;
 };
 
-struct RAIN_TYPE // hashcode: 0x4B9D35B0 (dec: 1268594096)
+struct RAIN_TYPE
 {
-	VECTOR_NOPAD position; // size=12, offset=0
-	SVECTOR oldposition; // size=8, offset=12
+	VECTOR_NOPAD position;
+	SVECTOR oldposition;
 };
 
-struct LAMP_STREAK // hashcode: 0xB0E3FA15 (dec: -1327236587)
+struct LAMP_STREAK
 {
-	SXYPAIR light_trails[4]; // size=16, offset=0
-	int id; // size=0, offset=16
-	short clock; // size=0, offset=20
-	char set; // size=0, offset=22
+	SXYPAIR light_trails[4];
+	int id;
+	short clock;
+	char set;
 };
 
-struct ROUTE_DATA // hashcode: 0xBBEEB7AD (dec: -1141983315)
+struct ROUTE_DATA
 {
-	short type; // size=0, offset=0
-	short height; // size=0, offset=2
-	short objectAngle; // size=0, offset=4
+	short type;
+	short height;
+	short objectAngle;
 };
 
-struct DENTUVS // hashcode: 0x7F7AFC21 (dec: 2138766369)
+struct DENTUVS
 {
-	char u3; // size=0, offset=0
+	char u3;
 };
 
-struct HUBCAP // hashcode: 0x8B4D12CD (dec: -1957883187)
+struct HUBCAP
 {
-	int Present[4]; // size=16, offset=0
-	VECTOR Offset[4]; // size=64, offset=16
-	MATRIX Orientation; // size=32, offset=80
-	MATRIX LocalOrientation; // size=32, offset=112
-	VECTOR Position; // size=16, offset=144
-	VECTOR Direction; // size=16, offset=160
-	float Height; // size=0, offset=176
-	int Duration; // size=0, offset=180
+	int Present[4];
+	VECTOR Offset[4];
+	MATRIX Orientation;
+	MATRIX LocalOrientation;
+	VECTOR Position;
+	VECTOR Direction;
+	float Height;
+	int Duration;
 };
 
-struct REPLAY_ICON // hashcode: 0x6B6009DA (dec: 1801456090)
+struct REPLAY_ICON
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	TEXTURE_DETAILS* texture; // size=14, offset=4
-	char* TextPtr; // size=0, offset=8
-	short tx; // size=0, offset=12
-	short ty; // size=0, offset=14
+	short x;
+	short y;
+	TEXTURE_DETAILS* texture;
+	char* TextPtr;
+	short tx;
+	short ty;
 };
 
-struct _pct // hashcode: 0x3CC33EEE (dec: 1019428590)
+struct _pct
 {
-	struct DB* current; // size=128, offset=0
-	unsigned short(*ptexture_pages)[128]; // size=4, offset=4
-	unsigned short(*ptexture_cluts)[128][32]; // size=4, offset=8
-	long f4colourTable[32]; // size=128, offset=12
-	int* polySizes; // size=0, offset=140
-	char* primptr; // size=0, offset=144
-	OTTYPE* ot; // size=0, offset=148
-	unsigned long clut; // size=0, offset=152
-	unsigned long tpage; // size=0, offset=156
-	unsigned long colour; // size=0, offset=160
-	int flags; // size=0, offset=164
-	SVECTOR* verts; // size=8, offset=168
-	unsigned long lastTexInfo; // size=0, offset=172
-	int scribble[8]; // size=32, offset=176
-	int model; // size=0, offset=208
+	struct DB* current;
+	unsigned short(*ptexture_pages)[128];
+	unsigned short(*ptexture_cluts)[128][32];
+	long f4colourTable[32];
+	int* polySizes;
+	char* primptr;
+	OTTYPE* ot;
+	unsigned long clut;
+	unsigned long tpage;
+	unsigned long colour;
+	int flags;
+	SVECTOR* verts;
+	unsigned long lastTexInfo;
+	int scribble[8];
+	int model;
 };
 
-struct MATRIX2 // hashcode: 0x7326ABFE (dec: 1931914238)
+struct MATRIX2
 {
-	short m[3][3]; // size=18, offset=0
-	short computed; // size=0, offset=18
-	char null[12]; // size=12, offset=20
+	short m[3][3];
+	short computed;
+	char null[12];
 };
 
-struct Spool // hashcode: 0x25ACC86C (dec: 632080492)
+struct Spool
 {
-	unsigned short offset; // size=0, offset=0
-	unsigned char connected_areas[2]; // size=2, offset=2
-	unsigned char pvs_size; // size=0, offset=4
-	unsigned char cell_data_size[3]; // size=3, offset=5
-	unsigned char super_region; // size=0, offset=8
-	unsigned char num_connected_areas; // size=0, offset=9
-	unsigned char roadm_size; // size=0, offset=10
-	unsigned char roadh_size; // size=0, offset=11
+	unsigned short offset;
+	unsigned char connected_areas[2];
+	unsigned char pvs_size;
+	unsigned char cell_data_size[3];
+	unsigned char super_region;
+	unsigned char num_connected_areas;
+	unsigned char roadm_size;
+	unsigned char roadh_size;
 };
 
 union VERT_INDEX
 {
 	struct {
-		unsigned char v0; // size=0, offset=4
-		unsigned char v1; // size=0, offset=5
-		unsigned char v2; // size=0, offset=6
-		unsigned char v3; // size=0, offset=7
+		unsigned char v0;
+		unsigned char v1;
+		unsigned char v2;
+		unsigned char v3;
 	};
 	uint value;
 };
 
-struct PL_POLYFT4 // hashcode: 0x851A459F (dec: -2061875809)
+struct PL_POLYFT4
 {
-	unsigned char id; // size=0, offset=0
-	unsigned char texture_set; // size=0, offset=1
-	unsigned char texture_id; // size=0, offset=2
-	unsigned char th; // size=0, offset=3
-	unsigned char v0; // size=0, offset=4
-	unsigned char v1; // size=0, offset=5
-	unsigned char v2; // size=0, offset=6
-	unsigned char v3; // size=0, offset=7
-	UV_INFO uv0; // size=2, offset=8
-	UV_INFO uv1; // size=2, offset=10
-	UV_INFO uv2; // size=2, offset=12
-	UV_INFO uv3; // size=2, offset=14
+	unsigned char id;
+	unsigned char texture_set;
+	unsigned char texture_id;
+	unsigned char th;
+	unsigned char v0;
+	unsigned char v1;
+	unsigned char v2;
+	unsigned char v3;
+	UV_INFO uv0;
+	UV_INFO uv1;
+	UV_INFO uv2;
+	UV_INFO uv3;
 };
 
-struct MVERTEX // hashcode: 0xCC5E5250 (dec: -866233776)
+struct MVERTEX
 {
-	short vx; // size=0, offset=0
-	short vy; // size=0, offset=2
-	short vz; // size=0, offset=4
+	short vx;
+	short vy;
+	short vz;
 	union {
 		short val;
 		struct {
-			unsigned char u0; // size=0, offset=0
-			unsigned char v0; // size=0, offset=1
+			unsigned char u0;
+			unsigned char v0;
 		};
-	}uv; // size=0, offset=6
+	}uv;
 };
 
-struct VERTEX // hashcode: 0x01A9F7DD (dec: 27916253)
+struct VERTEX
 {
-	DVECTOR coord; // size=4, offset=0
-	UV_INFO uv_coord; // size=2, offset=4
-	unsigned char pad[2]; // size=2, offset=6
+	DVECTOR coord;
+	UV_INFO uv_coord;
+	unsigned char pad[2];
 };
 
-struct TRAILBLAZER_DATA // hashcode: 0x99CBFE9E (dec: -1714684258)
+struct TRAILBLAZER_DATA
 {
-	int x; // size=0, offset=0
-	int z; // size=0, offset=4
-	short y; // size=0, offset=8
-	short rot; // size=0, offset=10
+	int x;
+	int z;
+	short y;
+	short rot;
 };
 
-struct SMASHED_CONE // hashcode: 0xC79161AF (dec: -946773585)
+struct SMASHED_CONE
 {
-	char cone; // size=0, offset=0
-	unsigned char active : 7; // size=7, offset=8
-	unsigned char side : 1; // size=1, offset=15
-	short rot_speed; // size=0, offset=2
-	VECTOR velocity; // size=16, offset=4
+	char cone;
+	unsigned char active : 7;
+	unsigned char side : 1;
+	short rot_speed;
+	VECTOR velocity;
 };
 
-struct POLYCOORD // hashcode: 0x567DCFE0 (dec: 1451085792)
+struct POLYCOORD
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	short u; // size=0, offset=4
-	short v; // size=0, offset=6
-	short w; // size=0, offset=8
-	short h; // size=0, offset=10
+	short x;
+	short y;
+	short u;
+	short v;
+	short w;
+	short h;
 };
 
-struct EventGlobal // hashcode: 0xF4852999 (dec: -192599655)
+struct EventGlobal
 {
-	int camera; // size=0, offset=0
-	int draw; // size=0, offset=4
-	EVENT** track; // size=40, offset=8
-	EVENT* cameraEvent; // size=40, offset=12
+	int camera;
+	int draw;
+	EVENT** track;
+	EVENT* cameraEvent;
 };
 
-enum SpecialCamera // Hashcode: 0xB5557F2F (dec: -1252688081)
+enum SpecialCamera
 {
 	SPECIAL_CAMERA_SET = 0,
 	SPECIAL_CAMERA_SET2 = 1,
@@ -1594,64 +1594,64 @@ enum SpecialCamera // Hashcode: 0xB5557F2F (dec: -1252688081)
 	SPECIAL_CAMERA_WAIT = 3,
 };
 
-struct MissionTrain // hashcode: 0x1C680836 (dec: 476579894)
+struct MissionTrain
 {
-	EVENT* engine; // size=40, offset=0
-	int* node; // size=0, offset=4
-	int cornerSpeed; // size=0, offset=8
-	int initialStraightSpeed; // size=0, offset=12
-	int finalStraightSpeed; // size=0, offset=16
-	int start; // size=0, offset=20
-	int startDir; // size=0, offset=24
+	EVENT* engine;
+	int* node;
+	int cornerSpeed;
+	int initialStraightSpeed;
+	int finalStraightSpeed;
+	int start;
+	int startDir;
 };
 
-struct Foam // hashcode: 0xFD0C756C (dec: -49515156)
+struct Foam
 {
-	MODEL* model; // size=36, offset=0
-	int rotate; // size=0, offset=4
+	MODEL* model;
+	int rotate;
 };
 
-struct EventCarriage // hashcode: 0xA136BEAC (dec: -1590247764)
+struct EventCarriage
 {
-	short rotation; // size=0, offset=0
-	short vel; // size=0, offset=2
+	short rotation;
+	short vel;
 };
 
-struct MultiCar // hashcode: 0x862F8E20 (dec: -2043703776)
+struct MultiCar
 {
-	EVENT* event; // size=40, offset=0
-	int count; // size=0, offset=4
+	EVENT* event;
+	int count;
 };
 
-struct Helicopter // hashcode: 0xE626A675 (dec: -433674635)
+struct Helicopter
 {
-	int speed; // size=0, offset=0
-	short pitch; // size=0, offset=4
-	short dp; // size=0, offset=6
-	short roll; // size=0, offset=8
-	short dr; // size=0, offset=10
-	int lastX; // size=0, offset=12
-	int lastZ; // size=0, offset=16
-	TEXTURE_DETAILS rotorTexture; // size=14, offset=20
-	short rotorrot; // size=0, offset=34
-	short rotorvel; // size=0, offset=36
-	int cleanModel; // size=0, offset=40
-	int deadModel; // size=0, offset=44
+	int speed;
+	short pitch;
+	short dp;
+	short roll;
+	short dr;
+	int lastX;
+	int lastZ;
+	TEXTURE_DETAILS rotorTexture;
+	short rotorrot;
+	short rotorvel;
+	int cleanModel;
+	int deadModel;
 };
 
-struct Detonator // hashcode: 0xB22424C8 (dec: -1306254136)
+struct Detonator
 {
-	int timer; // size=0, offset=0
-	int count; // size=0, offset=4
+	int timer;
+	int count;
 };
 
-struct CameraDelay // hashcode: 0xE75FD106 (dec: -413150970)
+struct CameraDelay
 {
-	int delay; // size=0, offset=0
-	int type; // size=0, offset=4
+	int delay;
+	int type;
 };
 
-enum VisType // Hashcode: 0x2316487E (dec: 588662910)
+enum VisType
 {
 	VIS_INIT = 0,
 	VIS_SORT = 1,
@@ -1659,111 +1659,111 @@ enum VisType // Hashcode: 0x2316487E (dec: 588662910)
 	VIS_NEXT = 3,
 };
 
-struct EventCamera // hashcode: 0x13E042AF (dec: 333464239)
+struct EventCamera
 {
-	VECTOR position; // size=16, offset=0
-	short yAng; // size=0, offset=16
-	MATRIX matrix; // size=32, offset=20
-	int rotate; // size=0, offset=52
+	VECTOR position;
+	short yAng;
+	MATRIX matrix;
+	int rotate;
 };
 
-enum Station // Hashcode: 0xABF98660 (dec: -1409710496)
+enum Station
 {
 	EVENT_NO_STATION = 0,
 	EVENT_APPROACHING = 1,
 	EVENT_LEAVING = 2,
 };
 
-struct MULTICAR_DATA // hashcode: 0xFB584F7B (dec: -78098565)
+struct MULTICAR_DATA
 {
-	int x; // size=0, offset=0
-	int z; // size=0, offset=4
-	unsigned char palette; // size=0, offset=8
-	unsigned char model; // size=0, offset=9
-	short rot; // size=0, offset=10
+	int x;
+	int z;
+	unsigned char palette;
+	unsigned char model;
+	short rot;
 };
 
-struct RENDER_ARG // hashcode: 0x5BAC7E8D (dec: 1538031245)
+struct RENDER_ARG
 {
-	unsigned char render; // size=0, offset=0
-	unsigned char credits; // size=0, offset=1
-	unsigned short recap; // size=0, offset=2
+	unsigned char render;
+	unsigned char credits;
+	unsigned short recap;
 };
 
-struct RENDER_ARGS // hashcode: 0x9CEEC3A3 (dec: -1662073949)
+struct RENDER_ARGS
 {
-	unsigned char nRenders; // size=0, offset=0
-	unsigned char subtitle; // size=0, offset=1
-	char screenx; // size=0, offset=2
-	char screeny; // size=0, offset=3
-	RENDER_ARG Args[4]; // size=16, offset=4
+	unsigned char nRenders;
+	unsigned char subtitle;
+	char screenx;
+	char screeny;
+	RENDER_ARG Args[4];
 };
 
-typedef struct __envsound // hashcode: 0x7218E697 (dec: 1914234519)
+typedef struct __envsound
 {
-	unsigned char type; // size=0, offset=0
-	unsigned char flags; // size=0, offset=1
-	VECTOR pos; // size=16, offset=4
-	VECTOR pos2; // size=16, offset=20
-	int bank; // size=0, offset=36
-	int sample; // size=0, offset=40
-	int vol; // size=0, offset=44
+	unsigned char type;
+	unsigned char flags;
+	VECTOR pos;
+	VECTOR pos2;
+	int bank;
+	int sample;
+	int vol;
 } envsound;
 
-typedef struct __envsoundtags // hashcode: 0x8645A61D (dec: -2042255843)
+typedef struct __envsoundtags
 {
-	int frame_cnt; // size=0, offset=0
-	int func_cnt; // size=0, offset=4
-	int num_envsnds; // size=0, offset=8
-	int envsnd_cnt; // size=0, offset=12
+	int frame_cnt;
+	int func_cnt;
+	int num_envsnds;
+	int envsnd_cnt;
 } envsoundtags;
 
-typedef struct __envsoundinfo // hashcode: 0x45AC9536 (dec: 1168938294)
+typedef struct __envsoundinfo
 {
-	VECTOR eff_pos[4]; // size=64, offset=0
-	VECTOR cam_pos; // size=16, offset=64
-	float g[4]; // size=16, offset=80
-	int thisS[4]; // size=16, offset=96
-	int playing_sound[4]; // size=16, offset=112
-	int chan[4]; // size=16, offset=128
-	unsigned long flags; // size=0, offset=144
+	VECTOR eff_pos[4];
+	VECTOR cam_pos;
+	float g[4];
+	int thisS[4];
+	int playing_sound[4];
+	int chan[4];
+	unsigned long flags;
 } envsoundinfo;
 
-struct SPEECH_QUEUE // hashcode: 0xF7AB07B1 (dec: -139786319)
+struct SPEECH_QUEUE
 {
-	char allowed; // size=0, offset=0
-	char chan; // size=0, offset=1
-	char is_playing; // size=0, offset=2
-	int count; // size=0, offset=4
-	char reverb; // size=0, offset=8
-	int slot[7]; // size=28, offset=12
+	char allowed;
+	char chan;
+	char is_playing;
+	int count;
+	char reverb;
+	int slot[7];
 };
 
-typedef struct __othercarsound // hashcode: 0x88F0C520 (dec: -1997486816)
+typedef struct __othercarsound
 {
-	int car; // size=0, offset=0
-	int chan; // size=0, offset=4
-	char in_use; // size=0, offset=8
-	char stopped; // size=0, offset=9
-	char idle; // size=0, offset=10
+	int car;
+	int chan;
+	char in_use;
+	char stopped;
+	char idle;
 } othercarsound;
 
-typedef struct __bitfield64 // hashcode: 0x2A3F54F0 (dec: 708793584)
+typedef struct __bitfield64
 {
-	long h; // size=0, offset=0
-	long l; // size=0, offset=4
+	long h;
+	long l;
 } bitfield64;
 
-struct GEAR_DESC // hashcode: 0xE4380123 (dec: -466091741)
+struct GEAR_DESC
 {
-	int lowidl_ws; // size=0, offset=0
-	int low_ws; // size=0, offset=4
-	int hi_ws; // size=0, offset=8
-	int ratio_ac; // size=0, offset=12
-	int ratio_id; // size=0, offset=16
+	int lowidl_ws;
+	int low_ws;
+	int hi_ws;
+	int ratio_ac;
+	int ratio_id;
 };
 
-enum GAMEMODE // Hashcode: 0xA71425E4 (dec: -1491851804)
+enum GAMEMODE
 {
 	GAMEMODE_NORMAL = 0,
 	GAMEMODE_QUIT = 1,
@@ -1774,99 +1774,99 @@ enum GAMEMODE // Hashcode: 0xA71425E4 (dec: -1491851804)
 	GAMEMODE_DEMO = 6,
 };
 
-struct MISSION_STEP // hashcode: 0x6445CD70 (dec: 1682296176)
+struct MISSION_STEP
 {
-	unsigned char flags : 3; // size=3, offset=0
-	unsigned char recap : 5; // size=5, offset=3
-	unsigned char data : 7; // size=7, offset=8
-	unsigned char disc : 1; // size=1, offset=15
+	unsigned char flags : 3;
+	unsigned char recap : 5;
+	unsigned char data : 7;
+	unsigned char disc : 1;
 };
 
-struct BOUND_BOX // hashcode: 0xF08E6742 (dec: -259102910)
+struct BOUND_BOX
 {
-	int x0; // size=0, offset=0
-	int y0; // size=0, offset=4
-	int z0; // size=0, offset=8
-	int x1; // size=0, offset=12
-	int y1; // size=0, offset=16
-	int z1; // size=0, offset=20
+	int x0;
+	int y0;
+	int z0;
+	int x1;
+	int y1;
+	int z1;
 };
 
-struct _HANDLING_TYPE // hashcode: 0x61CB7B87 (dec: 1640725383)
+struct _HANDLING_TYPE
 {
-	char frictionScaleRatio; // size=0, offset=0
-	char aggressiveBraking; // size=0, offset=1
-	char fourWheelDrive; // size=0, offset=2
-	char autoBrakeOn; // size=0, offset=3
+	char frictionScaleRatio;
+	char aggressiveBraking;
+	char fourWheelDrive;
+	char autoBrakeOn;
 };
 
-struct CHEATS // hashcode: 0x77AC236B (dec: 2007769963)
+struct CHEATS
 {
-	int RearWheelSteer; // size=0, offset=0
-	int MiniCars; // size=0, offset=4
-	int Stilts; // size=0, offset=8
-	int LowGravity; // size=0, offset=12
-	int Australia; // size=0, offset=16
-	int MagicMirror; // size=0, offset=20
+	int RearWheelSteer;
+	int MiniCars;
+	int Stilts;
+	int LowGravity;
+	int Australia;
+	int MagicMirror;
 };
 
-struct BOXINFO // hashcode: 0x0A20DC94 (dec: 169925780)
+struct BOXINFO
 {
-	VECTOR vel; // size=16, offset=0
-	VECTOR pos; // size=16, offset=16
-	int sf; // size=0, offset=32
-	int xs; // size=0, offset=36
-	int zs; // size=0, offset=40
-	int w; // size=0, offset=44
-	int h; // size=0, offset=48
-	int zb; // size=0, offset=52
-	int ypos; // size=0, offset=56
+	VECTOR vel;
+	VECTOR pos;
+	int sf;
+	int xs;
+	int zs;
+	int w;
+	int h;
+	int zb;
+	int ypos;
 };
 
-struct MAP_DATA // hashcode: 0x83C30077 (dec: -2084372361)
+struct MAP_DATA
 {
-	CAR_DATA* cp; // size=0, offset=0
-	VECTOR* base; // size=16, offset=4
-	VECTOR* pos; // size=16, offset=8
-	VECTOR* vel; // size=16, offset=12
-	VECTOR* size; // size=16, offset=16
-	int intention; // size=0, offset=20
-	int* map; // size=0, offset=24
-	int* local; // size=0, offset=28
+	CAR_DATA* cp;
+	VECTOR* base;
+	VECTOR* pos;
+	VECTOR* vel;
+	VECTOR* size;
+	int intention;
+	int* map;
+	int* local;
 };
 
-struct GAME_SAVE_HEADER // hashcode: 0xB1E0BE5E (dec: -1310671266)
+struct GAME_SAVE_HEADER
 {
-	unsigned long magic; // size=0, offset=0
-	unsigned char gMissionLadderPos; // size=0, offset=4
-	unsigned char pad1; // size=0, offset=5
-	unsigned char pad2; // size=0, offset=6
-	unsigned char pad3; // size=0, offset=7
-	MISSION_DATA SavedData; // size=228, offset=8
-	int reserved[8]; // size=32, offset=236
+	unsigned long magic;
+	unsigned char gMissionLadderPos;
+	unsigned char pad1;
+	unsigned char pad2;
+	unsigned char pad3;
+	MISSION_DATA SavedData;
+	int reserved[8];
 };
 
-struct CONFIG_SAVE_HEADER // hashcode: 0x6370AFC2 (dec: 1668329410)
+struct CONFIG_SAVE_HEADER
 {
-	unsigned long magic; // size=0, offset=0
-	int gMasterVolume; // size=0, offset=4
-	int gMusicVolume; // size=0, offset=8
-	int gSoundMode; // size=0, offset=12
-	int gVibration; // size=0, offset=16
-	int gCopDifficultyLevel; // size=0, offset=20
-	int gFurthestMission; // size=0, offset=24
-	MAPPING PadMapping[2]; // size=72, offset=28
-	SCORE_TABLES ScoreTables; // size=2160, offset=100
-	int PALAdjustX; // size=0, offset=2260
-	int PALAdjustY; // size=0, offset=2264
-	int NTSCAdjustX; // size=0, offset=2268
-	int NTSCAdjustY; // size=0, offset=2272
-	int gSubtitles; // size=0, offset=2276
-	ACTIVE_CHEATS AvailableCheats; // size=4, offset=2280
-	int reserved[6]; // size=24, offset=2284
+	unsigned long magic;
+	int gMasterVolume;
+	int gMusicVolume;
+	int gSoundMode;
+	int gVibration;
+	int gCopDifficultyLevel;
+	int gFurthestMission;
+	MAPPING PadMapping[2];
+	SCORE_TABLES ScoreTables;
+	int PALAdjustX;
+	int PALAdjustY;
+	int NTSCAdjustX;
+	int NTSCAdjustY;
+	int gSubtitles;
+	ACTIVE_CHEATS AvailableCheats;
+	int reserved[6];
 };
 
-enum GAMETYPE // Hashcode: 0xD623FEBE (dec: -702284098)
+enum GAMETYPE
 {
 	GAME_MISSION = 0,
 	GAME_TAKEADRIVE = 1,
@@ -1886,20 +1886,20 @@ enum GAMETYPE // Hashcode: 0xD623FEBE (dec: -702284098)
 	GAME_LOADEDREPLAY = 15,
 };
 
-struct OUT_CELL_FILE_HEADER // hashcode: 0x5665F7D5 (dec: 1449523157)
+struct OUT_CELL_FILE_HEADER
 {
-	int cells_across; // size=0, offset=0
-	int cells_down; // size=0, offset=4
-	int cell_size; // size=0, offset=8
-	int num_regions; // size=0, offset=12
-	int region_size; // size=0, offset=16
-	int num_cell_objects; // size=0, offset=20
-	int num_cell_data; // size=0, offset=24
-	int ambient_light_level; // size=0, offset=28
-	VECTOR_NOPAD light_source; // size=12, offset=32
+	int cells_across;
+	int cells_down;
+	int cell_size;
+	int num_regions;
+	int region_size;
+	int num_cell_objects;
+	int num_cell_data;
+	int ambient_light_level;
+	VECTOR_NOPAD light_source;
 };
 
-enum EXIT_VALUE // Hashcode: 0x3F23BCE8 (dec: 1059306728)
+enum EXIT_VALUE
 {
 	MENU_QUIT_NONE = 0,
 	MENU_QUIT_CONTINUE = 1,
@@ -1911,12 +1911,12 @@ enum EXIT_VALUE // Hashcode: 0x3F23BCE8 (dec: 1059306728)
 	MENU_QUIT_NEXTMISSION = 7,
 };
 
-struct XYWH // hashcode: 0x1C1E57F6 (dec: 471750646)
+struct XYWH
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	short w; // size=0, offset=4
-	short h; // size=0, offset=6
+	short x;
+	short y;
+	short w;
+	short h;
 };
 
 typedef void(*pauseFunc)(int dir);
@@ -1924,169 +1924,169 @@ typedef void(*pauseFunc)(int dir);
 struct MENU_ITEM;
 struct MENU_HEADER;
 
-struct MENU_ITEM // hashcode: 0x9519D4FB (dec: -1793469189)
+struct MENU_ITEM
 {
-	char* Text; // size=0, offset=0
-	unsigned char Type; // size=0, offset=4
-	unsigned char Justify; // size=0, offset=5
-	pauseFunc func; // size=0, offset=8
-	EXIT_VALUE ExitValue; // size=1, offset=12
-	MENU_HEADER* SubMenu; // size=0, offset=16
+	char* Text;
+	unsigned char Type;
+	unsigned char Justify;
+	pauseFunc func;
+	EXIT_VALUE ExitValue;
+	MENU_HEADER* SubMenu;
 };
 
-struct MENU_HEADER // hashcode: 0x0BDA3805 (dec: 198850565)
+struct MENU_HEADER
 {
-	char* Title; // size=0, offset=0
-	XYWH Bound; // size=8, offset=4
-	unsigned char NumItems; // size=0, offset=12
-	MENU_ITEM* MenuItems; // size=20, offset=16
+	char* Title;
+	XYWH Bound;
+	unsigned char NumItems;
+	MENU_ITEM* MenuItems;
 };
 
 
 
-struct AREA_LOAD_INFO // hashcode: 0xC55B5A7D (dec: -983868803)
+struct AREA_LOAD_INFO
 {
-	int xoffset; // size=0, offset=0
-	int zoffset; // size=0, offset=4
+	int xoffset;
+	int zoffset;
 };
 
-struct ROAD_MAP_LUMP_DATA // hashcode: 0xE3B836E2 (dec: -474466590)
+struct ROAD_MAP_LUMP_DATA
 {
-	int width; // size=0, offset=0
-	int height; // size=0, offset=4
-	int unitXMid; // size=0, offset=8
-	int unitZMid; // size=0, offset=12
+	int width;
+	int height;
+	int unitXMid;
+	int unitZMid;
 };
 
-struct __io // hashcode: 0x3FBD636F (dec: 1069376367)
+struct __io
 {
-	char in; // size=0, offset=0
-	char out; // size=0, offset=1
+	char in;
+	char out;
 };
 
-struct __xa_request // hashcode: 0xD6B93389 (dec: -692505719)
+struct __xa_request
 {
-	short delay; // size=0, offset=0
-	char bank; // size=0, offset=2
-	char track; // size=0, offset=3
-	char mission; // size=0, offset=4
-	char cutscene; // size=0, offset=5
+	short delay;
+	char bank;
+	char track;
+	char mission;
+	char cutscene;
 };
 
-struct _MISSION // hashcode: 0x85F0EB6C (dec: -2047808660)
+struct _MISSION
 {
-	int id; // size=0, offset=0
-	int size; // size=0, offset=4
-	int city; // size=0, offset=8
-	int time; // size=0, offset=12
-	int weather; // size=0, offset=16
-	XYPAIR playerStartPosition; // size=8, offset=20
-	int playerStartRotation; // size=0, offset=28
-	int type; // size=0, offset=32
-	short timer; // size=0, offset=36
-	short timerFlags; // size=0, offset=38
-	int strings; // size=0, offset=40
-	MS_COP_DATA cops; // size=16, offset=44
-	int msgCarWrecked; // size=0, offset=60
-	int msgOutOfTime; // size=0, offset=64
-	int msgComplete; // size=0, offset=68
-	int region; // size=0, offset=72
-	int route; // size=0, offset=76
-	int msgDrowned; // size=0, offset=80
-	int playerCarModel; // size=0, offset=84
-	int playerCarColour; // size=0, offset=88
-	int maxDamage; // size=0, offset=92
-	int residentModels[5]; // size=20, offset=96
-	int nCutscenes; // size=0, offset=116
-	int title; // size=0, offset=120
-	int msgPoliceCar; // size=0, offset=124
-	int msgDoorsLocked; // size=0, offset=128
+	int id;
+	int size;
+	int city;
+	int time;
+	int weather;
+	XYPAIR playerStartPosition;
+	int playerStartRotation;
+	int type;
+	short timer;
+	short timerFlags;
+	int strings;
+	MS_COP_DATA cops;
+	int msgCarWrecked;
+	int msgOutOfTime;
+	int msgComplete;
+	int region;
+	int route;
+	int msgDrowned;
+	int playerCarModel;
+	int playerCarColour;
+	int maxDamage;
+	int residentModels[5];
+	int nCutscenes;
+	int title;
+	int msgPoliceCar;
+	int msgDoorsLocked;
 };
 
-struct _ROUTE_INFO // hashcode: 0x5A21DB68 (dec: 1512168296)
+struct _ROUTE_INFO
 {
-	int nJunctions; // size=0, offset=0
-	char data[1000][4]; // size=4000, offset=4
-	LEAD_PARAMETERS parameters; // size=64, offset=4004
+	int nJunctions;
+	char data[1000][4];
+	LEAD_PARAMETERS parameters;
 };
 
-struct MR_MISSION // hashcode: 0xF240F754 (dec: -230623404)
+struct MR_MISSION
 {
-	int active; // size=0, offset=0
-	int gameover_delay; // size=0, offset=4
-	PAUSEMODE gameover_mode; // size=1, offset=8
-	short message_timer[2]; // size=4, offset=10
-	short message_priority[2]; // size=4, offset=14
-	char(*message_string[2]); // size=8, offset=20
-	MR_TIMER timer[2]; // size=24, offset=28
-	_TARGET* CarTarget; // size=64, offset=52
-	_TARGET* ChaseTarget; // size=64, offset=56
-	int PhantomCarId; // size=0, offset=60
-	int ChaseHitDelay; // size=0, offset=64
-	char* StealMessage; // size=0, offset=68
+	int active;
+	int gameover_delay;
+	PAUSEMODE gameover_mode;
+	short message_timer[2];
+	short message_priority[2];
+	char(*message_string[2]);
+	MR_TIMER timer[2];
+	_TARGET* CarTarget;
+	_TARGET* ChaseTarget;
+	int PhantomCarId;
+	int ChaseHitDelay;
+	char* StealMessage;
 };
 
-struct STOPCOPS // hashcode: 0x145E8976 (dec: 341739894)
+struct STOPCOPS
 {
-	VECTOR_NOPAD pos; // size=12, offset=0
-	int radius; // size=0, offset=12
+	VECTOR_NOPAD pos;
+	int radius;
 };
 
-enum FAIL_REASON // Hashcode: 0x6CB87873 (dec: 1824028787)
+enum FAIL_REASON
 {
 	FAILED_OUTOFTIME = 0,
 	FAILED_CnR_LOSTHIM = 1,
 	FAILED_MESSAGESET = 2,
 };
 
-struct MR_THREAD // hashcode: 0xEFF00E62 (dec: -269480350)
+struct MR_THREAD
 {
-	unsigned char active; // size=0, offset=0
-	unsigned char player; // size=0, offset=1
-	unsigned long* initial_sp; // size=0, offset=4
-	unsigned long* pc; // size=0, offset=8
-	unsigned long* sp; // size=0, offset=12
+	unsigned char active;
+	unsigned char player;
+	unsigned long* initial_sp;
+	unsigned long* pc;
+	unsigned long* sp;
 };
 
-struct POLYFT3 // hashcode: 0xF42A702D (dec: -198545363)
+struct POLYFT3
 {
-	unsigned char id; // size=0, offset=0
-	unsigned char texture_set; // size=0, offset=1
-	unsigned char texture_id; // size=0, offset=2
-	unsigned char spare; // size=0, offset=3
-	unsigned char v0; // size=0, offset=4
-	unsigned char v1; // size=0, offset=5
-	unsigned char v2; // size=0, offset=6
-	unsigned char pad; // size=0, offset=7
-	UV_INFO uv0; // size=2, offset=8
-	UV_INFO uv1; // size=2, offset=10
-	UV_INFO uv2; // size=2, offset=12
-	UV_INFO pad2; // size=2, offset=14
-	RGB color; // size=4, offset=16
+	unsigned char id;
+	unsigned char texture_set;
+	unsigned char texture_id;
+	unsigned char spare;
+	unsigned char v0;
+	unsigned char v1;
+	unsigned char v2;
+	unsigned char pad;
+	UV_INFO uv0;
+	UV_INFO uv1;
+	UV_INFO uv2;
+	UV_INFO pad2;
+	RGB color;
 };
 
 struct POLYGT3
 {
-	unsigned char id; // size=0, offset=0
-	unsigned char texture_set; // size=0, offset=1
-	unsigned char texture_id; // size=0, offset=2
-	unsigned char spare; // size=0, offset=3
-	unsigned char v0; // size=0, offset=4
-	unsigned char v1; // size=0, offset=5
-	unsigned char v2; // size=0, offset=6
-	unsigned char pad; // size=0, offset=7
-	unsigned char n0; // size=0, offset=8
-	unsigned char n1; // size=0, offset=9
-	unsigned char n2; // size=0, offset=10
-	unsigned char pad2; // size=0, offset=11
-	UV_INFO uv0; // size=2, offset=12
-	UV_INFO uv1; // size=2, offset=14
-	UV_INFO uv2; // size=2, offset=16
-	UV_INFO pad3; // size=2, offset=18
-	RGB color; // size=4, offset=20
+	unsigned char id;
+	unsigned char texture_set;
+	unsigned char texture_id;
+	unsigned char spare;
+	unsigned char v0;
+	unsigned char v1;
+	unsigned char v2;
+	unsigned char pad;
+	unsigned char n0;
+	unsigned char n1;
+	unsigned char n2;
+	unsigned char pad2;
+	UV_INFO uv0;
+	UV_INFO uv1;
+	UV_INFO uv2;
+	UV_INFO pad3;
+	RGB color;
 };
 
-enum LIMBS // Hashcode: 0x200BA5A5 (dec: 537634213)
+enum LIMBS
 {
 	ROOT = 0,
 	LOWERBACK = 1,
@@ -2113,20 +2113,20 @@ enum LIMBS // Hashcode: 0x200BA5A5 (dec: 537634213)
 	JOINT = 22,
 };
 
-struct BONE // hashcode: 0xC453A1B7 (dec: -1001152073)
+struct BONE
 {
-	LIMBS id; // size=1, offset=0
-	BONE* pParent; // size=68, offset=4
-	char numChildren; // size=0, offset=8
-	BONE(*pChildren[3]); // size=12, offset=12
-	SVECTOR_NOPAD* pvOrigPos; // size=6, offset=24
-	SVECTOR* pvRotation; // size=8, offset=28
-	VECTOR vOffset; // size=16, offset=32
-	VECTOR vCurrPos; // size=16, offset=48
-	MODEL** pModel; // size=36, offset=64
+	LIMBS id;
+	BONE* pParent;
+	char numChildren;
+	BONE(*pChildren[3]);
+	SVECTOR_NOPAD* pvOrigPos;
+	SVECTOR* pvRotation;
+	VECTOR vOffset;
+	VECTOR vCurrPos;
+	MODEL** pModel;
 };
 
-enum TEXTURE_PALS // Hashcode: 0x7EFDB21D (dec: 2130555421)
+enum TEXTURE_PALS
 {
 	NO_PAL = 0,
 	JEANS_PAL = 1,
@@ -2134,255 +2134,255 @@ enum TEXTURE_PALS // Hashcode: 0x7EFDB21D (dec: 2130555421)
 	CHEST_PAL = 3,
 };
 
-struct PED_DATA // hashcode: 0xF0838D4B (dec: -259814069)
+struct PED_DATA
 {
-	char cWidth; // size=0, offset=0
-	unsigned char cAdj; // size=0, offset=1
-	TEXTURE_DETAILS* ptd; // size=14, offset=4
-	TEXTURE_PALS texPal; // size=1, offset=8
+	char cWidth;
+	unsigned char cAdj;
+	TEXTURE_DETAILS* ptd;
+	TEXTURE_PALS texPal;
 };
 
-struct tRay // hashcode: 0x9D13B2B7 (dec: -1659653449)
+struct tRay
 {
-	long org[4]; // size=16, offset=0
-	long dir[4]; // size=16, offset=16
+	long org[4];
+	long dir[4];
 };
 
-struct tRange // hashcode: 0x2599E03D (dec: 630841405)
+struct tRange
 {
-	int lower; // size=0, offset=0
-	int upper; // size=0, offset=4
+	int lower;
+	int upper;
 };
 
-struct tAABB // hashcode: 0x67B18B0E (dec: 1739688718)
+struct tAABB
 {
-	tRange slab[3]; // size=24, offset=0
+	tRange slab[3];
 };
 
-struct DUPLICATION // hashcode: 0x6B8217F0 (dec: 1803687920)
+struct DUPLICATION
 {
-	char* buffer; // size=0, offset=0
-	int size; // size=0, offset=4
+	char* buffer;
+	int size;
 };
 
-struct tNode // hashcode: 0xA7EA5E4B (dec: -1477812661)
+struct tNode
 {
-	int vx; // size=0, offset=0
-	int vy; // size=0, offset=4
-	int vz; // size=0, offset=8
-	unsigned short dist; // size=0, offset=12
-	unsigned short ptoey; // size=0, offset=14
+	int vx;
+	int vy;
+	int vz;
+	unsigned short dist;
+	unsigned short ptoey;
 };
 
-struct PATHFIND_237fake // hashcode: 0xA878A4A1 (dec: -1468488543)
+struct PATHFIND_237fake
 {
-	short dx; // size=0, offset=0
-	short dz; // size=0, offset=2
+	short dx;
+	short dz;
 };
 
-struct PATHFIND_238fake // hashcode: 0x9B0AB30F (dec: -1693797617)
+struct PATHFIND_238fake
 {
-	short dx; // size=0, offset=0
-	short dz; // size=0, offset=2
+	short dx;
+	short dz;
 };
 
-struct PLAYER_SCORE // hashcode: 0x4C80DCD4 (dec: 1283513556)
+struct PLAYER_SCORE
 {
-	int time; // size=0, offset=0
-	int P2time; // size=0, offset=4
-	short items; // size=0, offset=8
-	short P2items; // size=0, offset=10
-	char name[6]; // size=6, offset=12
+	int time;
+	int P2time;
+	short items;
+	short P2items;
+	char name[6];
 };
 
-typedef struct SEATED_PEDESTRIANS // hashcode: 0x75CFA44E (dec: 1976542286)
+typedef struct SEATED_PEDESTRIANS
 {
-	int x; // size=0, offset=0
-	int z; // size=0, offset=4
-	short rotation; // size=0, offset=8
-	char index; // size=0, offset=10
-	char pad; // size=0, offset=11
+	int x;
+	int z;
+	short rotation;
+	char index;
+	char pad;
 } *SEATEDPTR;
 
-struct CAR_COLLISION_BOX // hashcode: 0xE148B668 (dec: -515328408)
+struct CAR_COLLISION_BOX
 {
-	int min_x; // size=0, offset=0
-	int max_x; // size=0, offset=4
-	int min_z; // size=0, offset=8
-	int max_z; // size=0, offset=12
+	int min_x;
+	int max_x;
+	int min_z;
+	int max_z;
 };
 
-typedef struct PEDESTRIAN_ROADS // hashcode: 0xC3763082 (dec: -1015664510)
+typedef struct PEDESTRIAN_ROADS
 {
-	short pos; // size=0, offset=0
-	short north; // size=0, offset=2
-	short south; // size=0, offset=4
-	short east; // size=0, offset=6
-	short west; // size=0, offset=8
+	short pos;
+	short north;
+	short south;
+	short east;
+	short west;
 } *LPPEDESTRIAN_ROADS;
 
-struct OUT_FONTINFO // hashcode: 0x22390EDA (dec: 574164698)
+struct OUT_FONTINFO
 {
-	unsigned char x; // size=0, offset=0
-	unsigned char y; // size=0, offset=1
-	char offx; // size=0, offset=2
-	char offy; // size=0, offset=3
-	unsigned char width; // size=0, offset=4
-	unsigned char height; // size=0, offset=5
-	unsigned short pad; // size=0, offset=6
+	unsigned char x;
+	unsigned char y;
+	char offx;
+	char offy;
+	unsigned char width;
+	unsigned char height;
+	unsigned short pad;
 };
 
-struct FONT_DIGIT // hashcode: 0x2500B456 (dec: 620803158)
+struct FONT_DIGIT
 {
-	char xOffset; // size=0, offset=0
-	char width; // size=0, offset=1
+	char xOffset;
+	char width;
 };
 
-struct TEXINF // hashcode: 0xFC140D7C (dec: -65794692)
+struct TEXINF
 {
-	unsigned short id; // size=0, offset=0
-	unsigned short nameoffset; // size=0, offset=2
-	unsigned char x; // size=0, offset=4
-	unsigned char y; // size=0, offset=5
-	unsigned char width; // size=0, offset=6
-	unsigned char height; // size=0, offset=7
+	unsigned short id;
+	unsigned short nameoffset;
+	unsigned char x;
+	unsigned char y;
+	unsigned char width;
+	unsigned char height;
 };
 
-struct SHADOWHDR // hashcode: 0x4ED3B57A (dec: 1322497402)
+struct SHADOWHDR
 {
-	unsigned long num_common_verts; // size=0, offset=0
-	unsigned short num_verts_total; // size=0, offset=4
-	unsigned short num_polys_total; // size=0, offset=6
-	unsigned short vert_offsets[4]; // size=8, offset=8
-	unsigned short nverts[4]; // size=8, offset=16
-	unsigned short npolys[4]; // size=8, offset=24
-	unsigned long(*poly_block[4]); // size=16, offset=32
-	SVECTOR* vertices; // size=8, offset=48
+	unsigned long num_common_verts;
+	unsigned short num_verts_total;
+	unsigned short num_polys_total;
+	unsigned short vert_offsets[4];
+	unsigned short nverts[4];
+	unsigned short npolys[4];
+	unsigned long(*poly_block[4]);
+	SVECTOR* vertices;
 };
 
-struct TYRE_TRACK // hashcode: 0xF19415A8 (dec: -241953368)
+struct TYRE_TRACK
 {
-	char type; // size=0, offset=0
-	char shade; // size=0, offset=1
-	char shade_type; // size=0, offset=2
-	char surface; // size=0, offset=3
-	SVECTOR_NOPAD p1; // size=6, offset=4
-	SVECTOR_NOPAD p2; // size=6, offset=10
-	SVECTOR_NOPAD p3; // size=6, offset=16
-	SVECTOR_NOPAD p4; // size=6, offset=22
+	char type;
+	char shade;
+	char shade_type;
+	char surface;
+	SVECTOR_NOPAD p1;
+	SVECTOR_NOPAD p2;
+	SVECTOR_NOPAD p3;
+	SVECTOR_NOPAD p4;
 };
 
-struct S_XYZ // hashcode: 0x44EE024B (dec: 1156448843)
+struct S_XYZ
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	short z; // size=0, offset=4
+	short x;
+	short y;
+	short z;
 };
 
-struct FLAREREC // hashcode: 0x61D9DD50 (dec: 1641667920)
+struct FLAREREC
 {
-	RGB16 transparency; // size=8, offset=0
-	char size; // size=0, offset=8
-	short gapmod; // size=0, offset=10
+	RGB16 transparency;
+	char size;
+	short gapmod;
 };
 
-struct __LSBDinfo // hashcode: 0x6EB8DAAC (dec: 1857608364)
+struct __LSBDinfo
 {
-	int addr; // size=0, offset=0
-	int memtop; // size=0, offset=4
-	int count[7]; // size=28, offset=8
-	int bnktop[7]; // size=28, offset=36
-	int append; // size=0, offset=64
+	int addr;
+	int memtop;
+	int count[7];
+	int bnktop[7];
+	int append;
 };
 
-struct CHANNEL_DATA // hashcode: 0x1B8E1AD1 (dec: 462297809)
+struct CHANNEL_DATA
 {
-	SpuVoiceAttr attr; // size=64, offset=0
-	unsigned char loop; // size=0, offset=64
-	unsigned char locked; // size=0, offset=65
-	unsigned short time; // size=0, offset=66
-	long samplerate; // size=0, offset=68
-	char player; // size=0, offset=72
-	long srcvolume; // size=0, offset=76
-	long volumeScale; // size=0, offset=80
-	unsigned short srcpitch; // size=0, offset=84
-	unsigned short dopplerScale; // size=0, offset=86
-	long cameradist; // size=0, offset=88
-	long lastcameradist; // size=0, offset=92
-	VECTOR* srcposition; // size=16, offset=96
-	VECTOR position; // size=16, offset=100
-	long* srcvelocity; // size=0, offset=116
+	SpuVoiceAttr attr;
+	unsigned char loop;
+	unsigned char locked;
+	unsigned short time;
+	long samplerate;
+	char player;
+	long srcvolume;
+	long volumeScale;
+	unsigned short srcpitch;
+	unsigned short dopplerScale;
+	long cameradist;
+	long lastcameradist;
+	VECTOR* srcposition;
+	VECTOR position;
+	long* srcvelocity;
 };
 
-struct SAMPLE_DATA // hashcode: 0x2179B04F (dec: 561623119)
+struct SAMPLE_DATA
 {
-	unsigned long address; // size=0, offset=0
-	unsigned long length; // size=0, offset=4
-	unsigned long loop; // size=0, offset=8
-	unsigned long samplerate; // size=0, offset=12
+	unsigned long address;
+	unsigned long length;
+	unsigned long loop;
+	unsigned long samplerate;
 };
 
-struct __pauseinfo // hashcode: 0x31AB86B4 (dec: 833324724)
+struct __pauseinfo
 {
-	unsigned short pitch[16]; // size=32, offset=0
-	unsigned short voll[16]; // size=32, offset=32
-	unsigned short volr[16]; // size=32, offset=64
-	unsigned short max; // size=0, offset=96
-	unsigned short lev; // size=0, offset=98
+	unsigned short pitch[16];
+	unsigned short voll[16];
+	unsigned short volr[16];
+	unsigned short max;
+	unsigned short lev;
 };
 
-struct SPOOLQ // hashcode: 0xF6540C3E (dec: -162264002)
+struct SPOOLQ
 {
-	unsigned char type; // size=0, offset=0
-	unsigned char data; // size=0, offset=1
-	unsigned short nsectors; // size=0, offset=2
-	unsigned long sector; // size=0, offset=4
-	char* addr; // size=0, offset=8
-	void (*func)(); // size=0, offset=12
+	unsigned char type;
+	unsigned char data;
+	unsigned short nsectors;
+	unsigned long sector;
+	char* addr;
+	void (*func)();
 #ifdef _DEBUG
 	const char* requestby;
 	int requestbyline;
 #endif
 };
 
-struct SPL_REGIONINFO // hashcode: 0xDA8E3C77 (dec: -628212617)
+struct SPL_REGIONINFO
 {
-	unsigned short region_to_unpack; // size=0, offset=0
-	unsigned short target_barrel_region; // size=0, offset=2
-	int nsectors; // size=0, offset=4
-	char* cell_addr; // size=0, offset=8
-	char* roadm_addr; // size=0, offset=12
+	unsigned short region_to_unpack;
+	unsigned short target_barrel_region;
+	int nsectors;
+	char* cell_addr;
+	char* roadm_addr;
 };
 
-struct AreaDataStr // hashcode: 0x2EA8DA37 (dec: 782817847)
+struct AreaDataStr
 {
-	unsigned short gfx_offset; // size=0, offset=0
-	unsigned short model_offset; // size=0, offset=2
-	unsigned short music_offset; // size=0, offset=4
-	unsigned short ambient_offset; // size=0, offset=6
-	unsigned char model_size; // size=0, offset=8
-	unsigned char pad; // size=0, offset=9
-	unsigned char num_tpages; // size=0, offset=10
-	unsigned char ambient_size; // size=0, offset=11
-	unsigned char music_size; // size=0, offset=12
-	unsigned char music_samples_size; // size=0, offset=13
-	unsigned char music_id; // size=0, offset=14
-	unsigned char ambient_id; // size=0, offset=15
+	unsigned short gfx_offset;
+	unsigned short model_offset;
+	unsigned short music_offset;
+	unsigned short ambient_offset;
+	unsigned char model_size;
+	unsigned char pad;
+	unsigned char num_tpages;
+	unsigned char ambient_size;
+	unsigned char music_size;
+	unsigned char music_samples_size;
+	unsigned char music_id;
+	unsigned char ambient_id;
 };
 
-struct DRAW_MODE // hashcode: 0x568DA31F (dec: 1452122911)
+struct DRAW_MODE
 {
-	short x1; // size=0, offset=0
-	short y1; // size=0, offset=2
-	short x2; // size=0, offset=4
-	short y2; // size=0, offset=6
-	short width; // size=0, offset=8
-	short height; // size=0, offset=10
-	short framex; // size=0, offset=12
-	short framey; // size=0, offset=14
+	short x1;
+	short y1;
+	short x2;
+	short y2;
+	short width;
+	short height;
+	short framex;
+	short framey;
 };
 
-enum CDTYPE // Hashcode: 0x61FF3A77 (dec: 1644116599)
+enum CDTYPE
 {
 	CDTYPE_NODISC = 0,
 	CDTYPE_SHELLOPEN = 1,
@@ -2391,7 +2391,7 @@ enum CDTYPE // Hashcode: 0x61FF3A77 (dec: 1644116599)
 	CDTYPE_CORRECTDISC = 4,
 };
 
-enum CITYTYPE // Hashcode: 0x89BC71DE (dec: -1984138786)
+enum CITYTYPE
 {
 	CITYTYPE_DAY = 0,
 	CITYTYPE_NIGHT = 1,
@@ -2399,59 +2399,59 @@ enum CITYTYPE // Hashcode: 0x89BC71DE (dec: -1984138786)
 	CITYTYPE_MULTI_NIGHT = 3,
 };
 
-struct TARGET_ARROW_MODEL // hashcode: 0x49188CA9 (dec: 1226345641)
+struct TARGET_ARROW_MODEL
 {
-	SVECTOR* pVerts; // size=8, offset=0
-	char* pTris; // size=0, offset=4
-	char numTris; // size=0, offset=8
+	SVECTOR* pVerts;
+	char* pTris;
+	char numTris;
 };
 
-struct TP // hashcode: 0x3B17636E (dec: 991388526)
+struct TP
 {
-	unsigned long flags; // size=0, offset=0
-	unsigned long offset; // size=0, offset=4
+	unsigned long flags;
+	unsigned long offset;
 };
 
-struct CAR_LOCALS // hashcode: 0xC11EBC40 (dec: -1054950336)
+struct CAR_LOCALS
 {
-	long vel[4]; // size=16, offset=0
-	long avel[4]; // size=16, offset=16
-	int extraangulardamping; // size=0, offset=32
-	int aggressive; // size=0, offset=36
+	long vel[4];
+	long avel[4];
+	int extraangulardamping;
+	int aggressive;
 };
 
-struct XA_TRACK // hashcode: 0xB1C796C2 (dec: -1312319806)
+struct XA_TRACK
 {
-	int start; // size=0, offset=0
-	int end; // size=0, offset=4
+	int start;
+	int end;
 };
 
-struct FE_CHARDATA // hashcode: 0x3BD93806 (dec: 1004091398)
+struct FE_CHARDATA
 {
-	unsigned char u; // size=0, offset=0
-	unsigned char v; // size=0, offset=1
-	unsigned char w; // size=0, offset=2
-	unsigned char h; // size=0, offset=3
+	unsigned char u;
+	unsigned char v;
+	unsigned char w;
+	unsigned char h;
 };
 
-struct FE_FONT // hashcode: 0x602743A1 (dec: 1613185953)
+struct FE_FONT
 {
-	int NumFonts; // size=0, offset=0
-	FE_CHARDATA CharInfo[256]; // size=1024, offset=4
+	int NumFonts;
+	FE_CHARDATA CharInfo[256];
 };
 
-struct SCREEN_LIMITS // hashcode: 0x445BA46E (dec: 1146856558)
+struct SCREEN_LIMITS
 {
-	short minx; // size=0, offset=0
-	short miny; // size=0, offset=2
-	short maxx; // size=0, offset=4
-	short maxy; // size=0, offset=6
+	short minx;
+	short miny;
+	short maxx;
+	short maxy;
 };
 
-struct BOTCH // hashcode: 0xE1A31543 (dec: -509405885)
+struct BOTCH
 {
-	int missNum; // size=0, offset=0
-	char** name; // size=0, offset=4
+	int missNum;
+	char** name;
 };
 
 #endif // DR2TYPES_H

--- a/src_rebuild/GAME/DR2TYPES.H
+++ b/src_rebuild/GAME/DR2TYPES.H
@@ -2021,8 +2021,8 @@ struct MR_MISSION
 	short message_priority[2];
 	char(*message_string[2]);
 	MR_TIMER timer[2];
-	_TARGET* CarTarget;
-	_TARGET* ChaseTarget;
+	MS_TARGET* CarTarget;
+	MS_TARGET* ChaseTarget;
 	int PhantomCarId;
 	int ChaseHitDelay;
 	char* StealMessage;

--- a/src_rebuild/GAME/FRONTEND/FEMAIN.C
+++ b/src_rebuild/GAME/FRONTEND/FEMAIN.C
@@ -430,7 +430,7 @@ void SetVariable(int var)
 	// 		int iNumScreens; // $t6
 	// 		int i; // $t0
 	// 		int j; // $a3
-	// 		struct RECT rect; // stack offset -40
+	// 		RECT rect; // stack offset -40
 	// 		char *ptr; // $a2
 	/* end block 1 */
 	// End offset: 0x001C0F24
@@ -528,7 +528,7 @@ void LoadFrontendScreens(void)
 		// Start offset: 0x001C0F24
 		// Variables:
 	// 		int iTpage; // $s2
-	// 		struct RECT rect; // stack offset -72
+	// 		RECT rect; // stack offset -72
 	// 		int p; // $s0
 	// 		int pages[7]; // stack offset -64
 	/* end block 1 */
@@ -690,14 +690,14 @@ void SetupBackgroundPolys(void)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ SetupScreenSprts(struct PSXSCREEN *pScr /*$a0*/)
+// void /*$ra*/ SetupScreenSprts(PSXSCREEN *pScr /*$a0*/)
  // line 1588, offset 0x001c132c
 	/* begin block 1 */
 		// Start line: 1589
 		// Start offset: 0x001C132C
 		// Variables:
 	// 		int tpage; // $a1
-	// 		struct POLY_FT3 *null; // $v0
+	// 		POLY_FT3 *null; // $v0
 	/* end block 1 */
 	// End offset: 0x001C147C
 	// End Line: 1650
@@ -766,7 +766,7 @@ void SetupScreenSprts(PSXSCREEN *pScr)
 
 // decompiled code
 // original method signature: 
-// void /*$ra*/ DrawScreen(struct PSXSCREEN *pScr /*stack 0*/)
+// void /*$ra*/ DrawScreen(PSXSCREEN *pScr /*stack 0*/)
  // line 1658, offset 0x001c147c
 	/* begin block 1 */
 		// Start line: 1659
@@ -1003,7 +1003,7 @@ void DisplayOnScreenText(void)
 		// Variables:
 	// 		int i; // $s0
 	// 		int tpage; // $v1
-	// 		struct RECT rect; // stack offset -40
+	// 		RECT rect; // stack offset -40
 	/* end block 1 */
 	// End offset: 0x001C1CF4
 	// End Line: 1916
@@ -1182,8 +1182,8 @@ void ReInitScreens(void)
 		// Start line: 1992
 		// Start offset: 0x001C1E18
 		// Variables:
-	// 		struct RECT rect; // stack offset -48
-	// 		struct PSXBUTTON *pNewB; // $s2
+	// 		RECT rect; // stack offset -48
+	// 		PSXBUTTON *pNewB; // $s2
 	/* end block 1 */
 	// End offset: 0x001C227C
 	// End Line: 2085
@@ -1713,7 +1713,7 @@ void DoFrontEnd(void)
 		// Start line: 2632
 		// Start offset: 0x001C2C2C
 		// Variables:
-	// 		struct DRAW_MODE *dm; // $s3
+	// 		DRAW_MODE *dm; // $s3
 	/* end block 1 */
 	// End offset: 0x001C2D90
 	// End Line: 2687
@@ -1790,7 +1790,7 @@ void SetFEDrawMode(void)
 		// Start line: 2697
 		// Start offset: 0x001C6378
 		// Variables:
-	// 		struct DB *db_hold; // $a1
+	// 		DB *db_hold; // $a1
 	/* end block 1 */
 	// End offset: 0x001C6404
 	// End Line: 2716
@@ -1852,8 +1852,8 @@ void EndFrame(void)
 		// Start line: 2746
 		// Start offset: 0x001C2D90
 		// Variables:
-	// 		struct FE_CHARDATA *pFontInfo; // $a0
-	// 		struct SPRT *font; // $t0
+	// 		FE_CHARDATA *pFontInfo; // $a0
+	// 		SPRT *font; // $t0
 	// 		unsigned char let; // $a0
 	// 		int counter; // $t4
 
@@ -1991,8 +1991,8 @@ int FEPrintString(char *string, int x, int y, int justification, int r, int g, i
 		// Start line: 2818
 		// Start offset: 0x001C2FD8
 		// Variables:
-	// 		struct POLY_FT4 *font; // $t0
-	// 		struct FE_CHARDATA *pFontInfo; // $a2
+	// 		POLY_FT4 *font; // $t0
+	// 		FE_CHARDATA *pFontInfo; // $a2
 	// 		char let; // $v1
 	// 		int tpage; // $v0
 	// 		int w; // $t3
@@ -2188,7 +2188,7 @@ int CentreScreen(int bSetup)
 		// Start offset: 0x001C3430
 		// Variables:
 	// 		int i; // $a0
-	// 		struct RECT rect; // stack offset -32
+	// 		RECT rect; // stack offset -32
 
 		/* begin block 1.1 */
 			// Start line: 3145
@@ -2204,7 +2204,7 @@ int CentreScreen(int bSetup)
 					// Start line: 3030
 					// Start offset: 0x001C37BC
 					// Variables:
-				// 		struct RECT rect; // stack offset -24
+				// 		RECT rect; // stack offset -24
 				/* end block 1.1.1.1 */
 				// End offset: 0x001C37BC
 				// End Line: 3030
@@ -2229,7 +2229,7 @@ int CentreScreen(int bSetup)
 					// Start line: 3030
 					// Start offset: 0x001C3858
 					// Variables:
-				// 		struct RECT rect; // stack offset -24
+				// 		RECT rect; // stack offset -24
 				/* end block 1.2.1.1 */
 				// End offset: 0x001C3858
 				// End Line: 3030
@@ -2843,7 +2843,7 @@ int MissionSelectScreen(int bSetup)
 				// Start line: 3703
 				// Start offset: 0x001C449C
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.1.1 */
 			// End offset: 0x001C449C
 			// End Line: 3703
@@ -2859,7 +2859,7 @@ int MissionSelectScreen(int bSetup)
 				// Start line: 3709
 				// Start offset: 0x001C44C4
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.2.1 */
 			// End offset: 0x001C44C4
 			// End Line: 3709
@@ -2997,9 +2997,9 @@ int MissionCityScreen(int bSetup)
 		// Start line: 3730
 		// Start offset: 0x001C4600
 		// Variables:
-	// 		struct RENDER_ARGS renderArgs; // stack offset -48
+	// 		RENDER_ARGS renderArgs; // stack offset -48
 	// 		int extraVal; // $a0
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 
 		/* begin block 1.1 */
 			// Start line: 3789
@@ -3009,7 +3009,7 @@ int MissionCityScreen(int bSetup)
 				// Start line: 3789
 				// Start offset: 0x001C4798
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.1.1 */
 			// End offset: 0x001C4798
 			// End Line: 3789
@@ -3027,7 +3027,7 @@ int MissionCityScreen(int bSetup)
 				// Start line: 3729
 				// Start offset: 0x001C4844
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.2.1 */
 			// End offset: 0x001C4844
 			// End Line: 3729
@@ -3043,7 +3043,7 @@ int MissionCityScreen(int bSetup)
 				// Start line: 3808
 				// Start offset: 0x001C4900
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.3.1 */
 			// End offset: 0x001C4900
 			// End Line: 3808
@@ -3059,7 +3059,7 @@ int MissionCityScreen(int bSetup)
 				// Start line: 3813
 				// Start offset: 0x001C4940
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.4.1 */
 			// End offset: 0x001C4940
 			// End Line: 3813
@@ -3238,7 +3238,7 @@ int CutSceneSelectScreen(int bSetup)
 		// Start line: 3857
 		// Start offset: 0x001C4B30
 		// Variables:
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 
 		/* begin block 1.1 */
 			// Start line: 3856
@@ -3248,7 +3248,7 @@ int CutSceneSelectScreen(int bSetup)
 				// Start line: 3856
 				// Start offset: 0x001C4E6C
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.1.1 */
 			// End offset: 0x001C4E6C
 			// End Line: 3856
@@ -3264,7 +3264,7 @@ int CutSceneSelectScreen(int bSetup)
 				// Start line: 3856
 				// Start offset: 0x001C4E6C
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.2.1 */
 			// End offset: 0x001C4E6C
 			// End Line: 3856
@@ -3280,7 +3280,7 @@ int CutSceneSelectScreen(int bSetup)
 				// Start line: 3856
 				// Start offset: 0x001C4EB4
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.3.1 */
 			// End offset: 0x001C4EB4
 			// End Line: 3856
@@ -3296,7 +3296,7 @@ int CutSceneSelectScreen(int bSetup)
 				// Start line: 3856
 				// Start offset: 0x001C4FAC
 				// Variables:
-			// 		struct RECT rect; // stack offset -16
+			// 		RECT rect; // stack offset -16
 			/* end block 1.4.1 */
 			// End offset: 0x001C50A0
 			// End Line: 3856
@@ -3491,7 +3491,7 @@ int CutSceneCitySelectScreen(int bSetup)
 	// 		int last; // $s2
 	// 		char text[4]; // stack offset -48
 	// 		int ypos[2]; // stack offset -40
-	// 		struct RECT rect; // stack offset -32
+	// 		RECT rect; // stack offset -32
 
 		/* begin block 1.1 */
 			// Start line: 4048
@@ -3501,7 +3501,7 @@ int CutSceneCitySelectScreen(int bSetup)
 				// Start line: 4048
 				// Start offset: 0x001C5254
 				// Variables:
-			// 		struct DB *db_hold; // $a1
+			// 		DB *db_hold; // $a1
 			/* end block 1.1.1 */
 			// End offset: 0x001C5254
 			// End Line: 4048
@@ -3517,7 +3517,7 @@ int CutSceneCitySelectScreen(int bSetup)
 				// Start line: 4070
 				// Start offset: 0x001C5284
 				// Variables:
-			// 		struct DB *db_hold; // $a1
+			// 		DB *db_hold; // $a1
 			/* end block 1.2.1 */
 			// End offset: 0x001C5284
 			// End Line: 4070
@@ -3533,7 +3533,7 @@ int CutSceneCitySelectScreen(int bSetup)
 				// Start line: 4097
 				// Start offset: 0x001C52CC
 				// Variables:
-			// 		struct DB *db_hold; // $a1
+			// 		DB *db_hold; // $a1
 			/* end block 1.3.1 */
 			// End offset: 0x001C52CC
 			// End Line: 4097
@@ -3549,7 +3549,7 @@ int CutSceneCitySelectScreen(int bSetup)
 				// Start line: 4119
 				// Start offset: 0x001C5420
 				// Variables:
-			// 		struct DB *db_hold; // $a1
+			// 		DB *db_hold; // $a1
 			/* end block 1.4.1 */
 			// End offset: 0x001C5530
 			// End Line: 4122
@@ -3765,7 +3765,7 @@ int SetVolumeScreen(int bSetup)
 	// 		int offset; // $a2
 	// 		int i; // $s4
 	// 		char text[32]; // stack offset -80
-	// 		struct SCORE_ENTRY *pSE; // stack offset -48
+	// 		SCORE_ENTRY *pSE; // stack offset -48
 	// 		int min; // $v1
 	// 		int frac; // $t0
 	/* end block 1 */
@@ -4631,7 +4631,7 @@ int GameNameScreen(int bSetup)
 		// Start offset: 0x001C61AC
 		// Variables:
 	// 		int i; // $a0
-	// 		struct RECT dest; // stack offset -24
+	// 		RECT dest; // stack offset -24
 	// 		unsigned short *palette; // $a2
 	/* end block 1 */
 	// End offset: 0x001C62F8
@@ -4708,7 +4708,7 @@ void FEInitCdIcon(void)
 	// 		unsigned short *palette; // $a1
 	// 		int temp; // $a2
 	// 		int i; // $a0
-	// 		struct RECT dest; // stack offset -16
+	// 		RECT dest; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x001C6378
 	// End Line: 4735

--- a/src_rebuild/GAME/FRONTEND/FEMAIN.H
+++ b/src_rebuild/GAME/FRONTEND/FEMAIN.H
@@ -1,6 +1,32 @@
 #ifndef FEMAIN_H
 #define FEMAIN_H
 
+struct PSXBUTTON // hashcode: 0x41BD456C (dec: 1102923116)
+{
+	short x; // size=0, offset=0
+	short y; // size=0, offset=2
+	short w; // size=0, offset=4
+	short h; // size=0, offset=6
+	unsigned char l; // size=0, offset=8
+	unsigned char r; // size=0, offset=9
+	unsigned char u; // size=0, offset=10
+	unsigned char d; // size=0, offset=11
+	int userDrawFunctionNum; // size=0, offset=12
+	short s_x; // size=0, offset=16
+	short s_y; // size=0, offset=18
+	int action; // size=0, offset=20
+	int var; // size=0, offset=24
+	char Name[32]; // size=32, offset=28
+};
+
+struct PSXSCREEN // hashcode: 0x9E392939 (dec: -1640421063)
+{
+	unsigned char index; // size=0, offset=0
+	unsigned char numButtons; // size=0, offset=1
+	unsigned char userFunctionNum; // size=0, offset=2
+	PSXBUTTON buttons[8]; // size=480, offset=4
+};
+
 extern int gInFrontend;
 extern int bRedrawFrontend;
 
@@ -12,9 +38,9 @@ extern void LoadBackgroundFile(char *name); // 0x001C0F24
 
 extern void SetupBackgroundPolys(); // 0x001C10F4
 
-extern void SetupScreenSprts(struct PSXSCREEN *pScr); // 0x001C132C
+extern void SetupScreenSprts(PSXSCREEN *pScr); // 0x001C132C
 
-extern void DrawScreen(struct PSXSCREEN *pScr); // 0x001C147C
+extern void DrawScreen(PSXSCREEN *pScr); // 0x001C147C
 
 extern void DisplayOnScreenText(); // 0x001C18E4
 

--- a/src_rebuild/GAME/FRONTEND/FEMAIN.H
+++ b/src_rebuild/GAME/FRONTEND/FEMAIN.H
@@ -1,30 +1,30 @@
 #ifndef FEMAIN_H
 #define FEMAIN_H
 
-struct PSXBUTTON // hashcode: 0x41BD456C (dec: 1102923116)
+struct PSXBUTTON
 {
-	short x; // size=0, offset=0
-	short y; // size=0, offset=2
-	short w; // size=0, offset=4
-	short h; // size=0, offset=6
-	unsigned char l; // size=0, offset=8
-	unsigned char r; // size=0, offset=9
-	unsigned char u; // size=0, offset=10
-	unsigned char d; // size=0, offset=11
-	int userDrawFunctionNum; // size=0, offset=12
-	short s_x; // size=0, offset=16
-	short s_y; // size=0, offset=18
-	int action; // size=0, offset=20
-	int var; // size=0, offset=24
-	char Name[32]; // size=32, offset=28
+	short x;
+	short y;
+	short w;
+	short h;
+	unsigned char l;
+	unsigned char r;
+	unsigned char u;
+	unsigned char d;
+	int userDrawFunctionNum;
+	short s_x;
+	short s_y;
+	int action;
+	int var;
+	char Name[32];
 };
 
-struct PSXSCREEN // hashcode: 0x9E392939 (dec: -1640421063)
+struct PSXSCREEN
 {
-	unsigned char index; // size=0, offset=0
-	unsigned char numButtons; // size=0, offset=1
-	unsigned char userFunctionNum; // size=0, offset=2
-	PSXBUTTON buttons[8]; // size=480, offset=4
+	unsigned char index;
+	unsigned char numButtons;
+	unsigned char userFunctionNum;
+	PSXBUTTON buttons[8];
 };
 
 extern int gInFrontend;

--- a/src_rebuild/GAME/MEMCARD/CMAN.H
+++ b/src_rebuild/GAME/MEMCARD/CMAN.H
@@ -2,13 +2,13 @@
 #define CMAN_H
 
 
-extern int card_manager(int operation, int options, char *textBuffer, struct FILEFORMAT *fileFormatPtr, struct SLICE *slicePtr, char *backImageName, char *bufferPtr96K); // 0x00102710
+extern int card_manager(int operation, int options, char *textBuffer, FILEFORMAT *fileFormatPtr, SLICE *slicePtr, char *backImageName, char *bufferPtr96K); // 0x00102710
 
-extern int cardman__FiiPcP10FILEFORMATP5SLICET2T2(int operation, int options, char *textBuffer, struct FILEFORMAT *fileFormatPtr, struct SLICE *slicePtr, char *backImageName, char *bufferPtr96K); // 0x001005E0
+extern int cardman__FiiPcP10FILEFORMATP5SLICET2T2(int operation, int options, char *textBuffer, FILEFORMAT *fileFormatPtr, SLICE *slicePtr, char *backImageName, char *bufferPtr96K); // 0x001005E0
 
 extern void LoadBackground__FPcT0(char *filename, char *buffer); // 0x00102744
 
-extern int EnterName__FP3PADP7DISPMANPc(struct PAD *pad, struct DISPMAN *disp, char *username); // 0x00102364
+extern int EnterName__FP3PADP7DISPMANPc(PAD *pad, DISPMAN *disp, char *username); // 0x00102364
 
 
 #endif

--- a/src_rebuild/GAME/MEMCARD/DISPLAY.H
+++ b/src_rebuild/GAME/MEMCARD/DISPLAY.H
@@ -2,121 +2,121 @@
 #define DISPLAY_H
 
 
-extern struct DISPMAN * __7DISPMANPlPPlP3PADP10FILEFORMATib(struct DISPMAN *this, long *imagePtr, long **sliceIconPtrs, struct PAD *pad, struct FILEFORMAT *fileFormatPtr, int language, unsigned int save); // 0x000F65A8
+extern DISPMAN * __7DISPMANPlPPlP3PADP10FILEFORMATib(DISPMAN *this, long *imagePtr, long **sliceIconPtrs, PAD *pad, FILEFORMAT *fileFormatPtr, int language, unsigned int save); // 0x000F65A8
 
-extern void _._7DISPMAN(struct DISPMAN *this, int __in_chrg); // 0x000FDAD8
+extern void _._7DISPMAN(DISPMAN *this, int __in_chrg); // 0x000FDAD8
 
-extern void DrawTitleBar__7DISPMAN(struct DISPMAN *this); // 0x000F72B8
+extern void DrawTitleBar__7DISPMAN(DISPMAN *this); // 0x000F72B8
 
-extern void DrawCards__7DISPMAN(struct DISPMAN *this); // 0x000F7508
+extern void DrawCards__7DISPMAN(DISPMAN *this); // 0x000F7508
 
-extern void DrawMenu__7DISPMAN(struct DISPMAN *this); // 0x000F7688
+extern void DrawMenu__7DISPMAN(DISPMAN *this); // 0x000F7688
 
-extern void DrawKeyInfo__7DISPMAN(struct DISPMAN *this); // 0x000F79C8
+extern void DrawKeyInfo__7DISPMAN(DISPMAN *this); // 0x000F79C8
 
-extern void DrawBlocks__7DISPMAN(struct DISPMAN *this); // 0x000F7C4C
+extern void DrawBlocks__7DISPMAN(DISPMAN *this); // 0x000F7C4C
 
-extern void DrawSlices__7DISPMAN(struct DISPMAN *this); // 0x000F819C
+extern void DrawSlices__7DISPMAN(DISPMAN *this); // 0x000F819C
 
-extern void write_mess_in_box__7DISPMANG4RECTPciiii(struct DISPMAN *this, struct RECT box, char *text, int font, int r, int g, int b); // 0x000F8B28
+extern void write_mess_in_box__7DISPMANG4RECTPciiii(DISPMAN *this, RECT box, char *text, int font, int r, int g, int b); // 0x000F8B28
 
-extern void DrawBlockName__7DISPMAN(struct DISPMAN *this); // 0x000F8D24
+extern void DrawBlockName__7DISPMAN(DISPMAN *this); // 0x000F8D24
 
-extern void DrawEnterName__7DISPMANPc(struct DISPMAN *this, char *ascii); // 0x000FDBEC
+extern void DrawEnterName__7DISPMANPc(DISPMAN *this, char *ascii); // 0x000FDBEC
 
-extern void SetMenuOption__7DISPMANi(struct DISPMAN *this, int menuOption); // 0x000FDC6C
+extern void SetMenuOption__7DISPMANi(DISPMAN *this, int menuOption); // 0x000FDC6C
 
-extern void SetActiveFunction__7DISPMANi(struct DISPMAN *this, int menuOption); // 0x000FDCBC
+extern void SetActiveFunction__7DISPMANi(DISPMAN *this, int menuOption); // 0x000FDCBC
 
-extern void MoveActiveAreaTo__7DISPMANi(struct DISPMAN *this, int area); // 0x000FDCC4
+extern void MoveActiveAreaTo__7DISPMANi(DISPMAN *this, int area); // 0x000FDCC4
 
-extern void SelectNewBlock__7DISPMANi(struct DISPMAN *this, int newBlock); // 0x000FDD0C
+extern void SelectNewBlock__7DISPMANi(DISPMAN *this, int newBlock); // 0x000FDD0C
 
-extern void ActiveAreaLeft__7DISPMAN(struct DISPMAN *this); // 0x000F8EE4
+extern void ActiveAreaLeft__7DISPMAN(DISPMAN *this); // 0x000F8EE4
 
-extern void ActiveAreaRight__7DISPMAN(struct DISPMAN *this); // 0x000F902C
+extern void ActiveAreaRight__7DISPMAN(DISPMAN *this); // 0x000F902C
 
-extern void ActiveAreaUp__7DISPMAN(struct DISPMAN *this); // 0x000F9270
+extern void ActiveAreaUp__7DISPMAN(DISPMAN *this); // 0x000F9270
 
-extern void ActiveAreaDown__7DISPMAN(struct DISPMAN *this); // 0x000F941C
+extern void ActiveAreaDown__7DISPMAN(DISPMAN *this); // 0x000F941C
 
-extern int ActiveAreaSelect__7DISPMANii(struct DISPMAN *this, int x, int y); // 0x000F96F0
+extern int ActiveAreaSelect__7DISPMANii(DISPMAN *this, int x, int y); // 0x000F96F0
 
-extern int GetArea__7DISPMANii(struct DISPMAN *this, int x, int y); // 0x000FDDD0
+extern int GetArea__7DISPMANii(DISPMAN *this, int x, int y); // 0x000FDDD0
 
-extern int ActiveAreaConfirm__7DISPMAN(struct DISPMAN *this); // 0x000F9BAC
+extern int ActiveAreaConfirm__7DISPMAN(DISPMAN *this); // 0x000F9BAC
 
-extern int ActiveAreaCancel__7DISPMAN(struct DISPMAN *this); // 0x000FDE50
+extern int ActiveAreaCancel__7DISPMAN(DISPMAN *this); // 0x000FDE50
 
-extern void AddingBlock__7DISPMANi(struct DISPMAN *this, int n); // 0x000FDF58
+extern void AddingBlock__7DISPMANi(DISPMAN *this, int n); // 0x000FDF58
 
-extern void DeletingCurrBlock__7DISPMANi(struct DISPMAN *this, int n); // 0x000FDF60
+extern void DeletingCurrBlock__7DISPMANi(DISPMAN *this, int n); // 0x000FDF60
 
-extern void InvalidateArea__7DISPMANG4RECT(struct DISPMAN *this, struct RECT rect); // 0x000FDF68
+extern void InvalidateArea__7DISPMANG4RECT(DISPMAN *this, RECT rect); // 0x000FDF68
 
-extern unsigned int intersect__7DISPMANG4RECTT1(struct DISPMAN *this, struct RECT rect1, struct RECT rect2); // 0x000F9FAC
+extern unsigned int intersect__7DISPMANG4RECTT1(DISPMAN *this, RECT rect1, RECT rect2); // 0x000F9FAC
 
-extern void InvalidateArea__7DISPMANi(struct DISPMAN *this, int n); // 0x000FE040
+extern void InvalidateArea__7DISPMANi(DISPMAN *this, int n); // 0x000FE040
 
-extern void DrawArea__7DISPMANi(struct DISPMAN *this, int n); // 0x000FE098
+extern void DrawArea__7DISPMANi(DISPMAN *this, int n); // 0x000FE098
 
-extern void FlashOn__7DISPMAN(struct DISPMAN *this); // 0x000FE144
+extern void FlashOn__7DISPMAN(DISPMAN *this); // 0x000FE144
 
-extern void FlashOff__7DISPMAN(struct DISPMAN *this); // 0x000FE150
+extern void FlashOff__7DISPMAN(DISPMAN *this); // 0x000FE150
 
-extern unsigned int Update__7DISPMAN(struct DISPMAN *this); // 0x000FA174
+extern unsigned int Update__7DISPMAN(DISPMAN *this); // 0x000FA174
 
-extern int PrintKanji__7DISPMANPsiiiiii(struct DISPMAN *this, short *string, int x, int y, int maxChars, int r, int g, int b); // 0x000FA684
+extern int PrintKanji__7DISPMANPsiiiiii(DISPMAN *this, short *string, int x, int y, int maxChars, int r, int g, int b); // 0x000FA684
 
-extern int FindKanji__7DISPMANs(struct DISPMAN *this, short sjisCode); // 0x000FE160
+extern int FindKanji__7DISPMANs(DISPMAN *this, short sjisCode); // 0x000FE160
 
-extern int CentrePrintKanji__7DISPMANPsiiiiii(struct DISPMAN *this, short *string, int x, int y, int maxChars, int r, int g, int b); // 0x000FE1B0
+extern int CentrePrintKanji__7DISPMANPsiiiiii(DISPMAN *this, short *string, int x, int y, int maxChars, int r, int g, int b); // 0x000FE1B0
 
 extern int KanjiStrLen__FPsi(short *kanjiStringPtr, int maxChars); // 0x000FE258
 
-extern void darken__7DISPMANG4RECT(struct DISPMAN *this, struct RECT rect); // 0x000FA97C
+extern void darken__7DISPMANG4RECT(DISPMAN *this, RECT rect); // 0x000FA97C
 
-extern int GetCurrBlock__7DISPMAN(struct DISPMAN *this); // 0x000FE2F4
+extern int GetCurrBlock__7DISPMAN(DISPMAN *this); // 0x000FE2F4
 
-extern int GetCurrSlice__7DISPMAN(struct DISPMAN *this); // 0x000FE300
+extern int GetCurrSlice__7DISPMAN(DISPMAN *this); // 0x000FE300
 
-extern void draw_card__7DISPMANiiPcb(struct DISPMAN *this, int x, int y, char *text, unsigned int selected); // 0x000FE30C
+extern void draw_card__7DISPMANiiPcb(DISPMAN *this, int x, int y, char *text, unsigned int selected); // 0x000FE30C
 
-extern int AddIcon__7DISPMANP9TIMSTRUCTiiiiiib(struct DISPMAN *this, struct TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans, unsigned int scale); // 0x000FE434
+extern int AddIcon__7DISPMANP9TIMSTRUCTiiiiiib(DISPMAN *this, TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans, unsigned int scale); // 0x000FE434
 
-extern int AddMoveImage__7DISPMANP4RECTT1(struct DISPMAN *this, struct RECT *srect, struct RECT *drect); // 0x000FE598
+extern int AddMoveImage__7DISPMANP4RECTT1(DISPMAN *this, RECT *srect, RECT *drect); // 0x000FE598
 
-extern int AddSprite__7DISPMANP9TIMSTRUCTiiiiii(struct DISPMAN *this, struct TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans); // 0x000FE61C
+extern int AddSprite__7DISPMANP9TIMSTRUCTiiiiii(DISPMAN *this, TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans); // 0x000FE61C
 
-extern int DrawSprite__7DISPMANP9TIMSTRUCTiiiiii(struct DISPMAN *this, struct TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans); // 0x000FACD4
+extern int DrawSprite__7DISPMANP9TIMSTRUCTiiiiii(DISPMAN *this, TIMSTRUCT *tim, int x, int y, int r, int g, int b, int trans); // 0x000FACD4
 
-extern int DrawBox__7DISPMANiiiiiii(struct DISPMAN *this, int x, int y, int w, int h, int r, int g, int b); // 0x000FE72C
+extern int DrawBox__7DISPMANiiiiiii(DISPMAN *this, int x, int y, int w, int h, int r, int g, int b); // 0x000FE72C
 
-extern int AddCircleG16__7DISPMANiiiiiiii(struct DISPMAN *this, int x, int y, int diameter, int complete, int r, int g, int b, int divisor); // 0x000FAED0
+extern int AddCircleG16__7DISPMANiiiiiiii(DISPMAN *this, int x, int y, int diameter, int complete, int r, int g, int b, int divisor); // 0x000FAED0
 
-extern short MessageBox__7DISPMANiPcbT3(struct DISPMAN *this, int type, char *text, unsigned int bIgnoreEvents, unsigned int bSwapKeys); // 0x000FB304
+extern short MessageBox__7DISPMANiPcbT3(DISPMAN *this, int type, char *text, unsigned int bIgnoreEvents, unsigned int bSwapKeys); // 0x000FB304
 
-extern struct RECT ProgressBox__7DISPMANPci(struct DISPMAN *this, char *text, int progress); // 0x000FC950
+extern RECT ProgressBox__7DISPMANPci(DISPMAN *this, char *text, int progress); // 0x000FC950
 
-extern int write_mess_c__7DISPMANPciiiiiiii(struct DISPMAN *this, char *mesPtr, int x, int y, int font, int maxChars, int r, int g, int b, int trans); // 0x000FE834
+extern int write_mess_c__7DISPMANPciiiiiiii(DISPMAN *this, char *mesPtr, int x, int y, int font, int maxChars, int r, int g, int b, int trans); // 0x000FE834
 
-extern int message_width__7DISPMANPcii(struct DISPMAN *this, char *mesPtr, int font, int maxChars); // 0x000FCC54
+extern int message_width__7DISPMANPcii(DISPMAN *this, char *mesPtr, int font, int maxChars); // 0x000FCC54
 
-extern int justify_mess__7DISPMANPcii(struct DISPMAN *this, char *messPtr, int font, int maxLineLength); // 0x000FCE00
+extern int justify_mess__7DISPMANPcii(DISPMAN *this, char *messPtr, int font, int maxLineLength); // 0x000FCE00
 
-extern int write_mess__7DISPMANPciiiiiiii(struct DISPMAN *this, char *mesPtr, int x, int y, int font, int maxChars, int r, int g, int b, int trans); // 0x000FD000
+extern int write_mess__7DISPMANPciiiiiiii(DISPMAN *this, char *mesPtr, int x, int y, int font, int maxChars, int r, int g, int b, int trans); // 0x000FD000
 
-extern int font_ref__7DISPMANcb(struct DISPMAN *this, char c, unsigned int accent); // 0x000FD410
+extern int font_ref__7DISPMANcb(DISPMAN *this, char c, unsigned int accent); // 0x000FD410
 
-extern void Tim2VRAM__7DISPMANPlP9TIMSTRUCTibiiii(struct DISPMAN *this, long *timDataPtr, struct TIMSTRUCT *destTimPtr, int abr, unsigned int setCoords, int clutX, int clutY, int iconX, int iconY); // 0x000FD658
+extern void Tim2VRAM__7DISPMANPlP9TIMSTRUCTibiiii(DISPMAN *this, long *timDataPtr, TIMSTRUCT *destTimPtr, int abr, unsigned int setCoords, int clutX, int clutY, int iconX, int iconY); // 0x000FD658
 
-extern void download_block_icon__7DISPMANiiii(struct DISPMAN *this, int iconX, int iconY, int clutX, int clutY); // 0x000FE908
+extern void download_block_icon__7DISPMANiiii(DISPMAN *this, int iconX, int iconY, int clutX, int clutY); // 0x000FE908
 
-extern void wipe_screen__7DISPMANii(struct DISPMAN *this, int wt, int step); // 0x000FD86C
+extern void wipe_screen__7DISPMANii(DISPMAN *this, int wt, int step); // 0x000FD86C
 
-extern void move_screen__7DISPMANiii(struct DISPMAN *this, int startY, int finishY, int steps); // 0x000FEA44
+extern void move_screen__7DISPMANiii(DISPMAN *this, int startY, int finishY, int steps); // 0x000FEA44
 
-extern int GetCyclesPerSecond__7DISPMAN(struct DISPMAN *this); // 0x000FEB24
+extern int GetCyclesPerSecond__7DISPMAN(DISPMAN *this); // 0x000FEB24
 
 
 #endif

--- a/src_rebuild/GAME/MEMCARD/MCMAIN.C
+++ b/src_rebuild/GAME/MEMCARD/MCMAIN.C
@@ -10,9 +10,9 @@
 		// Start line: 123
 		// Start offset: 0x0008730C
 		// Variables:
-	// 		struct REPLAY_SAVE_HEADER *rheader; // stack offset -40
-	// 		struct GAME_SAVE_HEADER *gheader; // stack offset -36
-	// 		struct CONFIG_SAVE_HEADER *cheader; // stack offset -32
+	// 		REPLAY_SAVE_HEADER *rheader; // stack offset -40
+	// 		GAME_SAVE_HEADER *gheader; // stack offset -36
+	// 		CONFIG_SAVE_HEADER *cheader; // stack offset -32
 	// 		char *pt; // stack offset -28
 	// 		int ret; // stack offset -24
 	// 		int size; // stack offset -20
@@ -345,7 +345,7 @@ void libcman_ReadControllers(void)
 		// Start line: 373
 		// Start offset: 0x00087A74
 		// Variables:
-	// 		struct RECT rect; // stack offset -56
+	// 		RECT rect; // stack offset -56
 	// 		char filename[32]; // stack offset -48
 	// 		char l; // stack offset -16
 	// 		int options; // stack offset -12
@@ -447,7 +447,7 @@ char * LoadMemCardOverlay(void)
 		// Start line: 464
 		// Start offset: 0x00087D78
 		// Variables:
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 	// 		unsigned long *buffer; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00087DC4
@@ -491,7 +491,7 @@ void StorePermanentTPage(void)
 		// Start line: 474
 		// Start offset: 0x00087DEC
 		// Variables:
-	// 		struct RECT rect; // stack offset -24
+	// 		RECT rect; // stack offset -24
 	// 		unsigned long *buffer; // stack offset -16
 	/* end block 1 */
 	// End offset: 0x00087E38

--- a/src_rebuild/GAME/MEMCARD/PAD.H
+++ b/src_rebuild/GAME/MEMCARD/PAD.H
@@ -2,69 +2,69 @@
 #define PAD_H
 
 
-extern struct PAD * __3PADPc(struct PAD *this, char *bufferPtr); // 0x000FEB70
+extern PAD * __3PADPc(PAD *this, char *bufferPtr); // 0x000FEB70
 
-extern void _._3PAD(struct PAD *this, int __in_chrg); // 0x000FFE44
+extern void _._3PAD(PAD *this, int __in_chrg); // 0x000FFE44
 
-extern int UpdateSlots__3PAD(struct PAD *this); // 0x000FFEA0
+extern int UpdateSlots__3PAD(PAD *this); // 0x000FFEA0
 
-extern unsigned short GetPadData__3PADi(struct PAD *this, int pad); // 0x000FECC0
+extern unsigned short GetPadData__3PADi(PAD *this, int pad); // 0x000FECC0
 
-extern unsigned int NegConInserted__3PAD(struct PAD *this); // 0x000FFEE0
+extern unsigned int NegConInserted__3PAD(PAD *this); // 0x000FFEE0
 
-extern unsigned int ControllerInserted__3PAD(struct PAD *this); // 0x000FFF10
+extern unsigned int ControllerInserted__3PAD(PAD *this); // 0x000FFF10
 
-extern unsigned int ControllerChanged__3PAD(struct PAD *this); // 0x000FFF48
+extern unsigned int ControllerChanged__3PAD(PAD *this); // 0x000FFF48
 
-extern unsigned int SetControllerType__3PAD(struct PAD *this); // 0x000FFF5C
+extern unsigned int SetControllerType__3PAD(PAD *this); // 0x000FFF5C
 
-extern unsigned int MouseInserted__3PAD(struct PAD *this); // 0x001000D0
+extern unsigned int MouseInserted__3PAD(PAD *this); // 0x001000D0
 
-extern int GetMouseX__3PAD(struct PAD *this); // 0x00100158
+extern int GetMouseX__3PAD(PAD *this); // 0x00100158
 
-extern int GetMouseY__3PAD(struct PAD *this); // 0x0010016C
+extern int GetMouseY__3PAD(PAD *this); // 0x0010016C
 
-extern void ResetPadData__3PAD(struct PAD *this); // 0x00100180
+extern void ResetPadData__3PAD(PAD *this); // 0x00100180
 
-extern char * port_name__3PADi(struct PAD *this, int port); // 0x000FF2CC
+extern char * port_name__3PADi(PAD *this, int port); // 0x000FF2CC
 
-extern unsigned int WaitUntilCardRemoved__3PADi(struct PAD *this, int slot); // 0x000FF3C0
+extern unsigned int WaitUntilCardRemoved__3PADi(PAD *this, int slot); // 0x000FF3C0
 
-extern unsigned int WaitUntilAnyCardInserted__3PAD(struct PAD *this); // 0x000FF6E4
+extern unsigned int WaitUntilAnyCardInserted__3PAD(PAD *this); // 0x000FF6E4
 
-extern char * GetPortName__3PADi(struct PAD *this, int slot); // 0x001001AC
+extern char * GetPortName__3PADi(PAD *this, int slot); // 0x001001AC
 
-extern char * GetControllerPortName__3PAD(struct PAD *this); // 0x00100214
+extern char * GetControllerPortName__3PAD(PAD *this); // 0x00100214
 
-extern unsigned int CardSelected__3PADi(struct PAD *this, int slot); // 0x00100244
+extern unsigned int CardSelected__3PADi(PAD *this, int slot); // 0x00100244
 
-extern unsigned int CurrCardInfoRead__3PAD(struct PAD *this); // 0x00100260
+extern unsigned int CurrCardInfoRead__3PAD(PAD *this); // 0x00100260
 
-extern void check_ports__3PAD(struct PAD *this); // 0x000FFA1C
+extern void check_ports__3PAD(PAD *this); // 0x000FFA1C
 
-extern void search_ports__3PADib(struct PAD *this, int slot, unsigned int cycle); // 0x000FFC98
+extern void search_ports__3PADib(PAD *this, int slot, unsigned int cycle); // 0x000FFC98
 
-extern int next_port__3PADi(struct PAD *this, int port); // 0x0010029C
+extern int next_port__3PADi(PAD *this, int port); // 0x0010029C
 
-extern int GetCurrNoUsedBlocks__3PAD(struct PAD *this); // 0x001002A4
+extern int GetCurrNoUsedBlocks__3PAD(PAD *this); // 0x001002A4
 
-extern unsigned int CurrSlotBlocksShared__3PADii(struct PAD *this, int block1, int block2); // 0x001002E0
+extern unsigned int CurrSlotBlocksShared__3PADii(PAD *this, int block1, int block2); // 0x001002E0
 
-extern struct MCSLOT * GetCurrSlotPtr__3PAD(struct PAD *this); // 0x0010031C
+extern MCSLOT * GetCurrSlotPtr__3PAD(PAD *this); // 0x0010031C
 
-extern int GetCurrSlot__3PAD(struct PAD *this); // 0x00100340
+extern int GetCurrSlot__3PAD(PAD *this); // 0x00100340
 
-extern struct MCSLOT * GetDestSlotPtr__3PAD(struct PAD *this); // 0x00100354
+extern MCSLOT * GetDestSlotPtr__3PAD(PAD *this); // 0x00100354
 
-extern unsigned int CardChanged__3PADi(struct PAD *this, int slot); // 0x0010037C
+extern unsigned int CardChanged__3PADi(PAD *this, int slot); // 0x0010037C
 
-extern unsigned int CardInserted__3PADi(struct PAD *this, int slot); // 0x001003B0
+extern unsigned int CardInserted__3PADi(PAD *this, int slot); // 0x001003B0
 
-extern void CycleSelectedSlot__3PAD(struct PAD *this); // 0x001003E4
+extern void CycleSelectedSlot__3PAD(PAD *this); // 0x001003E4
 
-extern unsigned int CardFormatted__3PADi(struct PAD *this, int slot); // 0x0010042C
+extern unsigned int CardFormatted__3PADi(PAD *this, int slot); // 0x0010042C
 
-extern int FormatCard__3PADi(struct PAD *this, int slot); // 0x00100460
+extern int FormatCard__3PADi(PAD *this, int slot); // 0x00100460
 
 
 #endif

--- a/src_rebuild/GAME/MEMCARD/SLOT.H
+++ b/src_rebuild/GAME/MEMCARD/SLOT.H
@@ -2,89 +2,89 @@
 #define SLOT_H
 
 
-extern struct MCSLOT * __6MCSLOTiiiiiiPc(struct MCSLOT *this, int port, int card, int iconX, int iconY, int clutX, int clutY, char *bufferPtr); // 0x000F523C
+extern MCSLOT * __6MCSLOTiiiiiiPc(MCSLOT *this, int port, int card, int iconX, int iconY, int clutX, int clutY, char *bufferPtr); // 0x000F523C
 
-extern void card_start__6MCSLOT(struct MCSLOT *this); // 0x000F3644
+extern void card_start__6MCSLOT(MCSLOT *this); // 0x000F3644
 
-extern void _._6MCSLOT(struct MCSLOT *this, int __in_chrg); // 0x000F52F0
+extern void _._6MCSLOT(MCSLOT *this, int __in_chrg); // 0x000F52F0
 
-extern void card_stop__6MCSLOT(struct MCSLOT *this); // 0x000F534C
+extern void card_stop__6MCSLOT(MCSLOT *this); // 0x000F534C
 
-extern int CheckCard__6MCSLOT(struct MCSLOT *this); // 0x000F5474
+extern int CheckCard__6MCSLOT(MCSLOT *this); // 0x000F5474
 
-extern int card_event__6MCSLOTi(struct MCSLOT *this, int timeout); // 0x000F555C
+extern int card_event__6MCSLOTi(MCSLOT *this, int timeout); // 0x000F555C
 
-extern void clear_event__6MCSLOT(struct MCSLOT *this); // 0x000F5610
+extern void clear_event__6MCSLOT(MCSLOT *this); // 0x000F5610
 
-extern unsigned int CardRemoved__6MCSLOT(struct MCSLOT *this); // 0x000F3828
+extern unsigned int CardRemoved__6MCSLOT(MCSLOT *this); // 0x000F3828
 
-extern unsigned int CardInserted__6MCSLOT(struct MCSLOT *this); // 0x000F3994
+extern unsigned int CardInserted__6MCSLOT(MCSLOT *this); // 0x000F3994
 
-extern int FormatCard__6MCSLOT(struct MCSLOT *this); // 0x000F3B04
+extern int FormatCard__6MCSLOT(MCSLOT *this); // 0x000F3B04
 
-extern void ReadCardDir__6MCSLOT(struct MCSLOT *this); // 0x000F3C74
+extern void ReadCardDir__6MCSLOT(MCSLOT *this); // 0x000F3C74
 
-extern void invalidate_info__6MCSLOT(struct MCSLOT *this); // 0x000F5668
+extern void invalidate_info__6MCSLOT(MCSLOT *this); // 0x000F5668
 
-extern int ReadCardInfo__6MCSLOTPc(struct MCSLOT *this, char *managerFilename); // 0x000F3DB8
+extern int ReadCardInfo__6MCSLOTPc(MCSLOT *this, char *managerFilename); // 0x000F3DB8
 
-extern void download_icon__6MCSLOTR9BLOCKINFOiiiii(struct MCSLOT *this, struct BLOCKINFO *blockInfo, int iconX, int iconY, int clutX, int clutY, int icon); // 0x000F56FC
+extern void download_icon__6MCSLOTR9BLOCKINFOiiiii(MCSLOT *this, BLOCKINFO *blockInfo, int iconX, int iconY, int clutX, int clutY, int icon); // 0x000F56FC
 
-extern int CopyBlock__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F5860
+extern int CopyBlock__6MCSLOTi(MCSLOT *this, int block); // 0x000F5860
 
-extern int ReadSlice__6MCSLOTiiP5SLICEP10FILEFORMAT(struct MCSLOT *this, int block, int slice, struct SLICE *slicePtr, struct FILEFORMAT *fileFormatPtr); // 0x000F41A0
+extern int ReadSlice__6MCSLOTiiP5SLICEP10FILEFORMAT(MCSLOT *this, int block, int slice, SLICE *slicePtr, FILEFORMAT *fileFormatPtr); // 0x000F41A0
 
-extern int read_block__6MCSLOTiPcR9BLOCKINFO(struct MCSLOT *this, int block, char *bufferPtr, struct BLOCKINFO *blockInfo); // 0x000F43A0
+extern int read_block__6MCSLOTiPcR9BLOCKINFO(MCSLOT *this, int block, char *bufferPtr, BLOCKINFO *blockInfo); // 0x000F43A0
 
-extern int PasteBlock__6MCSLOT(struct MCSLOT *this); // 0x000F5918
+extern int PasteBlock__6MCSLOT(MCSLOT *this); // 0x000F5918
 
-extern int ReadHeader__6MCSLOTii(struct MCSLOT *this, int block, int slice); // 0x000F5968
+extern int ReadHeader__6MCSLOTii(MCSLOT *this, int block, int slice); // 0x000F5968
 
-extern int RenameCopyBlock__6MCSLOTP10FILEFORMAT(struct MCSLOT *this, struct FILEFORMAT *fileFormatPtr); // 0x000F5A60
+extern int RenameCopyBlock__6MCSLOTP10FILEFORMAT(MCSLOT *this, FILEFORMAT *fileFormatPtr); // 0x000F5A60
 
-extern int WriteSlice__6MCSLOTiiP5SLICEP10FILEFORMATPc(struct MCSLOT *this, int block, int slice, struct SLICE *slicePtr, struct FILEFORMAT *fileFormatPtr, char *bufferPtr); // 0x000F5B38
+extern int WriteSlice__6MCSLOTiiP5SLICEP10FILEFORMATPc(MCSLOT *this, int block, int slice, SLICE *slicePtr, FILEFORMAT *fileFormatPtr, char *bufferPtr); // 0x000F5B38
 
-extern int write_block__6MCSLOTR9BLOCKINFOPc(struct MCSLOT *this, struct BLOCKINFO *blockInfo, char *bufferPtr); // 0x000F46B4
+extern int write_block__6MCSLOTR9BLOCKINFOPc(MCSLOT *this, BLOCKINFO *blockInfo, char *bufferPtr); // 0x000F46B4
 
-extern int CreateBlock__6MCSLOTP10FILEFORMATP5SLICE(struct MCSLOT *this, struct FILEFORMAT *fileFormatPtr, struct SLICE *slicePtr); // 0x000F49E8
+extern int CreateBlock__6MCSLOTP10FILEFORMATP5SLICE(MCSLOT *this, FILEFORMAT *fileFormatPtr, SLICE *slicePtr); // 0x000F49E8
 
-extern int DeleteBlock__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F502C
+extern int DeleteBlock__6MCSLOTi(MCSLOT *this, int block); // 0x000F502C
 
-extern void SetPort__6MCSLOTii(struct MCSLOT *this, int port, int card); // 0x000F5C70
+extern void SetPort__6MCSLOTii(MCSLOT *this, int port, int card); // 0x000F5C70
 
-extern unsigned int BlocksShared__6MCSLOTii(struct MCSLOT *this, int block1, int block2); // 0x000F5D30
+extern unsigned int BlocksShared__6MCSLOTii(MCSLOT *this, int block1, int block2); // 0x000F5D30
 
-extern int GetBlockSize__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F5DC8
+extern int GetBlockSize__6MCSLOTi(MCSLOT *this, int block); // 0x000F5DC8
 
-extern unsigned int CardInfoRead__6MCSLOT(struct MCSLOT *this); // 0x000F5DFC
+extern unsigned int CardInfoRead__6MCSLOT(MCSLOT *this); // 0x000F5DFC
 
-extern struct TIMSTRUCT * GetBlockIconPtr__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F5E08
+extern TIMSTRUCT * GetBlockIconPtr__6MCSLOTi(MCSLOT *this, int block); // 0x000F5E08
 
-extern int GetNoUsedBlocks__6MCSLOT(struct MCSLOT *this); // 0x000F5E84
+extern int GetNoUsedBlocks__6MCSLOT(MCSLOT *this); // 0x000F5E84
 
-extern short * GetBlockTitlePtr__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F5EA0
+extern short * GetBlockTitlePtr__6MCSLOTi(MCSLOT *this, int block); // 0x000F5EA0
 
-extern char * GetBlockFilenamePtr__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F5EE4
+extern char * GetBlockFilenamePtr__6MCSLOTi(MCSLOT *this, int block); // 0x000F5EE4
 
-extern int FilenameUsed__6MCSLOTPc(struct MCSLOT *this, char *filename); // 0x000F5F1C
+extern int FilenameUsed__6MCSLOTPc(MCSLOT *this, char *filename); // 0x000F5F1C
 
-extern int GetNumGremBlocks__6MCSLOTPc(struct MCSLOT *this, char *filename); // 0x000F5FBC
+extern int GetNumGremBlocks__6MCSLOTPc(MCSLOT *this, char *filename); // 0x000F5FBC
 
-extern int InsertSliceIntoCopyBuffer__6MCSLOTiPccccT2(struct MCSLOT *this, int slice, char *sliceName, char icon0, int icon1, int icon2, char *dataPtr); // 0x000F6088
+extern int InsertSliceIntoCopyBuffer__6MCSLOTiPccccT2(MCSLOT *this, int slice, char *sliceName, char icon0, int icon1, int icon2, char *dataPtr); // 0x000F6088
 
-extern int ExtractSliceFromCopyBuffer__6MCSLOTiPc(struct MCSLOT *this, int slice, char *bufferPtr); // 0x000F61F0
+extern int ExtractSliceFromCopyBuffer__6MCSLOTiPc(MCSLOT *this, int slice, char *bufferPtr); // 0x000F61F0
 
-extern char * GetSliceFilenamePtr__6MCSLOTii(struct MCSLOT *this, int block, int slice); // 0x000F628C
+extern char * GetSliceFilenamePtr__6MCSLOTii(MCSLOT *this, int block, int slice); // 0x000F628C
 
-extern unsigned int SliceUsed__6MCSLOTii(struct MCSLOT *this, int block, int slice); // 0x000F633C
+extern unsigned int SliceUsed__6MCSLOTii(MCSLOT *this, int block, int slice); // 0x000F633C
 
-extern int GetNoUsedSlices__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F63EC
+extern int GetNoUsedSlices__6MCSLOTi(MCSLOT *this, int block); // 0x000F63EC
 
-extern int GetSliceIconRef__6MCSLOTiii(struct MCSLOT *this, int block, int slice, int ref); // 0x000F6448
+extern int GetSliceIconRef__6MCSLOTiii(MCSLOT *this, int block, int slice, int ref); // 0x000F6448
 
-extern int GetNoSlices__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F64F4
+extern int GetNoSlices__6MCSLOTi(MCSLOT *this, int block); // 0x000F64F4
 
-extern unsigned int GremlinBlock__6MCSLOTi(struct MCSLOT *this, int block); // 0x000F6550
+extern unsigned int GremlinBlock__6MCSLOTi(MCSLOT *this, int block); // 0x000F6550
 
 extern void Ascii2ShiftJis__FPsPc(short *dest, char *source); // 0x000F512C
 


### PR DESCRIPTION
**NOW:**

- Cleaned up structs, typedefs, etc.

- Removed duplicate typedefs from DR2TYPES also found in the EMULATOR project.

- Replaced use of typedef struct tags with their ~~aliases~~ names, e.g. `_COP_DATA` -> `MS_COP_DATA`

- Removed prefixes where not needed, like `struct FOO bar`  -> `FOO bar`

- Replaced `long[4]` use with `LONGVECTOR` (and in one case, `LONGQUATERNION`)
-- **TODO:** Determine where `LONGQUATERNION` should be used instead of `LONGVECTOR` (for brevity sake)

- Removed verbose debug information from structures (stuff like hashcode, size/offset, etc.)

- Moved `PSXSCREEN` and `PSXBUTTON` to their appropriate header (no compiler issues)

**LATER:**

- Use typedef aliases where appropriate, e.g. `uchar` instead of `unsigned char`

- Move types to their appropriate header files without causing compiler issues